### PR TITLE
Fix CI pipeline bugs

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Export base image
         if: inputs.flush_cache || steps.cache-image.outputs.cache-hit != 'true' || github.event_name == 'schedule'
         run: |
-          sudo apt install pigz
+          sudo apt install pigz pv
           docker save redballoonsecurity/ofrak/core-dev-base:latest \
             | pigz -9 \
             | pv --size 2400m --interval 5 --force \

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
   schedule: 
     - cron: '0 0 * * *'
   workflow_dispatch: 

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -74,6 +74,7 @@ jobs:
           sudo apt install pigz
           docker save redballoonsecurity/ofrak/core-dev-base:latest \
             | pigz -9 \
+            | pv --size 2400m --interval 5 --force \
             > ofrak-base.tar.gz
 
   ofrak-ghidra:
@@ -97,7 +98,9 @@ jobs:
           path: ofrak-base.tar.gz
       - name: Load base image
         run: |
-          docker load --input ofrak-base.tar.gz
+          sudo apt install pv
+          pv --size 2400m --interval 5 --force ofrak-base.tar.gz \
+            | docker load 
           docker images
       - name: Build Ghidra image
         run: |
@@ -149,7 +152,9 @@ jobs:
           path: ofrak-base.tar.gz
       - name: Load base image
         run: |
-          docker load --input ofrak-base.tar.gz
+          sudo apt install pv
+          pv --size 2400m --interval 5 --force ofrak-base.tar.gz \
+            | docker load 
           docker images
       - name: Build angr image
         run: |
@@ -191,7 +196,9 @@ jobs:
           path: ofrak-base.tar.gz
       - name: Load base image
         run: |
-          docker load --input ofrak-base.tar.gz
+          sudo apt install pv
+          pv --size 2400m --interval 5 --force ofrak-base.tar.gz \
+            | docker load 
           docker images
       - name: Build tutorial image
         run: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -8,6 +8,10 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: 
     inputs:
+      flush_cache:
+        description: Flush the Docker image cache
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -57,12 +61,12 @@ jobs:
           path: ofrak-base.tar.gz
       - name: Build base image
         # Always rebuild the base image when the scheduled workflow runs
-        if: steps.cache-image.outputs.cache-hit != 'true' || github.event_name == 'schedule'
+        if: inputs.flush_cache || steps.cache-image.outputs.cache-hit != 'true' || github.event_name == 'schedule'
         run: |
           python3 -m pip install PyYAML
           DOCKER_BUILDKIT=1 python3 build_image.py --config ofrak-core-dev.yml --base 
       - name: Export base image
-        if: steps.cache-image.outputs.cache-hit != 'true' || github.event_name == 'schedule'
+        if: inputs.flush_cache || steps.cache-image.outputs.cache-hit != 'true' || github.event_name == 'schedule'
         run: |
           sudo apt install pigz
           docker save redballoonsecurity/ofrak/core-dev-base:latest \

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Load base image
         run: |
           sudo apt install pv
-          pv --size 2400m --interval 5 --force ofrak-base.tar.gz \
+          pv --interval 5 --force ofrak-base.tar.gz \
             | docker load 
           docker images
       - name: Build Ghidra image
@@ -153,7 +153,7 @@ jobs:
       - name: Load base image
         run: |
           sudo apt install pv
-          pv --size 2400m --interval 5 --force ofrak-base.tar.gz \
+          pv --interval 5 --force ofrak-base.tar.gz \
             | docker load 
           docker images
       - name: Build angr image
@@ -197,7 +197,7 @@ jobs:
       - name: Load base image
         run: |
           sudo apt install pv
-          pv --size 2400m --interval 5 --force ofrak-base.tar.gz \
+          pv --interval 5 --force ofrak-base.tar.gz \
             | docker load 
           docker images
       - name: Build tutorial image

--- a/build_image.py
+++ b/build_image.py
@@ -75,9 +75,10 @@ def main():
     if config.build_base:
         full_base_image_name = "/".join((config.registry, config.base_image_name))
         cache_args = []
-        for cache in config.cache_from:
-            cache_args.append("--cache-from")
-            cache_args.append(cache)
+        if config.cache_from is not None:
+            for cache in config.cache_from:
+                cache_args.append("--cache-from")
+                cache_args.append(cache)
         base_command = [
             "docker",
             "build",


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

PR #27 added a GitHub CI pipeline. This pull request fixes some minor issues with the pipeline and adds some minor improvements. Specifically:

- Use `pv` when doing `docker load` and `docker save` so there is a logged progress bar
- Run the pipeline on merges with `master`, not just pull requests
- Add an optional input to force flushing the Docker image cache on manual workflow runs
- Fix a small bug in `build_image.py` when no `--cache-from` arguments are passed

**Anyone you think should look at this, specifically?**

@whyitfor 