### PR TITLE
Fix undefined name result

### DIFF
--- a/ofrak_components/ofrak_components_test/test_gzip_component.py
+++ b/ofrak_components/ofrak_components_test/test_gzip_component.py
@@ -80,7 +80,7 @@ class TestGzipUnpackWithTrailingBytes(UnpackModifyPackPattern):
 
             gunzip_command = ["gzip", "-d", "-c", gzip_path]
             try:
-                subprocess.run(gunzip_command, check=True, capture_output=True)
+                result = subprocess.run(gunzip_command, check=True, capture_output=True)
                 data = result.stdout
             except subprocess.CalledProcessError as e:
                 if e.returncode == 2 or e.returncode == -2:


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./ofrak_components/ofrak_components_test/test_gzip_component.py:84:24: F821 undefined name 'result'
                data = result.stdout
                       ^
./ofrak_core/ofrak/core/patch_maker/linkable_binary.py:150:22: F821 undefined name 'PatchMaker'
        patch_maker: "PatchMaker",  # type: ignore
                     ^
./ofrak_core/ofrak/service/error.py:55:49: F821 undefined name 'DataNode'
    def __init__(self, message, new_child_node: "DataNode", existing_child_node: "DataNode"):  # type: ignores
                                                ^
./ofrak_core/ofrak/service/error.py:55:82: F821 undefined name 'DataNode'
    def __init__(self, message, new_child_node: "DataNode", existing_child_node: "DataNode"):  # type: ignore
                                                                                 ^
4     F821 undefined name 'result'
4
```