### PR TITLE
Add function coverage targets for OFRAK packages

### DIFF
--- a/disassemblers/ofrak_angr/Makefile
+++ b/disassemblers/ofrak_angr/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest --cov=ofrak_angr ofrak_angr_test
-	fun-coverage --cov-fail-under=83
+	fun-coverage --cov-fail-under=82
 
 .PHONY: dependencies
 dependencies:

--- a/disassemblers/ofrak_angr/Makefile
+++ b/disassemblers/ofrak_angr/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest --cov=ofrak_angr ofrak_angr_test
-	fun-coverage
+	fun-coverage --cov-fail-under=83
 
 .PHONY: dependencies
 dependencies:

--- a/disassemblers/ofrak_binary_ninja/Makefile
+++ b/disassemblers/ofrak_binary_ninja/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest --cov=ofrak_binary_ninja --cov-report=term-missing ofrak_binary_ninja_test
-	fun-coverage --cov-fail-under=88
+	fun-coverage --cov-fail-under=87
 
 .PHONY: dependencies
 dependencies:

--- a/disassemblers/ofrak_binary_ninja/Makefile
+++ b/disassemblers/ofrak_binary_ninja/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest --cov=ofrak_binary_ninja --cov-report=term-missing ofrak_binary_ninja_test
-	fun-coverage
+	fun-coverage --cov-fail-under=88
 
 .PHONY: dependencies
 dependencies:

--- a/disassemblers/ofrak_capstone/Makefile
+++ b/disassemblers/ofrak_capstone/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest --cov=ofrak_capstone --cov-report=term-missing test_ofrak_capstone.py
-	fun-coverage
+	fun-coverage --cov-fail-under=100
 
 .PHONY: dependencies
 dependencies:

--- a/disassemblers/ofrak_ghidra/Makefile
+++ b/disassemblers/ofrak_ghidra/Makefile
@@ -9,6 +9,6 @@ develop:
 
 test:
 	$(PYTHON) -m pytest --cov=ofrak_ghidra --cov-report=term-missing ofrak_ghidra_test
-	fun-coverage --cov-fail-under=64
+	fun-coverage --cov-fail-under=63
 
 dependencies:

--- a/disassemblers/ofrak_ghidra/Makefile
+++ b/disassemblers/ofrak_ghidra/Makefile
@@ -9,6 +9,6 @@ develop:
 
 test:
 	$(PYTHON) -m pytest --cov=ofrak_ghidra --cov-report=term-missing ofrak_ghidra_test
-	fun-coverage
+	fun-coverage --cov-fail-under=64
 
 dependencies:

--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage
+	fun-coverage --cov-fail-under=78
 
 .PHONY: test
 test: inspect test-components

--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage --cov-fail-under=78
+	fun-coverage --cov-fail-under=77
 
 .PHONY: test
 test: inspect test-components

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -16,12 +16,12 @@ inspect:
 .PHONY: test-core
 test-core:
 	$(PYTHON) -m pytest test_ofrak/unit test_ofrak/components --cov=ofrak --cov-report=term-missing
-	fun-coverage
+	fun-coverage --cov-fail-under=65
 
 .PHONY: test-services
 test-services:
 	$(PYTHON) -m pytest test_ofrak/service --cov=ofrak --cov-report=term-missing
-	fun-coverage
+	fun-coverage --cov-fail-under=39
 
 .PHONY: test
 test: inspect test-core test-services

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -16,12 +16,12 @@ inspect:
 .PHONY: test-core
 test-core:
 	$(PYTHON) -m pytest test_ofrak/unit test_ofrak/components --cov=ofrak --cov-report=term-missing
-	fun-coverage --cov-fail-under=65
+	fun-coverage --cov-fail-under=64
 
 .PHONY: test-services
 test-services:
 	$(PYTHON) -m pytest test_ofrak/service --cov=ofrak --cov-report=term-missing
-	fun-coverage --cov-fail-under=39
+	fun-coverage --cov-fail-under=38
 
 .PHONY: test
 test: inspect test-core test-services

--- a/ofrak_patch_maker/Makefile
+++ b/ofrak_patch_maker/Makefile
@@ -24,7 +24,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest --cov=ofrak_patch_maker --cov-report=term-missing ofrak_patch_maker_test
-	fun-coverage --cov-fail-under=80
+	fun-coverage --cov-fail-under=79
 
 .PHONY: dependencies
 dependencies:

--- a/ofrak_patch_maker/Makefile
+++ b/ofrak_patch_maker/Makefile
@@ -24,7 +24,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest --cov=ofrak_patch_maker --cov-report=term-missing ofrak_patch_maker_test
-	fun-coverage
+	fun-coverage --cov-fail-under=80
 
 .PHONY: dependencies
 dependencies:


### PR DESCRIPTION
**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
This change enforces function coverage for Python libraries in this repository. Specifically, it ensures that the current level of function coverage is the baseline: the tests will fail if function coverage dips below this line.

**Anyone you think should look at this, specifically?**
@EdwardLarson 