### PR TITLE
Fix undefined names in Python type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.3.0
     hooks:
       - id: end-of-file-fixer
   - repo: https://github.com/myint/autoflake
@@ -9,11 +9,11 @@ repos:
       - id: autoflake
         args: [ '--in-place', '--remove-all-unused-imports', '--ignore-init-module-imports' ]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: ['--py37-plus']
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black

--- a/ofrak_core/ofrak/core/patch_maker/linkable_binary.py
+++ b/ofrak_core/ofrak/core/patch_maker/linkable_binary.py
@@ -150,7 +150,7 @@ class LinkableBinary(GenericBinary):
     # TODO: Un-stringify PatchMaker; OFRAK imports in PatchMaker results in circular Program imports
     async def make_linkable_bom(
         self,
-        patch_maker: "PatchMaker",  # type: ignore
+        patch_maker: PatchMaker,
         build_tmp_dir: str,
     ) -> tuple[BOM, PatchRegionConfig]:
         """

--- a/ofrak_core/ofrak/service/error.py
+++ b/ofrak_core/ofrak/service/error.py
@@ -1,9 +1,12 @@
-from typing import Dict, Any
+from __future__ import annotations
+
+from typing import Any
 
 import json
 import sys
 
 import ofrak_type.error
+from ofrak.service.data_service import DataNode
 
 
 class SerializedError(RuntimeError):
@@ -15,7 +18,7 @@ class SerializedError(RuntimeError):
         return {"type": type(error).__name__, "message": str(error)}
 
     @classmethod
-    def from_json(cls, serialized: str) -> "SerializedError":
+    def from_json(cls, serialized: str) -> SerializedError:
         error_dict = json.loads(serialized)
         error_type = error_dict["type"]
         try:
@@ -31,7 +34,7 @@ class SerializedError(RuntimeError):
             return error(error_dict["message"])
 
     @classmethod
-    def from_dict(cls, error_dict: Dict[str, Any]) -> "SerializedError":
+    def from_dict(cls, error_dict: dict[str, Any]) -> SerializedError:
         return cls(error_dict["message"])
 
 
@@ -52,7 +55,7 @@ class OutOfBoundError(DataServiceError):
 
 
 class OverlapError(DataServiceError):
-    def __init__(self, message, new_child_node: "DataNode", existing_child_node: "DataNode"):  # type: ignore
+    def __init__(self, message, new_child_node: DataNode, existing_child_node: DataNode):  # type: ignore
         super().__init__(message)
         self.new_child_node = new_child_node
         self.existing_child_node = existing_child_node

--- a/ofrak_core/ofrak/service/error.py
+++ b/ofrak_core/ofrak/service/error.py
@@ -55,7 +55,7 @@ class OutOfBoundError(DataServiceError):
 
 
 class OverlapError(DataServiceError):
-    def __init__(self, message, new_child_node: DataNode, existing_child_node: DataNode):  # type: ignore
+    def __init__(self, message, new_child_node: DataNode, existing_child_node: DataNode):
         super().__init__(message)
         self.new_child_node = new_child_node
         self.existing_child_node = existing_child_node


### PR DESCRIPTION
$ `pre-commit autoupdate`
```
Updating https://github.com/pre-commit/pre-commit-hooks ... updating v2.3.0 -> v4.3.0.
Updating https://github.com/myint/autoflake ... already up to date.
Updating https://github.com/asottile/pyupgrade ... updating v2.32.0 -> v2.37.3.
Updating https://github.com/psf/black ... updating 22.3.0 -> 22.6.0.
```
Fix the following undefined names in Python type hints:
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./ofrak_core/ofrak/core/patch_maker/linkable_binary.py:150:22: F821 undefined name 'PatchMaker'
        patch_maker: "PatchMaker",  # type: ignore
                     ^
./ofrak_core/ofrak/service/error.py:55:49: F821 undefined name 'DataNode'
    def __init__(self, message, new_child_node: "DataNode", existing_child_node: "DataNode"):  # type: ignore
                                                ^
./ofrak_core/ofrak/service/error.py:55:82: F821 undefined name 'DataNode'
    def __init__(self, message, new_child_node: "DataNode", existing_child_node: "DataNode"):  # type: ignore
                                                                                 ^
3     F821 undefined name 'PatchMaker'
3
```
Add `from __future__ import annotations` so that `pyupgrade` can reduce typing imports by using the updated syntax.