### PR TITLE
Add flash component documentation and example

### DIFF
--- a/docs/user-guide/flash_component.md
+++ b/docs/user-guide/flash_component.md
@@ -129,7 +129,7 @@ root_resource.add_attributes(CUSTOM_FLASH_ATTRIBUTES)
 await root_resource.save()
 ```
 
-We have included an example that unpacks a provided flash dump, makes a modification, and repacks it into the same format in [`Example 9: Flash Modification`](`/examples/ex9_flash_modification.html`).
+We have included an example that unpacks a provided flash dump, makes a modification, and repacks it into the same format in [`Example 9: Flash Modification`](`https://ofrak.com/docs/examples/ex9_flash_modification.html`).
 
 
 <div align="right">

--- a/docs/user-guide/flash_component.md
+++ b/docs/user-guide/flash_component.md
@@ -1,17 +1,20 @@
-# Flash Component
+# NAND Flash Components
 ## Overview
 OFRAK includes a flash component that can unpack and pack a raw flash dump that includes out-of-band (OOB) data. A raw dump includes this extra data that make it hard to analyze without separating the "useful" data from the OOB data.
 
-In this page, we will cover why we have this component, what a typical dump may look like, and how to get started with the flash component.
+This page covers what a typical flash dump may look like and how to get started with using the flash components.
 
 ## A Typical Flash Dump
+
+A typical flash dump looks something like this:
+
 |    DATA   |    OOB   |    DATA   |    OOB   |    ...   |
 | --------- | -------- | --------- | -------- | -------- |
 | 512 Bytes | 16 Bytes | 512 Bytes | 16 Bytes |    ...   |
 
 This pattern may continue for the entire flash chip or could have fields in the header or tail block that show the size of the region that includes OOB data.
 
-Other examples are more complex. Sometimes this is because not all of the dump is ECC protected or needs OOB data so delimiters or magic bytes are necessary to show the area. An example format:
+Other examples are more complex. Sometimes this is due to the fact that not all of the dump is ECC protected or needs OOB data. In such cases, delimiters or magic bytes are necessary to show the area. An example format:
 
 Header Block
 
@@ -64,7 +67,7 @@ class FlashFieldType(Enum):
 - `DELIMITER` may be placed between fields in a block or to indicate what type of block it is.
 - `TOTAL_SIZE` indicates the size of the entire region that includes OOB data.
 
-We recognize that some fields may be used differently than our implementation currently allows and we are likely missing some fields to be truly universal. In these cases, these classes can be overriden to be more flexible with your own use case.
+This class can be overridden or augmented if other field types are encountered.
 
 
 ## Usage
@@ -73,18 +76,7 @@ A `FlashAttributes` must be provided in order to use the flash component. As wit
 ### `FlashAttributes`
 The `FlashAttributes` is necessary for communicating the information necessary to understand your specific flash format. This is the definition of the dataclass:
 
-```python
-class FlashAttributes(ResourceAttributes):
-    # Block formats must be ORDERED iterables
-    data_block_format: Iterable[FlashField]
-    header_block_format: Optional[Iterable[FlashField]] = None
-    first_data_block_format: Optional[Iterable[FlashField]] = None
-    last_data_block_format: Optional[Iterable[FlashField]] = None
-    tail_block_format: Optional[Iterable[FlashField]] = None
-    ecc_attributes: Optional[FlashEccAttributes] = None
-    checksum_func: Optional[Callable[[Any], Any]] = None
-```
-The only required field is the `data_block_format`. These block formats are specified using an *ordered* `Iterable[FlashField]` to describe the block:
+The only required field is the `data_block_format`. These block formats are specified using an *ordered* `Iterable[FlashField]` to describe the block.
 
 ```python
 @dataclass
@@ -115,8 +107,8 @@ class FlashEccAttributes(ResourceAttributes):
 ```
 
 
-### Running the component
-It can be used like any other component after first tagging the resource as `FlashResource` and then adding the attributes:
+### Running the Flash components
+The Flash components can be used like any other OFRAK components. The first step is to tag a resource as a [FlashResource][ofrak_components.flash.FlashResource] and tag it with its flash resource attributes:
 
 ```python
 # Create root resource and tag

--- a/docs/user-guide/flash_component.md
+++ b/docs/user-guide/flash_component.md
@@ -1,0 +1,137 @@
+# Flash Component
+## Overview
+OFRAK includes a flash component that can unpack and pack a raw flash dump that includes out-of-band (OOB) data. A raw dump includes this extra data that make it hard to analyze without separating the "useful" data from the OOB data.
+
+In this page, we will cover why we have this component, what a typical dump may look like, and how to get started with the flash component.
+
+## A Typical Flash Dump
+|    DATA   |    OOB   |    DATA   |    OOB   |    ...   |
+| --------- | -------- | --------- | -------- | -------- |
+| 512 Bytes | 16 Bytes | 512 Bytes | 16 Bytes |    ...   |
+
+This pattern may continue for the entire flash chip or could have fields in the header or tail block that show the size of the region that includes OOB data.
+
+Other examples are more complex. Sometimes this is because not all of the dump is ECC protected or needs OOB data so delimiters or magic bytes are necessary to show the area. An example format:
+
+Header Block
+
+| MAGIC | DATA | DELIMITER | ECC |
+| ----- | ---- | --------- | --- |
+| 7 bytes | 215 bytes | 1 byte | 32 bytes |
+
+Data Block
+
+| DATA | DELIMITER | ECC |
+| ---- | --------- | --- |
+| 222 bytes | 1 byte | 32 bytes |
+
+Last Data Block
+
+| DATA | DELIMITER | ECC |
+| ---- | --------- | --- |
+| 222 bytes | 1 byte | 32 bytes |
+
+Tail Block
+
+| DELIMITER | DATA SIZE | CHECKSUM | ECC |
+| --------- | --------- | -------- | --- |
+| 1 byte | 4 bytes | 16 bytes | 32 bytes |
+
+This format is interesting because it has a different sized tail block as well as different delimiters to represent the type of block. The component is able to handle these different types of fields by providing attributes in `FlashAttributes` that also includes a `FlashEccAttributes`. We will describe the other parts of these attributes and how to use them later in this page.
+
+### Types of Fields
+In our experience, we have run into flash dumps that have included the following fields:
+```python
+class FlashFieldType(Enum):
+    DATA = 0
+    ECC = 1
+    ALIGNMENT = 2
+    MAGIC = 3
+    DATA_SIZE = 4
+    ECC_SIZE = 5
+    CHECKSUM = 6
+    DELIMITER = 7
+    TOTAL_SIZE = 8
+```
+
+- `DATA` is the "useful" information in the dump.
+- `ECC` are the most common OOB data with several common algorithms for verifying and correcting the data.
+- `ALIGNMENT` can be used for padding to fill an entire block or page.
+- `MAGIC` is in some dumps that are not entirely covered in OOB data. These bytes indicate the start of the OOB inclusive region.
+- `DATA_SIZE` indicates the expected size of the `DATA`
+- `ECC_SIZE` indicates the size of the `ECC` field.
+- `CHECKSUM` ensures that the data is read as expected.
+- `DELIMITER` may be placed between fields in a block or to indicate what type of block it is.
+- `TOTAL_SIZE` indicates the size of the entire region that includes OOB data.
+
+We recognize that some fields may be used differently than our implementation currently allows and we are likely missing some fields to be truly universal. In these cases, these classes can be overriden to be more flexible with your own use case.
+
+
+## Usage
+A `FlashAttributes` must be provided in order to use the flash component. As with other aspects of OFRAK, this can be modified and overriden if it does not work specifically for your use case.
+
+### `FlashAttributes`
+The `FlashAttributes` is necessary for communicating the information necessary to understand your specific flash format. This is the definition of the dataclass:
+
+```python
+class FlashAttributes(ResourceAttributes):
+    # Block formats must be ORDERED iterables
+    data_block_format: Iterable[FlashField]
+    header_block_format: Optional[Iterable[FlashField]] = None
+    first_data_block_format: Optional[Iterable[FlashField]] = None
+    last_data_block_format: Optional[Iterable[FlashField]] = None
+    tail_block_format: Optional[Iterable[FlashField]] = None
+    ecc_attributes: Optional[FlashEccAttributes] = None
+    checksum_func: Optional[Callable[[Any], Any]] = None
+```
+The only required field is the `data_block_format`. These block formats are specified using an *ordered* `Iterable[FlashField]` to describe the block:
+
+```python
+@dataclass
+class FlashField:
+    field_type: FlashFieldType
+    size: int
+```
+This dataclass uses the previously shown `Enum` with our various field types. We just need to specify the field type and the size for each `FlashField` and provide them in order. An example:
+```python
+FlashAttributes(
+    data_block_format=[
+        FlashField(FlashFieldType.DATA, 512),
+        FlashField(FlashFieldType.ECC, 16),
+    ],
+)
+```
+
+The `ecc_attributes` is also important for any dumps that include ECC. You have the option of providing the algorithms for encoding, decoding, and correcting the data. In addition, this is where the magic and any delimiter bytes are specified. The definition:
+```python
+class FlashEccAttributes(ResourceAttributes):
+    ecc_class: Optional[EccAlgorithm] = None
+    ecc_magic: Optional[bytes] = None
+    head_delimiter: Optional[bytes] = None
+    first_data_delimiter: Optional[bytes] = None
+    data_delimiter: Optional[bytes] = None
+    last_data_delimiter: Optional[bytes] = None
+    tail_delimiter: Optional[bytes] = None
+```
+
+
+### Running the component
+It can be used like any other component after first tagging the resource as `FlashResource` and then adding the attributes:
+
+```python
+# Create root resource and tag
+root_resource = await ofrak_context.create_root_resource_from_file(IN_FILE)
+root_resource.add_tag(FlashResource)
+await root_resource.save()
+
+# Add our attributes
+root_resource.add_attributes(CUSTOM_FLASH_ATTRIBUTES)
+await root_resource.save()
+```
+
+We have included an example that unpacks a provided flash dump, makes a modification, and repacks it into the same format in [`Example 9: Flash Modification`](`/examples/ex9_flash_modification.html`).
+
+
+<div align="right">
+<img src="../../assets/square_02.png" width="125" height="125">
+</div>

--- a/docs/user-guide/flash_component.md
+++ b/docs/user-guide/flash_component.md
@@ -40,10 +40,10 @@ Tail Block
 | --------- | --------- | -------- | --- |
 | 1 byte | 4 bytes | 16 bytes | 32 bytes |
 
-This format is interesting because it has a different sized tail block as well as different delimiters to represent the type of block. The component is able to handle these different types of fields by providing attributes in `FlashAttributes` that also includes a `FlashEccAttributes`. We will describe the other parts of these attributes and how to use them later in this page.
+This format is interesting because it has a different sized tail block as well as different delimiters to represent the type of block. The [FlashUnpacker][ofrak_component.flash.FlashResourceUnpacker] is able to handle these different types of fields by providing attributes in [FlashAttributes][ofrak_component.flash.FlashAttributes] that also includes a [FlashEccAttributes][ofrak_component.flash.FlashEccAttributes]. We will describe the other parts of these attributes and how to use them later in this page.
 
 ### Types of Fields
-In our experience, we have run into flash dumps that have included the following fields:
+The class [FlashFieldType][ofrak_components.flash.FlashFieldType] contains field types that are commonly encountered in flash dumps:
 ```python
 class FlashFieldType(Enum):
     DATA = 0
@@ -71,10 +71,10 @@ This class can be overridden or augmented if other field types are encountered.
 
 
 ## Usage
-A `FlashAttributes` must be provided in order to use the flash component. As with other aspects of OFRAK, this can be modified and overriden if it does not work specifically for your use case.
+A [FlashAttributes][ofrak_components.flash.FlashAttributes] must be provided in order to use the flash component. As with other aspects of OFRAK, this can be modified and overridden if it does not work specifically for your use case.
 
 ### `FlashAttributes`
-The `FlashAttributes` is necessary for communicating the information necessary to understand your specific flash format. This is the definition of the dataclass:
+The FlashAttributes][ofrak_components.flash.FlashAttributes] is necessary for communicating the information necessary to understand your specific flash format.
 
 The only required field is the `data_block_format`. These block formats are specified using an *ordered* `Iterable[FlashField]` to describe the block.
 
@@ -121,7 +121,7 @@ root_resource.add_attributes(CUSTOM_FLASH_ATTRIBUTES)
 await root_resource.save()
 ```
 
-We have included an example that unpacks a provided flash dump, makes a modification, and repacks it into the same format in [`Example 9: Flash Modification`](`https://ofrak.com/docs/examples/ex9_flash_modification.html`).
+See [Example 9: Flash Modification](https://ofrak.com/docs/examples/ex9_flash_modification.html) for example usage of these components.
 
 
 <div align="right">

--- a/docs/user-guide/flash_component.md
+++ b/docs/user-guide/flash_component.md
@@ -78,12 +78,6 @@ The FlashAttributes][ofrak_components.flash.FlashAttributes] is necessary for co
 
 The only required field is the `data_block_format`. These block formats are specified using an *ordered* `Iterable[FlashField]` to describe the block.
 
-```python
-@dataclass
-class FlashField:
-    field_type: FlashFieldType
-    size: int
-```
 This dataclass uses the previously shown `Enum` with our various field types. We just need to specify the field type and the size for each `FlashField` and provide them in order. An example:
 ```python
 FlashAttributes(
@@ -94,17 +88,7 @@ FlashAttributes(
 )
 ```
 
-The `ecc_attributes` is also important for any dumps that include ECC. You have the option of providing the algorithms for encoding, decoding, and correcting the data. In addition, this is where the magic and any delimiter bytes are specified. The definition:
-```python
-class FlashEccAttributes(ResourceAttributes):
-    ecc_class: Optional[EccAlgorithm] = None
-    ecc_magic: Optional[bytes] = None
-    head_delimiter: Optional[bytes] = None
-    first_data_delimiter: Optional[bytes] = None
-    data_delimiter: Optional[bytes] = None
-    last_data_delimiter: Optional[bytes] = None
-    tail_delimiter: Optional[bytes] = None
-```
+The `ecc_attributes` are also important for any dumps that include ECC. You have the option of providing the algorithms for encoding, decoding, and correcting the data. In addition, this is where the magic and any delimiter bytes are specified. See [FlashEccAttributes][ofrak_components.flash.FlashEccAttributes] for more information.
 
 
 ### Running the Flash components

--- a/examples/ex9_flash_modification.py
+++ b/examples/ex9_flash_modification.py
@@ -1,0 +1,72 @@
+"""
+This example demonstrates how to use the flash component to unpack, modify, and repack a raw flash dump.
+The included dump has ECC data mixed in with useful data.
+We want to strip out the ECC then modify the data before repacking.
+"""
+import argparse
+import os
+
+import test_ofrak.components
+from ofrak import OFRAK, OFRAKContext, ResourceFilter
+from ofrak.core.binary import BinaryPatchConfig, BinaryPatchModifier
+from ofrak_components.flash import (
+    FlashAttributes,
+    FlashEccAttributes,
+    FlashField,
+    FlashFieldType,
+    FlashResource,
+    FlashLogicalDataResource,
+)
+from ofrak_components.ecc.reedsolomon import ReedSolomon
+
+TEST_FILE = os.path.join(test_ofrak.components.ASSETS_DIR, "flash_test_plain.bin")
+
+FLASH_ATTRIBUTES = FlashAttributes(
+    data_block_format=[
+        FlashField(FlashFieldType.DATA, 223),
+        FlashField(FlashFieldType.ECC, 32),
+    ],
+    ecc_attributes=FlashEccAttributes(
+        ecc_class=ReedSolomon(nsym=32),
+    ),
+)
+
+
+async def main(ofrak_context: OFRAKContext, in_file: str, out_file: str):
+    # Create root resource and tag
+    root_resource = await ofrak_context.create_root_resource_from_file(in_file)
+    root_resource.add_tag(FlashResource)
+    await root_resource.save()
+
+    # Add our attributes
+    root_resource.add_attributes(FLASH_ATTRIBUTES)
+    await root_resource.save()
+
+    # Unpack
+    await root_resource.unpack_recursively()
+    print(f"Unpacked:\n{await root_resource.summarize_tree()}")
+
+    # Get the logical data
+    logical_data_resource = await root_resource.get_only_descendant(
+        r_filter=ResourceFilter.with_tags(FlashLogicalDataResource),
+    )
+
+    # Modify the logical data
+    new_data = b"INSERT ME!"
+    patch_config = BinaryPatchConfig(0x16, new_data)
+    await logical_data_resource.run(BinaryPatchModifier, patch_config)
+
+    # Repack and save to disk
+    await root_resource.flush_to_disk(out_file)
+    print(f"Saved repacked dump to {out_file}!")
+    print(await root_resource.summarize_tree())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-file", default=TEST_FILE)
+    parser.add_argument("--output-file", default="./repacked_flash_dump.bin")
+    args = parser.parse_args()
+
+    ofrak = OFRAK()
+    ofrak.run(main, args.input_file, args.output_file)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - PatchMaker:
         - User Guide: "user-guide/patch-maker/user-guide.md"
         - Troubleshooting: "user-guide/patch-maker/troubleshooting.md"
+      - NAND Flash Component: "user-guide/flash_component.md"
   - Contributor Guide:
       - Getting Started: "contributor-guide/getting-started.md"
       - Writing Components:


### PR DESCRIPTION
**Link to Related Issue(s)**

**Please describe the changes in your request.**
Adds a documentation page explaining why and how to use the NAND flash component. Includes the accompanying link in the navigation menu. An example is also included.

**Anyone you think should look at this, specifically?**
@whyitfor @andresito00 