### PR TITLE
Add tests for Pe resource views

### DIFF
--- a/ofrak_core/test_ofrak/components/test_pe_component.py
+++ b/ofrak_core/test_ofrak/components/test_pe_component.py
@@ -1,26 +1,32 @@
 import os
+from typing import List
+
 import pytest
 
-from ofrak.core.pe.model import Pe
-
-PE_TESTFILE_PATHS = [
-    "./jumpnbump.exe",
-    "./kernel32.dll",
-]
+from ofrak import OFRAKContext, Resource
+from ofrak.core.pe.model import Pe, PeSection, PeSectionFlag, PeSectionHeader, PeOptionalHeader
 
 
-@pytest.mark.parametrize("test_case", PE_TESTFILE_PATHS)
-async def test_pe_unpacker(ofrak_context, test_case):
-    assets_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "./assets"))
-    pe_file_path = os.path.join(assets_dir, test_case)
-    root_resource = await ofrak_context.create_root_resource_from_file(pe_file_path)
-    await root_resource.unpack_recursively()
+@pytest.fixture(params=["jumpnbump.exe", "kernel32.dll"])
+async def pe_root_resource(ofrak_context: OFRAKContext, request):
+    return await _get_test_resource_from_file_name(ofrak_context, request.param)
 
-    pe_view = await root_resource.view_as(Pe)
 
-    # Get the sections
-    sections = list(await pe_view.get_sections())
+async def test_pe_unpacker(pe_root_resource: Resource):
+    await pe_root_resource.unpack_recursively()
+
+    pe_view = await pe_root_resource.view_as(Pe)
+    optional_header = await pe_view.get_optional_header()
+    assert isinstance(optional_header, PeOptionalHeader)
+
+    # Get the sections, tet get_header / get_flags()
+    sections: List[PeSection] = list(await pe_view.get_sections())
     assert len(sections) > 0
+    for section in sections:
+        section_header = await section.get_header()
+        assert isinstance(section_header, PeSectionHeader)
+        for section_flag in section_header.get_flags():
+            assert isinstance(section_flag, PeSectionFlag)
 
     # Get the code region; test get_header() / get_body()
     code_regions = list(await pe_view.get_sections())
@@ -29,3 +35,30 @@ async def test_pe_unpacker(ofrak_context, test_case):
     code_region_header = await code_region.get_header()
     assert code_region_header.name == ".text"
     assert await code_region_header.get_body() == code_region
+
+
+@pytest.fixture
+async def kernel32_dll(ofrak_context: OFRAKContext) -> Resource:
+    return await _get_test_resource_from_file_name(ofrak_context, "kernel32.dll")
+
+
+async def test_pe_get_memory_region_for_vaddr(kernel32_dll: Resource):
+    """
+    Test that Program.get_memory_region_for_vaddr works for Pe as intended.
+    """
+    await kernel32_dll.unpack()
+    pe_view = await kernel32_dll.view_as(Pe)
+    for section in await pe_view.get_sections():
+        section_header = await section.get_header()
+        virtual_address = section_header.m_virtual_address
+        memory_region = await pe_view.get_memory_region_for_vaddr(virtual_address + 4)
+        assert memory_region.virtual_address == virtual_address
+
+
+async def _get_test_resource_from_file_name(
+    ofrak_context: OFRAKContext, test_file_name: str
+) -> Resource:
+    assets_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "./assets"))
+    file_path = os.path.join(assets_dir, test_file_name)
+    root_resource = await ofrak_context.create_root_resource_from_file(file_path)
+    return root_resource


### PR DESCRIPTION
**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Increase function test coverage for Pe resource views to 100.

- test PeSectionHeader.get_flags
- test Program.get_memory_region_for_vaddr returns the correct MemoryRegion
- refactor test resource generation code

**Anyone you think should look at this, specifically?**
No.