### PR TITLE
FilesystemRoot.initialize_from_disk path validation

### DIFF
--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -276,6 +276,16 @@ class FilesystemRoot(ResourceView):
         path: str,
     ):
         root_path = os.path.normpath(path)
+
+        if not os.path.exists(root_path):
+            raise FileNotFoundError(
+                f"Could not initialize from disk. Root path does not exist: {root_path}"
+            )
+        if not os.path.isdir(root_path):
+            raise FileNotFoundError(
+                f"Could not initialize from disk. Found a file instead of a directory: {root_path}"
+            )
+
         for root, dirs, files in os.walk(root_path):
             for d in sorted(dirs):
                 absolute_path = os.path.join(root, d)


### PR DESCRIPTION
**Link to Related Issue(s)**
Closes #60 

**Please describe the changes in your request.**
Adds validation of the path parameter passed to `FilesystemRoot.initialize_from_disk`. Will raise a `FileNotFoundError` if the path is not found or is to a file instead of a directory.

**Anyone you think should look at this, specifically?**
@whyitfor since they opened the issue
