### PR TITLE
Fix lack of IDs in tutorial notebook 6

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -209,7 +209,7 @@ jobs:
             --base \
             --finish \
             --cache-from redballoonsecurity/ofrak/core-dev-base:latest
-      - name: Test components
+      - name: Test tutorials
         run: |
           docker run \
             --interactive \

--- a/ofrak_tutorial/notebooks_with_outputs/6_code_insertion_with_extension.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/6_code_insertion_with_extension.ipynb
@@ -2,44 +2,50 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "62cb51d5",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Lesson 6: Code extension by adding a new segment in the ELF"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "504eeea5",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Objectives**: add a new segment in an ELF; use the OFRAK PatchMaker to convert a C patch into a binary patch, including a linking step"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "33855fd0",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Section Overview\n",
     "In this section, we will replace a call to `puts` with a wrapper function that converts all lower-case characters to upper-case in the target x86 ELF `hello_world`. We will explore what happens when and why patches can be applied in various ways and then learn about OFRAK PatchMaker in order to implement the objective."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 1,
+   "id": "c82e4268",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "### Target binary `hello_world`\n",
@@ -80,16 +86,16 @@
     "c_patch_filename = \"c_patch.c\"\n",
     "with open(c_patch_filename, \"w\") as f:\n",
     "    f.write(c_patch)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "02b3a874",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We shall allocate in the free-space of `hello_world` the wrapper function `uppercase_and_print`, which is called instead of `puts` in `main`. `uppercase_and_print` will copy the string from RO memory, modify it, then call the library function `extern int puts(char *str)` with the modified string buffer.\n",
     "\n",
@@ -163,17 +169,16 @@
     "        00405044 c3              RET\n",
     "\n",
     "```"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a25bf6e2",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
    },
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
    "source": [
     "## Strategies of Patching\n",
     "#### Function Wrapping\n",
@@ -240,16 +245,16 @@
     "\n",
     "#### Data-only patching\n",
     "Generally if the data is provided in RO memory, we could just replace the string with a capitalized variant, instead of modifying the program to capitalize the string at runtime. [Lesson 1](./1_simple_string_modification.ipynb) addresses data-only patching. For this lesson we will perform a code patch for demonstration purposes.\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1d28a672",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Considering other places to patch\n",
     "Could we hook something else to capitalize strings without copying from read-only memory? We could look for an existing function that already performs an array copy to writeable memory, and replace it with a modified version that also capitalizes each character as they are written to the destination. Such a function does not exist in our `hello_world` example as the string is directly passed to `puts` from RO memory. However,  we may consider patching GLIBC instead. If you expand the call-chain for GLIBC `puts` then it should look something like this:\n",
@@ -277,28 +282,28 @@
     "It looks like [_IO_new_file_xsputn](https://elixir.bootlin.com/glibc/glibc-2.29/source/libio/fileops.c#L1180) [line 1243](https://elixir.bootlin.com/glibc/glibc-2.29/source/libio/fileops.c#L1243) is a macro expanded into a memcpy. One could replace the [mempcpy](https://elixir.bootlin.com/glibc/glibc-2.36/source/sysdeps/i386/i686/mempcpy.S#L37) call with something that performs a `BYTE != 0x20 ? BYTE & ~ 0x20 : BYTE` operation before writing each byte to the destination. The modified `mempcpy` would be embedded in the free-space of the target binary and be called in `__mempcpy`'s place on [line 1243](https://elixir.bootlin.com/glibc/glibc-2.29/source/libio/fileops.c#L1243).\n",
     "\n",
     "While this patch would mitigate the introduction of an extra indirection by replacing (not wrapping) an existing `memcpy`, there are two major drawbacks to this strategy: additional machinery would need to be implemented to prevent the modified `mempcpy` from modifying bytes un-intended for STDOUT, and this patch depends on specific versions of GLIBC to be loaded into the target binary's runtime. This patch seems more complicated to implement properly and is less portable due to its dependence on system-provided runtime libraries; nonetheless, whether it is suitable is dependent on the constraints a patch author is working with."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "97bc40d0",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Overall**, a patch author has to wear two hats simultaneously: a patch author needs to apply the mindset of an engineer to decide on designs that fit some set of constraints, while also applying the mindset of a scientist to model behavior when modifications are made (and possibly on a binary without available source code). Certain patches may favor modularity and portability while other patch designs may favor performance, resulting in less portable and lower-level optimizations being applied; and in either case there may be requirements on timing and state guarantees that the modification has to satisfy."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c45bb82a",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Using OFRAK PatchMaker\n",
     "\n",
@@ -312,33 +317,32 @@
     "4. **Compile** the `uppercase_and_print` patch source using OFRAK _PatchMaker_, after defining the program attributes, toolchain and symbols we wish to re-link to `hello_world`;\n",
     "5. **Inject** the extended ELF segment with the compiled patch blob using OFRAK _BinaryPatchModifier_;\n",
     "6. **Pack** the OFRAK resource we've modified back into an executable, so we can run and test our work!"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84425592",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
    },
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
    "source": [
     "\n",
     "#### [1] Unpack `hello_world` onto an OFRAK resource tree\n",
     "\n",
     "First lets instantiate OFRAK with the Ghidra analyzer backend and create a root resource from the `hello_world` binary we want to patch:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 2,
+   "id": "8e378012",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import ofrak_ghidra\n",
@@ -349,39 +353,33 @@
     "binary_analysis_context = await ofrak.create_ofrak_context()\n",
     "\n",
     "root_resource = await binary_analysis_context.create_root_resource_from_file(\"hello_world\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "47a8f988",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### [2] Extend the `hello_world` resource with a new ELF segment with OFRAK core\n",
     "\n",
     "With the root resource created, let's start with the creation of the new segment. We will use OFRAK's `LiefAddSegmentModifier`, leveraging the [LIEF project](https://lief-project.github.io/) to add an ELF segment which will contain the code for `uppercase_and_print`."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 3,
    "id": "5d2912b0",
    "metadata": {
-    "tags": [
-     "nbval-ignore-output"
-    ],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": [
+     "nbval-ignore-output"
+    ]
    },
    "outputs": [
     {
@@ -447,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 4,
    "id": "3421c337",
    "metadata": {
     "pycharm": {
@@ -503,7 +501,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 5,
+   "id": "a48ef84f",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import tempfile\n",
@@ -514,32 +518,32 @@
     "exec_path        = os.path.join(bld_dir, \"hello_world_patch_exec\")\n",
     "input_filename   = \"hello_world\"\n",
     "output_filename  = \"HELLO_WORLD\""
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "18bf7d03",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "\n",
     "`hello_world` is a 64-bit x86 ELF binary compiled with GCC, however in this example we will compile the patch with LLVM. It works, but mixing objects compiled by different toolchains and compiler flags could increase the chances of un-predictable failures in other examples. Usually the most predictable results (and failures) are achieved by matching the toolchain configuration of the host binary, which can be inferred through some reverse engineering (fingerprinting, strings, debug info).\n",
     "\n",
     "Let's create the `ProgramAttributes` with information we know about the target binary:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 6,
+   "id": "946a040a",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from ofrak.core import ProgramAttributes\n",
@@ -554,29 +558,29 @@
     "    endianness = Endianness.BIG_ENDIAN,\n",
     "    processor  = None,\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "In supporting multiple toolchains, `ToolchainConfig` specifies generic compiler features (optimization level, force inline functions, etc.) which _PatchMaker_ maps into specific compiler flags provided to each toolchain. A full description can be found in the docstring for `ToolchainConfig` in `ofrak_patch_maker/ofrak_patch_maker/toolchain/model.py`. Let's compile our patch with `-OS` optimization, function inlining, as well as reduce extraneous scaffolding that may be added by the compiler:"
-   ],
+   "id": "2ac00fde",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "In supporting multiple toolchains, `ToolchainConfig` specifies generic compiler features (optimization level, force inline functions, etc.) which _PatchMaker_ maps into specific compiler flags provided to each toolchain. A full description can be found in the docstring for `ToolchainConfig` in `ofrak_patch_maker/ofrak_patch_maker/toolchain/model.py`. Let's compile our patch with `-OS` optimization, function inlining, as well as reduce extraneous scaffolding that may be added by the compiler:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": 7,
+   "id": "7202288c",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from ofrak_patch_maker.toolchain.model import (\n",
@@ -597,29 +601,29 @@
     "    debug_info       = False,\n",
     "    check_overlap    = False,\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Having specified `ProgramAttributes` and `ToolchainConfig`, we can set up the `PatchMaker` to link `extern int puts(char *str)` in our patch to the original address of `puts` in our target binary:"
-   ],
+   "id": "6f598d14",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Having specified `ProgramAttributes` and `ToolchainConfig`, we can set up the `PatchMaker` to link `extern int puts(char *str)` in our patch to the original address of `puts` in our target binary:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": 8,
+   "id": "aa7e00b2",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -657,29 +661,29 @@
     ")\n",
     "\n",
     "print(f\"Once the BOM is created, `extern int puts(char *str)` will point to 0x{puts_cb.virtual_address:x}, the address of the `puts` thunk in `hello_world` which can be accessed from within the patch source code.\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "_PatchMaker_ can build a patch from multiple source, object and header files, so we ask it to generate a `BOM` (Batched Objects and Metadata):"
-   ],
+   "id": "dbd883fe",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "_PatchMaker_ can build a patch from multiple source, object and header files, so we ask it to generate a `BOM` (Batched Objects and Metadata):"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": 9,
+   "id": "9fde02fe",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -690,7 +694,7 @@
       "bss_size_required:             0\n",
       "entry_point_symbol (optional): None\n",
       "\n",
-      "object map[c_patch]:           AssembledObject(path='/tmp/tmphb35jn44/hello_world_patch_bom_files/c_patch.c.o', file_format=<BinFileType.ELF: 'elf'>, segment_map=immutabledict({'': Segment(segment_name='', vm_address=0, offset=0, is_entry=False, length=0, access_perms=<MemoryPermissions.R: 1>), '.strtab': Segment(segment_name='.strtab', vm_address=0, offset=280, is_entry=False, length=88, access_perms=<MemoryPermissions.R: 1>), '.text': Segment(segment_name='.text', vm_address=0, offset=64, is_entry=False, length=69, access_perms=<MemoryPermissions.RX: 5>), '.rela.text': Segment(segment_name='.rela.text', vm_address=0, offset=256, is_entry=False, length=24, access_perms=<MemoryPermissions.R: 1>), '.comment': Segment(segment_name='.comment', vm_address=0, offset=133, is_entry=False, length=22, access_perms=<MemoryPermissions.R: 1>), '.note.GNU-stack': Segment(segment_name='.note.GNU-stack', vm_address=0, offset=155, is_entry=False, length=0, access_perms=<MemoryPermissions.R: 1>), '.symtab': Segment(segment_name='.symtab', vm_address=0, offset=160, is_entry=False, length=96, access_perms=<MemoryPermissions.R: 1>)}), symbols=immutabledict({'c_patch.c': 0, 'uppercase_and_print': 0}))\n",
+      "object map[c_patch]:           AssembledObject(path='/tmp/tmplw4ax4l2/hello_world_patch_bom_files/c_patch.c.o', file_format=<BinFileType.ELF: 'elf'>, segment_map=immutabledict({'': Segment(segment_name='', vm_address=0, offset=0, is_entry=False, length=0, access_perms=<MemoryPermissions.R: 1>), '.strtab': Segment(segment_name='.strtab', vm_address=0, offset=280, is_entry=False, length=88, access_perms=<MemoryPermissions.R: 1>), '.text': Segment(segment_name='.text', vm_address=0, offset=64, is_entry=False, length=69, access_perms=<MemoryPermissions.RX: 5>), '.rela.text': Segment(segment_name='.rela.text', vm_address=0, offset=256, is_entry=False, length=24, access_perms=<MemoryPermissions.R: 1>), '.comment': Segment(segment_name='.comment', vm_address=0, offset=133, is_entry=False, length=22, access_perms=<MemoryPermissions.R: 1>), '.note.GNU-stack': Segment(segment_name='.note.GNU-stack', vm_address=0, offset=155, is_entry=False, length=0, access_perms=<MemoryPermissions.R: 1>), '.symtab': Segment(segment_name='.symtab', vm_address=0, offset=160, is_entry=False, length=96, access_perms=<MemoryPermissions.R: 1>)}), symbols=immutabledict({'c_patch.c': 0, 'uppercase_and_print': 0}))\n",
       "\n"
      ]
     }
@@ -710,29 +714,29 @@
     "      f\"bss_size_required:             {bom.bss_size_required}\\n\"\n",
     "      f\"entry_point_symbol (optional): {bom.entry_point_symbol}\\n\\n\"\n",
     "      f\"object map[c_patch]:           {bom.object_map['c_patch.c']}\\n\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Then we generate the `PatchRegionConfig`, which describes the segment we've extended in step [3] and maps it to the `uppercase_and_print` code blob that we are about to compile:"
-   ],
+   "id": "eb1f9f9f",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Then we generate the `PatchRegionConfig`, which describes the segment we've extended in step [3] and maps it to the `uppercase_and_print` code blob that we are about to compile:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 10,
+   "id": "635e0eed",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from ofrak_patch_maker.model import PatchRegionConfig\n",
@@ -757,37 +761,39 @@
     "\n",
     "# Generate a PatchRegionConfig incorporating the previous information\n",
     "p = PatchRegionConfig(bom.name + \"_patch\", segment_dict)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "And finally for this step, we compile the patch into an FEM (Final Executable and Metadata) and write it to disk:"
-   ],
+   "id": "0fdf9a21",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "And finally for this step, we compile the patch into an FEM (Final Executable and Metadata) and write it to disk:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "80577a17",
    "metadata": {
     "pycharm": {
-     "name": "#%%\n",
-     "is_executing": true
+     "is_executing": true,
+     "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ld.lld: warning: cannot find entry symbol _start; not setting start address\n"
+     ]
+    }
+   ],
    "source": [
     "from ofrak_patch_maker.toolchain.utils import get_file_format\n",
     "\n",
@@ -799,20 +805,26 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### [5] Inject the extended ELF segment with the compiled patch blob using OFRAK _BinaryPatchModifier_\n",
-    "Having compiled the patch, we shall extract `uppercase_and_print` from the FEM into the extended segment we created in step [3] on the OFRAK resource tree:"
-   ],
+   "id": "e2b983b8",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "#### [5] Inject the extended ELF segment with the compiled patch blob using OFRAK _BinaryPatchModifier_\n",
+    "Having compiled the patch, we shall extract `uppercase_and_print` from the FEM into the extended segment we created in step [3] on the OFRAK resource tree:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": 12,
+   "id": "65177471",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -845,13 +857,7 @@
     "await root_resource.run(BinaryPatchModifier, patch_config)\n",
     "\n",
     "print(\"OFRAK tree patched!\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -867,34 +873,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 13,
+   "id": "8147b30e",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "await root_resource.pack()\n",
     "await root_resource.flush_to_disk(output_filename)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's test our results!"
-   ],
+   "id": "9d25df90",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Let's test our results!"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": 14,
    "id": "cadf4555",
    "metadata": {
     "pycharm": {
@@ -923,15 +929,15 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "If you can see the capitalized \"HELLO, WORLD!\" output, the patch has successfully been applied. Feel free to experiment with the patch source and toolchain configuration in this notebook."
-   ],
+   "id": "d4a636e7",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "If you can see the capitalized \"HELLO, WORLD!\" output, the patch has successfully been applied. Feel free to experiment with the patch source and toolchain configuration in this notebook."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -967,10 +973,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

The CI pipeline is currently blocked by failure to convert some of the tutorial Jupyter notebooks. This, in turn, is because an [update to `nbformat`](https://pypi.org/project/nbformat/5.5.0/#history) (on which the Jupyter notebook package depends) no longer accepts cells without IDs. 

This PR fixes this issue by giving all of the cells in tutorial notebook 6 IDs. For some weird reason, that was the only notebook without them. 

The fixed notebook was generated by opening the broken notebook in the web interface, running all cells, and exporting the resulting notebook as an `.ipynb`. 

**Anyone you think should look at this, specifically?**

@whyitfor 