### PR TITLE
Fix undefined names in Python type hints - again

### DIFF
--- a/ofrak_core/ofrak/core/patch_maker/linkable_binary.py
+++ b/ofrak_core/ofrak/core/patch_maker/linkable_binary.py
@@ -19,6 +19,7 @@ from ofrak.service.resource_service_i import (
 )
 from ofrak.core.patch_maker.linkable_symbol import LinkableSymbol, LinkableSymbolType
 from ofrak_patch_maker.model import BOM, PatchRegionConfig
+from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.model import Segment
 from ofrak_type.error import NotFoundError
 
@@ -147,7 +148,7 @@ class LinkableBinary(GenericBinary):
     # TODO: Un-stringify PatchMaker; OFRAK imports in PatchMaker results in circular Program imports
     async def make_linkable_bom(
         self,
-        patch_maker: "PatchMaker",  # type: ignore
+        patch_maker: PatchMaker,
         build_tmp_dir: str,
     ) -> Tuple[BOM, PatchRegionConfig]:
         """

--- a/ofrak_core/ofrak/service/assembler/assembler_service_keystone.py
+++ b/ofrak_core/ofrak/service/assembler/assembler_service_keystone.py
@@ -243,7 +243,7 @@ class KeystoneAssemblerService(AssemblerServiceInterface):
         assembly_list: Iterable[str],
         vm_addrs: Iterable[int],
         program_attributes: ProgramAttributes,
-        mode=InstructionSetMode.NONE,  # type: InstructionSetMode
+        mode: InstructionSetMode = InstructionSetMode.NONE,
     ) -> AsyncIterator[bytes]:
         for assembly, vm_addr in zip(assembly_list, vm_addrs):
             result = await self.assemble(assembly, vm_addr, program_attributes, mode)

--- a/ofrak_core/ofrak/service/assembler/model/assembler_arguments.py
+++ b/ofrak_core/ofrak/service/assembler/model/assembler_arguments.py
@@ -1,8 +1,8 @@
 class AssemblerFileArguments:
     def __init__(
         self,
-        source_file,  # type: str
-        vm_address,  # type: int
+        source_file: str,
+        vm_address: int,
     ):
         self.source_file = source_file
         self.vm_address = vm_address

--- a/ofrak_core/ofrak/service/error.py
+++ b/ofrak_core/ofrak/service/error.py
@@ -4,6 +4,7 @@ import json
 import sys
 
 import ofrak_type.error
+from ofrak.service.data_service import DataNode
 
 
 class SerializedError(RuntimeError):
@@ -23,7 +24,7 @@ class SerializedError(RuntimeError):
         except AttributeError:
             try:
                 error = getattr(ofrak_type.error, error_type)
-            except:
+            except Exception:
                 raise ValueError(error_dict)
         if issubclass(error, cls):
             return error.from_dict({"message": error_dict["message"]})
@@ -52,7 +53,7 @@ class OutOfBoundError(DataServiceError):
 
 
 class OverlapError(DataServiceError):
-    def __init__(self, message, new_child_node: "DataNode", existing_child_node: "DataNode"):  # type: ignore
+    def __init__(self, message, new_child_node: DataNode, existing_child_node: DataNode):
         super().__init__(message)
         self.new_child_node = new_child_node
         self.existing_child_node = existing_child_node

--- a/ofrak_io/ofrak_io/stream_capture.py
+++ b/ofrak_io/ofrak_io/stream_capture.py
@@ -27,7 +27,7 @@ class StreamCapture:
         self.stream_file_descriptor = self.stream.fileno()
         self.pipe_out, self.pipe_in = os.pipe()
         self.stream_captured = ""
-        self.stream_file_descriptor_copy = None  # type: Optional[int]
+        self.stream_file_descriptor_copy: Optional[int] = None
 
     def __enter__(self):
         self.start()

--- a/ofrak_type/ofrak_type/bit_width.py
+++ b/ofrak_type/ofrak_type/bit_width.py
@@ -11,5 +11,5 @@ class BitWidth(Enum):
     BIT_32 = 32
     BIT_64 = 64
 
-    def get_word_size(self):  # type: () -> int
+    def get_word_size(self) -> int:
         return int(self.value / 8)


### PR DESCRIPTION
Replace #9 with a solution that does not use `from __future__ import annotations`
1. Run https://pypi.org/project/com2ann to translate type comments into Python type annotations.
2. Resolve the undefined names in type hints but **_without_** `from __future__ import annotations` which caused problems in #9