### PR TITLE
Put the `Dockerfile` syntax line at the top

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -178,7 +178,9 @@ def check_package_contents(package_path: str):
 
 
 def create_dockerfile_base(config: OfrakImageConfig) -> str:
-    dockerfile_base_parts = []
+    dockerfile_base_parts = [
+        "# syntax = docker/dockerfile:1.3",
+    ]
 
     # Support multi-stage builds
     for package_path in config.packages_paths:
@@ -189,7 +191,6 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
         dockerfile_base_parts.append(dockerstub)
 
     dockerfile_base_parts += [
-        "# syntax = docker/dockerfile:1.3",
         "FROM python:3.7-bullseye@sha256:338ead05c1a0aa8bd8fcba8e4dbbe2afd0283b4732fd30cf9b3bfcfcbc4affab",
     ]
     for package_path in config.packages_paths:


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

The `# syntax` line in a `Dockerfile` must be the first line. This change fixes the generated `Dockerfile` such that this is the case. This, in turn, fixes errors when building the image with a mounted Binary Ninja license.

**Anyone you think should look at this, specifically?**

@whyitfor 