### PR TITLE
Changed x86 specific binaries and options for M1 support

### DIFF
--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -1,12 +1,15 @@
+ARG TARGETARCH
+
 # - u-boot-tools: for mkimage, to test the UImage packer/unpacker
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
       build-essential
 
 # Install CMake
-ENV CMAKE_VERSION 3.19.2
-ENV CMAKE_SHA256 4d8a6d852c530f263b22479aad196416bb4406447e918bd9759c6593b7f5f3f9
-RUN cd /tmp && \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    export CMAKE_VERSION=3.19.2; \
+    export CMAKE_SHA256=4d8a6d852c530f263b22479aad196416bb4406447e918bd9759c6593b7f5f3f9; \
+    cd /tmp && \
     curl -sSL -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
     echo "${CMAKE_SHA256}\tcmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum -c && \
     tar -zxvf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
@@ -14,7 +17,22 @@ RUN cd /tmp && \
     cp -r bin/ share/ /usr/local/ && \
     cp -r doc/ man/ /usr/local/share/ && \
 	cd /tmp && \
-    rm -rf cmake-${CMAKE_VERSION}-Linux-x86_64*
+    rm -rf cmake-${CMAKE_VERSION}-Linux-x86_64*; \
+fi;
+
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+    export CMAKE_VERSION=3.24.1; \
+    export CMAKE_SHA256=d50c40135df667ed659f8e4eb7cf7d53421250304f7b3e1a70af9cf3d0f2ab18; \
+    cd /tmp && \
+    curl -sSL -O https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-aarch64.tar.gz && \
+    echo "$CMAKE_SHA256\tcmake-$CMAKE_VERSION-linux-aarch64.tar.gz" | sha256sum -c && \
+    tar -zxvf cmake-$CMAKE_VERSION-linux-aarch64.tar.gz && \
+    cd cmake-$CMAKE_VERSION-linux-aarch64 && \
+    cp -r bin/ share/ /usr/local/ && \
+    cp -r doc/ man/ /usr/local/share/ && \
+	cd /tmp && \
+    rm -rf cmake-$CMAKE_VERSION-linux-aarch64*; \
+fi;
 
 # Install Keystone
 RUN cd /tmp && \

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -18,7 +18,7 @@ RUN cd /tmp && \
 RUN cd /tmp && \
     apt-get -y update  && apt-get -y install software-properties-common gcc-10
 
-RUN if ["$TARGETARCH" = "amd64"]; then \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
     cd /tmp && \
     apt-get update && apt-get install -y texinfo && \
     wget http://archive.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.34.orig.tar.xz --show-progress --progress=bar:force:noscroll && \
@@ -29,19 +29,20 @@ RUN if ["$TARGETARCH" = "amd64"]; then \
     make -j32; \
 fi;
 
-RUN if ["$TARGETARCH" = "arm64"]; then \
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
     cd /tmp && \
     apt-get update && apt-get install -y texinfo && \
     wget http://archive.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.34.orig.tar.xz --show-progress --progress=bar:force:noscroll && \
     tar xvf binutils_2.34.orig.tar.xz -C /opt/rbs/toolchain && \
     rm -rf binutils_2.34.orig.tar.xz && \
     cd /opt/rbs/toolchain/binutils-2.34 && \
-    ./configure CC=/usr/bin/x86_64-linux-gnu-gcc-10 && \
+    ./configure CC=/usr/bin/aarch64-linux-gnu-gcc-10 && \
     make -j32; \
 fi;
 
 #M68k GNU 10 Linux
-RUN if ["$TARGETARCH" = "amd64"]; then \
+#Only exists for x86
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
     apt-get update && apt-get install -y gcc-10-m68k-linux-gnu; \
 fi;
 
@@ -64,14 +65,12 @@ RUN cd /tmp/vbcc && cp ./bin/* /opt/rbs/toolchain/vbcc_0_9/bin/ && \
     cp ./vobjdump /opt/rbs/toolchain/vbcc_0_9/bin/
 
 #AARCH64 GNU 10 Linux
-RUN if ["$TARGETARCH" = "amd64"]; then \
+RUN if ![ "$TARGETARCH" = "arm64" ]; then \
     apt-get update && apt-get install -y gcc-10-aarch64-linux-gnu; \
 fi;
 
-RUN if ["$TARGETARCH" = "arm64"]; then \
-    ln -s gcc-10 /usr/bin/aarch64-linux-gnu-gcc-10 \
-    ln -s ld /usr/bin/aarch64-linux-gnu-ld \
-    ln -s objdump /usr/bin/aarch64-linux-gnu-objdump; \
+RUN if ![ "$TARGETARCH" = "amd64" ]; then \
+    apt-get update && install -y gcc-10-x86-64-linux-gnu; \
 fi;
 
 #AVR GCC

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -65,12 +65,8 @@ RUN cd /tmp/vbcc && cp ./bin/* /opt/rbs/toolchain/vbcc_0_9/bin/ && \
     cp ./vobjdump /opt/rbs/toolchain/vbcc_0_9/bin/
 
 #AARCH64 GNU 10 Linux
-RUN if ![ "$TARGETARCH" = "arm64" ]; then \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
     apt-get update && apt-get install -y gcc-10-aarch64-linux-gnu; \
-fi;
-
-RUN if ![ "$TARGETARCH" = "amd64" ]; then \
-    apt-get update && install -y gcc-10-x86-64-linux-gnu; \
 fi;
 
 #AVR GCC

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -1,3 +1,5 @@
+ARG TARGETARCH
+
 # LLVM
 RUN mkdir -p /opt/rbs/toolchain && \
     cd /tmp && \
@@ -16,17 +18,32 @@ RUN cd /tmp && \
 RUN cd /tmp && \
     apt-get -y update  && apt-get -y install software-properties-common gcc-10
 
-RUN cd /tmp && \
+RUN if ["$TARGETARCH" = "amd64"]; then \
+    cd /tmp && \
     apt-get update && apt-get install -y texinfo && \
     wget http://archive.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.34.orig.tar.xz --show-progress --progress=bar:force:noscroll && \
     tar xvf binutils_2.34.orig.tar.xz -C /opt/rbs/toolchain && \
     rm -rf binutils_2.34.orig.tar.xz && \
     cd /opt/rbs/toolchain/binutils-2.34 && \
     ./configure CC=/usr/bin/x86_64-linux-gnu-gcc-10 && \
-    make -j32
+    make -j32; \
+fi;
+
+RUN if ["$TARGETARCH" = "arm64"]; then \
+    cd /tmp && \
+    apt-get update && apt-get install -y texinfo && \
+    wget http://archive.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.34.orig.tar.xz --show-progress --progress=bar:force:noscroll && \
+    tar xvf binutils_2.34.orig.tar.xz -C /opt/rbs/toolchain && \
+    rm -rf binutils_2.34.orig.tar.xz && \
+    cd /opt/rbs/toolchain/binutils-2.34 && \
+    ./configure CC=/usr/bin/x86_64-linux-gnu-gcc-10 && \
+    make -j32; \
+fi;
 
 #M68k GNU 10 Linux
-RUN apt-get update && apt-get install -y gcc-10-m68k-linux-gnu
+RUN if ["$TARGETARCH" = "amd64"]; then \
+    apt-get update && apt-get install -y gcc-10-m68k-linux-gnu; \
+fi;
 
 #M68k VBCC
 RUN cd /tmp && \
@@ -47,7 +64,15 @@ RUN cd /tmp/vbcc && cp ./bin/* /opt/rbs/toolchain/vbcc_0_9/bin/ && \
     cp ./vobjdump /opt/rbs/toolchain/vbcc_0_9/bin/
 
 #AARCH64 GNU 10 Linux
-RUN apt-get update && apt-get install -y gcc-10-aarch64-linux-gnu
+RUN if ["$TARGETARCH" = "amd64"]; then \
+    apt-get update && apt-get install -y gcc-10-aarch64-linux-gnu; \
+fi;
+
+RUN if ["$TARGETARCH" = "arm64"]; then \
+    ln -s gcc-10 /usr/bin/aarch64-linux-gnu-gcc-10 \
+    ln -s ld /usr/bin/aarch64-linux-gnu-ld \
+    ln -s objdump /usr/bin/aarch64-linux-gnu-objdump; \
+fi;
 
 #AVR GCC
 RUN apt-get update && apt-get install -y gcc-avr binutils-avr avr-libc


### PR DESCRIPTION
These changes support M1 for only core functionality and does not include backend support from Ghidra/Binja. 