### PR TITLE
Add a test for OFRAK.run.

### DIFF
--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest test_ofrak --cov=ofrak --cov-report=term-missing
-	fun-coverage --cov-fail-under=78
+	fun-coverage --cov-fail-under=79
 
 .PHONY: dependencies
 dependencies:

--- a/ofrak_core/test_ofrak/unit/test_ofrak_context.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_context.py
@@ -7,6 +7,7 @@ def test_ofrak_context():
     """
     Test that OFRAK.run successfully creates an event loop and runs the target async function.
     """
+    # Reset the event loop (this appears to be necessary when running in CI)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 

--- a/ofrak_core/test_ofrak/unit/test_ofrak_context.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_context.py
@@ -1,4 +1,15 @@
+import asyncio
+
+import pytest
+
 from ofrak import OFRAK, OFRAKContext
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()
 
 
 def test_ofrak_context():

--- a/ofrak_core/test_ofrak/unit/test_ofrak_context.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_context.py
@@ -1,0 +1,15 @@
+from ofrak import OFRAK, OFRAKContext
+
+
+def test_ofrak_context():
+    """
+    Test that OFRAK.run successfully creates an event loop and runs the target async function.
+    """
+
+    async def main(ofrak_context: OFRAKContext, binary: bytes):
+        resource = await ofrak_context.create_root_resource("test_binary", binary)
+        data = await resource.get_data()
+        assert data == binary
+
+    ofrak = OFRAK()
+    ofrak.run(main, b"Hello world\n")

--- a/ofrak_core/test_ofrak/unit/test_ofrak_context.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_context.py
@@ -1,21 +1,14 @@
 import asyncio
 
-import pytest
-
 from ofrak import OFRAK, OFRAKContext
-
-
-@pytest.fixture
-def event_loop():
-    loop = asyncio.get_event_loop()
-    yield loop
-    loop.close()
 
 
 def test_ofrak_context():
     """
     Test that OFRAK.run successfully creates an event loop and runs the target async function.
     """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     async def main(ofrak_context: OFRAKContext, binary: bytes):
         resource = await ofrak_context.create_root_resource("test_binary", binary)


### PR DESCRIPTION
**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Adds a unit test for `OFRAK.run` method. This raises `ofrak` function coverage to 79%.