### PR TITLE
Fix/tempdir filter nbvals

### DIFF
--- a/ofrak_tutorial/nbval_sanitizer.cfg
+++ b/ofrak_tutorial/nbval_sanitizer.cfg
@@ -9,9 +9,8 @@ regex: resources_(modified|deleted|created)=\{.*\}(,|\))
 replace: resources_\1={SOME_RESOURCES_\1}\2
 
 [tmp_directories]
-regex: /tmp/tmp[^/]+
+regex: ^.*\/te?mp\/.*$
 replace: /tmp/SOME_TMP_DIR
-
 
 [segmentation_faults]
 # Some systems add the "core dumped", it doesn't matter in this context, so strip it

--- a/ofrak_tutorial/nbval_sanitizer.cfg
+++ b/ofrak_tutorial/nbval_sanitizer.cfg
@@ -9,7 +9,7 @@ regex: resources_(modified|deleted|created)=\{.*\}(,|\))
 replace: resources_\1={SOME_RESOURCES_\1}\2
 
 [tmp_directories]
-regex: ^.*/te?mp/.*$
+regex: /.+/tmp[^/]+
 replace: /tmp/SOME_TMP_DIR
 
 [segmentation_faults]

--- a/ofrak_tutorial/nbval_sanitizer.cfg
+++ b/ofrak_tutorial/nbval_sanitizer.cfg
@@ -9,7 +9,7 @@ regex: resources_(modified|deleted|created)=\{.*\}(,|\))
 replace: resources_\1={SOME_RESOURCES_\1}\2
 
 [tmp_directories]
-regex: ^.*\/te?mp\/.*$
+regex: ^.*/te?mp/.*$
 replace: /tmp/SOME_TMP_DIR
 
 [segmentation_faults]


### PR DESCRIPTION
This makes the nbval sanitizer work on setups where the tmpdir root is in an arbitrary subdirectory.