### PR TITLE
Bump lief to 0.12.1

### DIFF
--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     },
     install_requires=[
         "intervaltree==3.1.0",
-        "lief==0.11.5",
+        "lief==0.12.1",
         "orjson~=3.6.7",
         "pefile==2022.5.30",
         "python-magic",


### PR DESCRIPTION
**Link to Related Issue(s)**
https://github.com/redballoonsecurity/ofrak/security/dependabot/1
https://github.com/redballoonsecurity/ofrak/security/dependabot/2
https://github.com/redballoonsecurity/ofrak/security/dependabot/3
https://github.com/redballoonsecurity/ofrak/security/dependabot/4

**Please describe the changes in your request.**
Bump lief version to 0.12.1 to mitigate the above-referenced security issues in older versions of lief. 

**Anyone you think should look at this, specifically?**
@jstrieb 