### PR TITLE
Bumped squashfs-tools to 4.5.1

### DIFF
--- a/ofrak_components/Dockerstub
+++ b/ofrak_components/Dockerstub
@@ -61,7 +61,7 @@ RUN wget https://raw.githubusercontent.com/iBotPeaches/Apktool/v2.3.3/scripts/li
 RUN cd /tmp && \
     git clone https://github.com/plougher/squashfs-tools.git && \
     cd squashfs-tools/squashfs-tools && \
-    git checkout 4.5 && \
+    git checkout 4.5.1 && \
     sed -i 's/^#\(XZ\|LZO\|LZ4\|ZSTD\)_SUPPORT/\1_SUPPORT/g' Makefile && \
     make -j && \
     make install && \


### PR DESCRIPTION
Issue #10 

This version bump includes [squashfs-tools commit f151730a83e92cbea00eda8f70e9039e145054a9 : "Unsquashfs: don't use max open file limit if larger than caches"](https://github.com/plougher/squashfs-tools/commit/f151730a83e92cbea00eda8f70e9039e145054a9). It was created to address https://github.com/plougher/squashfs-tools/issues/125 which I believe is related to #10. This change fixes the error present and allows the tutorial image to run without issue.