### PR TITLE
PatchMaker support for AVR

### DIFF
--- a/ofrak_core/ofrak/core/elf/lief_modifier.py
+++ b/ofrak_core/ofrak/core/elf/lief_modifier.py
@@ -13,10 +13,21 @@ from ofrak_type.range import Range
 
 @dataclass
 class LiefAddSegmentConfig(ComponentConfig):
+    """
+    Config for the [LiefAddSegmentModifier][ofrak.core.elf.lief_modifier.LiefAddSegmentModifier].
+
+    :ivar virtual_address: virtual address of the new segment
+    :ivar alignment: alignment of the new segment
+    :ivar content: list of integers representing the raw bytes of the new segment
+    :ivar rwx_flags: string representation of the new segment's R/W/X permissions
+    :ivar replace_note: replace the unused NOTE segment with the new segment, rather than adding a
+    new segment. defaults to `True`, as adding a new segment may corrupt the ELF due to a LIEF bug.
+    """
     virtual_address: int
     alignment: int
     content: List[int]
     rwx_flags: str
+    replace_note: bool = True
 
 
 class LiefAddSegmentModifier(Modifier[LiefAddSegmentConfig]):
@@ -24,8 +35,7 @@ class LiefAddSegmentModifier(Modifier[LiefAddSegmentConfig]):
     targets = (Elf,)
 
     async def modify(self, resource: Resource, config: LiefAddSegmentConfig) -> None:
-        binary = lief.parse(await resource.get_data())
-        assert binary.has(lief.ELF.SEGMENT_TYPES.NOTE)
+        binary: lief.ELF.Binary = lief.parse(await resource.get_data())
 
         segment = lief.ELF.Segment()
         segment.type = lief.ELF.SEGMENT_TYPES.LOAD
@@ -38,10 +48,17 @@ class LiefAddSegmentModifier(Modifier[LiefAddSegmentConfig]):
             segment.add(lief.ELF.SEGMENT_FLAGS.W)
         if "x" in config.rwx_flags:
             segment.add(lief.ELF.SEGMENT_FLAGS.X)
-        # segment           = binary.add(segment)
-        # instead of adding a segment to the binary, replace a useless NOTE segment
-        # based on https://github.com/lief-project/LIEF/issues/98
-        segment = binary.replace(segment, binary[lief.ELF.SEGMENT_TYPES.NOTE])
+
+        if config.replace_note:
+            # instead of adding a segment to the binary, replace a useless NOTE segment
+            #   see https://github.com/lief-project/LIEF/issues/98
+            #   and https://github.com/lief-project/LIEF/issues/143
+            if not binary.has(lief.ELF.SEGMENT_TYPES.NOTE):
+                raise ValueError("Binary must have a NOTE section to add a new section")
+            segment = binary.replace(segment, binary[lief.ELF.SEGMENT_TYPES.NOTE])
+        else:
+            segment = binary.add(segment)
+
         with tempfile.NamedTemporaryFile() as temp_file:
             binary.write(temp_file.name)
             temp_file.flush()

--- a/ofrak_core/ofrak/core/elf/lief_modifier.py
+++ b/ofrak_core/ofrak/core/elf/lief_modifier.py
@@ -23,6 +23,7 @@ class LiefAddSegmentConfig(ComponentConfig):
     :ivar replace_note: replace the unused NOTE segment with the new segment, rather than adding a
     new segment. defaults to `True`, as adding a new segment may corrupt the ELF due to a LIEF bug.
     """
+
     virtual_address: int
     alignment: int
     content: List[int]

--- a/ofrak_core/ofrak/core/elf/model.py
+++ b/ofrak_core/ofrak/core/elf/model.py
@@ -163,6 +163,7 @@ class ElfMachine(Enum):
             ElfMachine.EM_AARCH64.value: InstructionSet.AARCH64,
             ElfMachine.EM_68K.value: InstructionSet.M68K,
             ElfMachine.EM_COLDFIRE.value: InstructionSet.M68K,
+            ElfMachine.EM_AVR.value: InstructionSet.AVR,
             # While there is an assembler for MaxQ (
             # https://www.maximintegrated.com/content/dam/files/design/tools/tech-docs/4465
             # /AN4465-dev-tools-guide.pdf), in practice PPC is quite similar.

--- a/ofrak_core/test_ofrak/components/test_patch_maker_component.py
+++ b/ofrak_core/test_ofrak/components/test_patch_maker_component.py
@@ -217,7 +217,7 @@ async def test_function_replacement_modifier(ofrak_context: OFRAKContext, config
     await target_program.resource.flush_to_disk(new_program_path)
 
     # Check that the modified program looks as expected.
-    readobj_path = get_repository_config("toolchain.conf", config.toolchain_name, "BIN_PARSER")
+    readobj_path = get_repository_config(config.toolchain_name, "BIN_PARSER")
 
     # LLVM-specific fix: use llvm-objdump, not llvm-readobj
     if "readobj" in readobj_path:

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -48,3 +48,6 @@ RUN cd /tmp/vbcc && cp ./bin/* /opt/rbs/toolchain/vbcc_0_9/bin/ && \
 
 #AARCH64 GNU 10 Linux
 RUN apt-get update && apt-get install -y gcc-10-aarch64-linux-gnu
+
+#AVR GCC
+RUN apt-get update && apt-get install -y gcc-avr binutils-avr avr-libc

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
@@ -143,23 +143,15 @@ class Toolchain(ABC):
         :raises NotImplementedError: if an assembler for that ISA does not exist
         :returns: filepath to the assembler program
         """
-        if self._processor.isa == InstructionSet.ARM:
-            assembler_path = "ARM_ASM_PATH"
-        elif self._processor.isa == InstructionSet.MIPS:
-            assembler_path = "MIPS_ASM_PATH"
-        elif self._processor.isa == InstructionSet.PPC:
-            assembler_path = "PPC_ASM_PATH"
-        elif self._processor.isa == InstructionSet.M68K:
+        if self._processor.isa == InstructionSet.M68K:
             assembler_path = "M68K_ASM_PATH"
         elif (
             self._processor.isa == InstructionSet.X86
             and self._processor.bit_width == BitWidth.BIT_64
         ):
             assembler_path = "X86_64_ASM_PATH"
-        elif self._processor.isa == InstructionSet.AARCH64:
-            assembler_path = "AARCH64_ASM_PATH"
         else:
-            raise NotImplementedError()
+            assembler_path = f"{self._processor.isa.value.upper()}_ASM_PATH"
         return get_repository_config("ASM", assembler_path)
 
     @property

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
@@ -143,7 +143,6 @@ class Toolchain(ABC):
         :raises NotImplementedError: if an assembler for that ISA does not exist
         :returns: filepath to the assembler program
         """
-        conf_filename = "toolchain.conf"
         if self._processor.isa == InstructionSet.ARM:
             assembler_path = "ARM_ASM_PATH"
         elif self._processor.isa == InstructionSet.MIPS:
@@ -161,42 +160,42 @@ class Toolchain(ABC):
             assembler_path = "AARCH64_ASM_PATH"
         else:
             raise NotImplementedError()
-        return get_repository_config(conf_filename, "ASM", assembler_path)
+        return get_repository_config("ASM", assembler_path)
 
     @property
     def _preprocessor_path(self) -> str:
         """
         :return str: path to the toolchain preprocessor - this is usually the compiler.
         """
-        return get_repository_config("toolchain.conf", self.name, "PREPROCESSOR")
+        return get_repository_config(self.name, "PREPROCESSOR")
 
     @property
     def _compiler_path(self) -> str:
         """
         :return str: path to the toolchain compiler
         """
-        return get_repository_config("toolchain.conf", self.name, "COMPILER")
+        return get_repository_config(self.name, "COMPILER")
 
     @property
     def _linker_path(self) -> str:
         """
         :return str: path to the toolchain linker
         """
-        return get_repository_config("toolchain.conf", self.name, "LINKER")
+        return get_repository_config(self.name, "LINKER")
 
     @property
     def _readobj_path(self) -> str:
         """
         :return str: path to the toolchain binary analysis utility
         """
-        return get_repository_config("toolchain.conf", self.name, "BIN_PARSER")
+        return get_repository_config(self.name, "BIN_PARSER")
 
     @property
     def _lib_path(self) -> str:
         """
         :return str: path to the toolchain libraries
         """
-        return get_repository_config("toolchain.conf", self.name, "LIB")
+        return get_repository_config(self.name, "LIB")
 
     @property
     @abstractmethod

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -5,7 +5,8 @@ from abc import ABC
 from typing import Iterable, List, Mapping, Optional, Tuple, Dict
 from warnings import warn
 
-from ofrak.core.architecture import ProgramAttributes, InstructionSet, SubInstructionSet
+from ofrak.core.architecture import ProgramAttributes
+from ofrak_type.architecture import InstructionSet, SubInstructionSet
 from ofrak_patch_maker.binary_parser.gnu import GNU_ELF_Parser, GNU_V10_ELF_Parser
 from ofrak_patch_maker.toolchain.abstract import Toolchain, RBS_AUTOGEN_WARNING
 from ofrak_patch_maker.toolchain.model import (

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -360,8 +360,6 @@ class GNU_10_Toolchain(Abstract_GNU_Toolchain):
     ):
         super().__init__(processor, toolchain_config, logger=logger)
 
-        self._compiler_flags.append("-fno-plt")
-
         if self._compiler_target is not None:
             self._compiler_flags.append(f"-march={self._compiler_target}")
         if self._config.compiler_cpu:

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -614,6 +614,7 @@ class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
             return processor.sub_isa.value.lower()
         return SubInstructionSet.ARMv8A.value.lower()
 
+
 class GNU_AVR_5_Toolchain(Abstract_GNU_Toolchain):
     binary_file_parsers = [GNU_ELF_Parser()]
 

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/utils.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/utils.py
@@ -20,11 +20,10 @@ def get_file_format(path):
         ValueError("Invalid BinFileType!!!")
 
 
-def get_repository_config(config_name: str, section: str, key: Optional[str] = None):
+def get_repository_config(section: str, key: Optional[str] = None):
     """
     Find config file and values. Look in user's `~/etc` directory followed by `/etc`.
 
-    :param config_name: config filename
     :param section: section name in config file
     :param key: key in `config[section]`
 
@@ -36,6 +35,7 @@ def get_repository_config(config_name: str, section: str, key: Optional[str] = N
 
     config = configparser.RawConfigParser()
     config_root = "/etc"
+    config_name = "toolchain.conf"
     try:
         local_etc = os.path.join(os.environ["HOME"], "etc")
         paths = [local_etc, config_root]

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/version.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/version.py
@@ -5,6 +5,7 @@ from ofrak_patch_maker.toolchain.gnu import (
     GNU_X86_64_LINUX_EABI_10_3_0_Toolchain,
     GNU_M68K_LINUX_10_Toolchain,
     GNU_AARCH64_LINUX_10_Toolchain,
+    GNU_AVR_5_Toolchain,
 )
 from ofrak_patch_maker.toolchain.llvm_12 import LLVM_12_0_1_Toolchain
 from ofrak_patch_maker.toolchain.vbcc_gnu_hybrid import VBCC_0_9_GNU_Hybrid_Toolchain
@@ -17,3 +18,4 @@ class ToolchainVersion(Enum):
     GNU_M68K_LINUX_10 = GNU_M68K_LINUX_10_Toolchain
     VBCC_M68K_0_9 = VBCC_0_9_GNU_Hybrid_Toolchain
     GNU_AARCH64_LINUX_10 = GNU_AARCH64_LINUX_10_Toolchain
+    GNU_AVR_5 = GNU_AVR_5_Toolchain

--- a/ofrak_patch_maker/ofrak_patch_maker_test/__init__.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/__init__.py
@@ -14,6 +14,7 @@ ARM_EXTENSION = ".arm"
 AARCH64_EXTENSION = ".aarch64"
 X86_EXTENSION = ".x86"
 M68K_EXTENSION = ".m68k"
+AVR_EXTENSION = ".avr"
 
 ARM_TOOLCHAINS_UNDER_TEST = [
     (
@@ -91,4 +92,18 @@ M68K_TOOLCHAINS_UNDER_TEST = [
         ),
         M68K_EXTENSION,
     ),
+]
+
+AVR_TOOLCHAINS_UNDER_TEST = [
+    (
+        ToolchainVersion.GNU_AVR_5,
+        ProgramAttributes(
+            InstructionSet.AVR,
+            SubInstructionSet.AVR2,
+            BitWidth.BIT_32,
+            Endianness.LITTLE_ENDIAN,
+            ProcessorType.AVR,
+        ),
+        AVR_EXTENSION,
+    )
 ]

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_toolchain_c.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_toolchain_c.py
@@ -4,7 +4,8 @@ import tempfile
 
 import pytest
 
-from ofrak.core.architecture import ProgramAttributes, InstructionSet
+from ofrak.core.architecture import ProgramAttributes
+from ofrak_type.architecture import InstructionSet
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.model import (
@@ -49,6 +50,7 @@ def test_bounds_check(toolchain: ToolchainVersion, proc: ProgramAttributes, exte
     build_dir = tempfile.mkdtemp()
 
     if proc.isa == InstructionSet.AVR:
+        # avr-gcc does not support relocatable
         relocatable = False
     else:
         relocatable = True

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_toolchain_c.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_toolchain_c.py
@@ -4,7 +4,7 @@ import tempfile
 
 import pytest
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak.core.architecture import ProgramAttributes, InstructionSet
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.model import (
@@ -20,6 +20,7 @@ from ofrak_patch_maker_test import (
     X86_TOOLCHAINS_UNDER_TEST,
     M68K_TOOLCHAINS_UNDER_TEST,
     AARCH64_TOOLCHAINS_UNDER_TEST,
+    AVR_TOOLCHAINS_UNDER_TEST,
 )
 from ofrak_type.memory_permissions import MemoryPermissions
 
@@ -29,7 +30,8 @@ from ofrak_type.memory_permissions import MemoryPermissions
     ARM_TOOLCHAINS_UNDER_TEST
     + X86_TOOLCHAINS_UNDER_TEST
     + M68K_TOOLCHAINS_UNDER_TEST
-    + AARCH64_TOOLCHAINS_UNDER_TEST,
+    + AARCH64_TOOLCHAINS_UNDER_TEST
+    + AVR_TOOLCHAINS_UNDER_TEST,
 )
 @pytest.mark.params_format(
     "toolchain={toolchain} proc={proc} extension={extension}",
@@ -46,10 +48,14 @@ def test_bounds_check(toolchain: ToolchainVersion, proc: ProgramAttributes, exte
     source_path = os.path.join(source_dir, "bounds_check.c")
     build_dir = tempfile.mkdtemp()
 
+    if proc.isa == InstructionSet.AVR:
+        relocatable = False
+    else:
+        relocatable = True
     tc_config = ToolchainConfig(
         file_format=BinFileType.ELF,
         force_inlines=True,
-        relocatable=True,
+        relocatable=relocatable,
         no_std_lib=True,
         no_jump_tables=True,
         no_bss_section=True,
@@ -104,7 +110,10 @@ def test_bounds_check(toolchain: ToolchainVersion, proc: ProgramAttributes, exte
 
 @pytest.mark.parametrize(
     "toolchain, proc, extension",
-    ARM_TOOLCHAINS_UNDER_TEST + X86_TOOLCHAINS_UNDER_TEST + M68K_TOOLCHAINS_UNDER_TEST,
+    ARM_TOOLCHAINS_UNDER_TEST
+    + X86_TOOLCHAINS_UNDER_TEST
+    + M68K_TOOLCHAINS_UNDER_TEST
+    + AVR_TOOLCHAINS_UNDER_TEST,
 )
 @pytest.mark.params_format(
     "toolchain={toolchain} proc={proc}, extension={extension}",
@@ -121,10 +130,16 @@ def test_hello_world(toolchain: ToolchainVersion, proc: ProgramAttributes, exten
     source_path = os.path.join(source_dir, "hello_world.c")
     build_dir = tempfile.mkdtemp()
 
+    if toolchain in [ToolchainVersion.GNU_AVR_5]:
+        relocatable = False
+        base_symbols = {"__mulhi3": 0x1234}  # Dummy address to fix missing symbol
+    else:
+        relocatable = True
+        base_symbols = None
     tc_config = ToolchainConfig(
         file_format=BinFileType.ELF,
         force_inlines=True,
-        relocatable=True,
+        relocatable=relocatable,
         no_std_lib=True,
         no_jump_tables=True,
         no_bss_section=False,
@@ -142,6 +157,7 @@ def test_hello_world(toolchain: ToolchainVersion, proc: ProgramAttributes, exten
         toolchain_version=toolchain,
         logger=logger,
         build_dir=build_dir,
+        base_symbols=base_symbols,
     )
 
     bom = patch_maker.make_bom(

--- a/ofrak_patch_maker/toolchain.conf
+++ b/ofrak_patch_maker/toolchain.conf
@@ -38,8 +38,15 @@ COMPILER = /usr/bin/aarch64-linux-gnu-gcc-10
 LINKER = /usr/bin/aarch64-linux-gnu-ld
 BIN_PARSER = /usr/bin/aarch64-linux-gnu-objdump
 
+[GNU_AVR_5]
+PREPROCESSOR = /usr/bin/avr-gcc
+COMPILER = /usr/bin/avr-gcc
+LINKER = /usr/bin/avr-ld
+BIN_PARSER = /usr/bin/avr-objdump
+
 [ASM]
 ARM_ASM_PATH = /opt/rbs/toolchain/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-as
 X86_64_ASM_PATH = /opt/rbs/toolchain/binutils-2.34/gas/as-new
 M68K_ASM_PATH = /usr/bin/m68k-linux-gnu-as
 AARCH64_ASM_PATH = /usr/bin/aarch64-linux-gnu-as
+AVR_ASM_PATH = /usr/bin/avr-as


### PR DESCRIPTION
This PR adds PatchMaker and toolchain support for the AVR architecture. Needed to fix a few assumptions, for example, some compiler/linker flags set in `Abstract_GNU_Toolchain` are not supported in `avr-gcc`. Additionally, the `LiefAddSegmentModifier` relied on an existing NOTE segment, which AVR ELFs do not have. I've added a configuration option to choose between NOTE replacement vs LIEF's add segment method.