### PR TITLE
Use fewer layers in the "finish" Dockerfile

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -209,7 +209,6 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
         package_names.append(package_name)
         finish_stub_parts = [
             f"ARG OFRAK_SRC_DIR=/{package_name}",
-            "WORKDIR $OFRAK_SRC_DIR",
             f"ADD {package_path} $OFRAK_SRC_DIR\n",
         ]
         dockerfile_finish_parts.append("\n".join(finish_stub_parts))

--- a/build_image.py
+++ b/build_image.py
@@ -210,20 +210,30 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
         finish_stub_parts = [
             f"ARG OFRAK_SRC_DIR=/{package_name}",
             "WORKDIR $OFRAK_SRC_DIR",
-            f"ADD {package_path} $OFRAK_SRC_DIR",
-            "ARG INSTALL_TARGET",
-            "RUN make $INSTALL_TARGET\n\n",
+            f"ADD {package_path} $OFRAK_SRC_DIR\n",
         ]
         dockerfile_finish_parts.append("\n".join(finish_stub_parts))
     dockerfile_finish_parts.append("WORKDIR /\n")
+    dockerfile_finish_parts.append("ARG INSTALL_TARGET\n")
+    develop_makefile = "\\n\\\n".join(
+        [
+            "$INSTALL_TARGET:",
+            "\\n\\\n".join(
+                [f"\tmake -C {package_name} $INSTALL_TARGET" for package_name in package_names]
+            ),
+            "\\n",
+        ]
+    )
+    dockerfile_finish_parts.append(f'RUN printf "{develop_makefile}" >> Makefile\n\n')
+    dockerfile_finish_parts.append("RUN make $INSTALL_TARGET\n\n")
     finish_makefile = "\\n\\\n".join(
         [
             "test:",
             "\\n\\\n".join([f"\tmake -C {package_name} test" for package_name in package_names]),
-            "",
+            "\\n",
         ]
     )
-    dockerfile_finish_parts.append(f"RUN printf '{finish_makefile}' >> Makefile")
+    dockerfile_finish_parts.append(f'RUN printf "{finish_makefile}" >> Makefile')
     return "".join(dockerfile_finish_parts)
 
 

--- a/build_image.py
+++ b/build_image.py
@@ -210,11 +210,8 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
     for package_path in config.packages_paths:
         package_name = os.path.basename(package_path)
         package_names.append(package_name)
-        finish_stub_parts = [
-            f"ADD {package_path} $OFRAK_SRC_DIR/{package_name}\n",
-        ]
-        dockerfile_finish_parts.append("\n".join(finish_stub_parts))
-    dockerfile_finish_parts.append("WORKDIR /\n")
+        dockerfile_finish_parts.append(f"ADD {package_path} $OFRAK_SRC_DIR/{package_name}\n")
+    dockerfile_finish_parts.append("\nWORKDIR /\n")
     dockerfile_finish_parts.append("ARG INSTALL_TARGET\n")
     develop_makefile = "\\n\\\n".join(
         [
@@ -225,7 +222,7 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
             "\\n",
         ]
     )
-    dockerfile_finish_parts.append(f'RUN printf "{develop_makefile}" >> Makefile\n\n')
+    dockerfile_finish_parts.append(f'RUN printf "{develop_makefile}" >> Makefile\n')
     dockerfile_finish_parts.append("RUN make $INSTALL_TARGET\n\n")
     finish_makefile = "\\n\\\n".join(
         [
@@ -234,7 +231,7 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
             "\\n",
         ]
     )
-    dockerfile_finish_parts.append(f'RUN printf "{finish_makefile}" >> Makefile')
+    dockerfile_finish_parts.append(f'RUN printf "{finish_makefile}" >> Makefile\n')
     return "".join(dockerfile_finish_parts)
 
 

--- a/build_image.py
+++ b/build_image.py
@@ -203,11 +203,16 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
 def create_dockerfile_finish(config: OfrakImageConfig) -> str:
     full_base_image_name = "/".join((config.registry, config.base_image_name))
     dockerfile_finish_parts = [f"FROM {full_base_image_name}:{GIT_COMMIT_HASH}\n\n"]
-    dockerfile_finish_parts.append("WORKDIR /\n\n")
-    package_names = [os.path.basename(package_path) for package_path in config.packages_paths]
-    dockerfile_finish_parts.append(
-        "ADD " + " ".join([p + "/" for p in config.packages_paths]) + " /\n\n"
-    )
+    package_names = list()
+    for package_path in config.packages_paths:
+        package_name = os.path.basename(package_path)
+        package_names.append(package_name)
+        finish_stub_parts = [
+            f"ARG OFRAK_SRC_DIR=/{package_name}",
+            f"ADD {package_path} $OFRAK_SRC_DIR\n",
+        ]
+        dockerfile_finish_parts.append("\n".join(finish_stub_parts))
+    dockerfile_finish_parts.append("WORKDIR /\n")
     dockerfile_finish_parts.append("ARG INSTALL_TARGET\n")
     develop_makefile = "\\n\\\n".join(
         [
@@ -219,7 +224,7 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
         ]
     )
     dockerfile_finish_parts.append(f'RUN printf "{develop_makefile}" >> Makefile\n\n')
-    # dockerfile_finish_parts.append("RUN make $INSTALL_TARGET\n\n")
+    dockerfile_finish_parts.append("RUN make $INSTALL_TARGET\n\n")
     finish_makefile = "\\n\\\n".join(
         [
             "test:",

--- a/build_image.py
+++ b/build_image.py
@@ -202,14 +202,16 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
 
 def create_dockerfile_finish(config: OfrakImageConfig) -> str:
     full_base_image_name = "/".join((config.registry, config.base_image_name))
-    dockerfile_finish_parts = [f"FROM {full_base_image_name}:{GIT_COMMIT_HASH}\n\n"]
+    dockerfile_finish_parts = [
+        f"FROM {full_base_image_name}:{GIT_COMMIT_HASH}\n\n",
+        f"ARG OFRAK_SRC_DIR=/\n",
+    ]
     package_names = list()
     for package_path in config.packages_paths:
         package_name = os.path.basename(package_path)
         package_names.append(package_name)
         finish_stub_parts = [
-            f"ARG OFRAK_SRC_DIR=/{package_name}",
-            f"ADD {package_path} $OFRAK_SRC_DIR\n",
+            f"ADD {package_path} $OFRAK_SRC_DIR/{package_name}\n",
         ]
         dockerfile_finish_parts.append("\n".join(finish_stub_parts))
     dockerfile_finish_parts.append("WORKDIR /\n")


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

In OFRAK Docker image builds that have many packages, we are hitting the maximum layer depth allowed by Docker. This PR condenses many separate layers (that are rarely cached) in the "finish" image into one layer.

I tried to further condense the "finish" image by having all of the `ADD` lines in `finish.Dockerfile` be combined into one big `ADD`, but it doesn't actually look like that's possible to cleanly do. The problem is that, as it is now, each `ADD` command specifically writes to a destination directory it must create. Thus, writing everything to `/` doesn't create those directories. Rather, it dumps the contents of those directories into the root directory. See:

- <https://stackoverflow.com/a/45644105>
- <https://stackoverflow.com/a/37715522>

Luckily, the layer reduction from this changeset is good enough for now.

**Anyone you think should look at this, specifically?**

@EdwardLarson 

**Example `finish.Dockerfile` generated by the new code**

``` dockerfile
FROM redballoonsecurity/ofrak/tutorial-base:c9bad104

ARG OFRAK_SRC_DIR=/
ADD ofrak_type $OFRAK_SRC_DIR/ofrak_type
ADD ofrak_io $OFRAK_SRC_DIR/ofrak_io
ADD ofrak_patch_maker $OFRAK_SRC_DIR/ofrak_patch_maker
ADD ofrak_core $OFRAK_SRC_DIR/ofrak_core
ADD ofrak_components $OFRAK_SRC_DIR/ofrak_components
ADD disassemblers/ofrak_ghidra $OFRAK_SRC_DIR/ofrak_ghidra
ADD frontend $OFRAK_SRC_DIR/frontend
ADD ofrak_tutorial $OFRAK_SRC_DIR/ofrak_tutorial

WORKDIR /
ARG INSTALL_TARGET
RUN printf "$INSTALL_TARGET:\n\
        make -C ofrak_type $INSTALL_TARGET\n\
        make -C ofrak_io $INSTALL_TARGET\n\
        make -C ofrak_patch_maker $INSTALL_TARGET\n\
        make -C ofrak_core $INSTALL_TARGET\n\
        make -C ofrak_components $INSTALL_TARGET\n\
        make -C ofrak_ghidra $INSTALL_TARGET\n\
        make -C frontend $INSTALL_TARGET\n\
        make -C ofrak_tutorial $INSTALL_TARGET\n\
\n" >> Makefile
RUN make $INSTALL_TARGET

RUN printf "test:\n\
        make -C ofrak_type test\n\
        make -C ofrak_io test\n\
        make -C ofrak_patch_maker test\n\
        make -C ofrak_core test\n\
        make -C ofrak_components test\n\
        make -C ofrak_ghidra test\n\
        make -C frontend test\n\
        make -C ofrak_tutorial test\n\
\n" >> Makefile
```