### PR TITLE
Angr in GUI

### DIFF
--- a/disassemblers/ofrak_angr/ofrak_angr/serializer.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/serializer.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from angr import Project
+
+from ofrak.service.serialization.pjson_types import PJSONType
+from ofrak.service.serialization.serializers.serializer_i import SerializerInterface
+
+
+class AngrAnalysisSerializer(SerializerInterface):
+    """
+    Dummy serializer to silently pass serialization attempts, and hard fail on attempting to
+    deserialize.
+    """
+
+    targets = (Project,)
+
+    def obj_to_pjson(self, obj: Project, type_hint: Any) -> PJSONType:
+        return None
+
+    def pjson_to_obj(self, pjson_obj: Any, type_hint: Any) -> Project:
+        raise NotImplementedError("Deserialization for Angr projects is not yet supported!")

--- a/disassemblers/ofrak_angr/ofrak_angr_test/test_serializer.py
+++ b/disassemblers/ofrak_angr/ofrak_angr_test/test_serializer.py
@@ -1,0 +1,27 @@
+import pytest
+from angr import Project
+
+from ofrak import OFRAKContext
+from ofrak.core import File
+from ofrak.service.serialization.serializers.serializer_i import SerializerInterface
+from ofrak_angr.model import AngrAnalysis
+from ofrak_angr.serializer import AngrAnalysisSerializer
+
+
+@pytest.fixture
+def serializer():
+    return AngrAnalysisSerializer()
+
+
+async def test_angr_project_serializer(
+    ofrak_context: OFRAKContext, hello_world_elf: bytes, serializer: SerializerInterface
+):
+    root = await ofrak_context.create_root_resource("hello_world", hello_world_elf, (File,))
+    await root.identify()
+    angr_analysis = await root.analyze(AngrAnalysis)
+
+    serialized_project = serializer.obj_to_pjson(angr_analysis.project, Project)
+    assert serialized_project is None
+
+    with pytest.raises(NotImplementedError):
+        _ = serializer.pjson_to_obj(serialized_project, Project)

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -3,7 +3,7 @@
 ################################################################################
 
 PORT ?= 8888
-OFRAK_SOURCE_DIR ?= ~/ofrak
+OFRAK_SOURCE_DIR ?= $(CURDIR)/..
 
 
 ################################################################################
@@ -56,7 +56,7 @@ images: app-image ofrak-server-image proxy-image
 
 .PHONY: ofrak-server-image
 ofrak-server-image:
-	cp --recursive $(OFRAK_SOURCE_DIR)/docs/ backend/
+	cp -r $(OFRAK_SOURCE_DIR)/docs/ backend/
 	cp $(OFRAK_SOURCE_DIR)/mkdocs.yml backend/mkdocs.yml
 	docker build -t rbs/ofrak-server:latest -f backend/ofrak_server.Dockerfile backend
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -56,8 +56,6 @@ images: app-image ofrak-server-image proxy-image
 
 .PHONY: ofrak-server-image
 ofrak-server-image:
-	cp -r $(OFRAK_SOURCE_DIR)/docs/ backend/
-	cp $(OFRAK_SOURCE_DIR)/mkdocs.yml backend/mkdocs.yml
 	docker build -t rbs/ofrak-server:latest -f backend/ofrak_server.Dockerfile backend
 
 .PHONY: proxy-image

--- a/frontend/backend/ofrak_server.Dockerfile
+++ b/frontend/backend/ofrak_server.Dockerfile
@@ -6,6 +6,5 @@ COPY $BACKEND_DIR/ofrak_server.py /ofrak_server.py
 RUN python3 -m pip install aiohttp~=3.8.1
 
 ENTRYPOINT python3 -m ofrak_ghidra.server start \
-  & mkdocs serve --dev-addr 0.0.0.0:8000 \
   & python3 /ofrak_server.py 0.0.0.0 8877 \
   & sleep infinity

--- a/frontend/backend/ofrak_server.Dockerfile
+++ b/frontend/backend/ofrak_server.Dockerfile
@@ -1,12 +1,11 @@
 FROM redballoonsecurity/ofrak/dev:latest
 
-COPY ofrak_server.py /ofrak_server.py
-COPY docs /docs
-COPY mkdocs.yml /mkdocs.yml
+ARG BACKEND_DIR=.
+COPY $BACKEND_DIR/ofrak_server.py /ofrak_server.py
 
 RUN python3 -m pip install aiohttp~=3.8.1
 
 ENTRYPOINT python3 -m ofrak_ghidra.server start \
   & mkdocs serve --dev-addr 0.0.0.0:8000 \
-  & python3 /ofrak_server.py 0.0.0.0 8877 ghidra \
+  & python3 /ofrak_server.py 0.0.0.0 8877 \
   & sleep infinity

--- a/frontend/backend/ofrak_server.py
+++ b/frontend/backend/ofrak_server.py
@@ -476,7 +476,7 @@ if __name__ == "__main__":
     if len(sys.argv) == 4:
         backend = sys.argv[3]
     else:
-        backend = "ghidra"
+        backend = None
 
     ofrak = OFRAK(logging.INFO)
 
@@ -486,9 +486,18 @@ if __name__ == "__main__":
 
         ofrak.injector.discover(ofrak_capstone)
         ofrak.injector.discover(ofrak_binary_ninja)
-    else:
+
+    elif backend == "ghidra":
         import ofrak_ghidra  # type: ignore
 
         ofrak.injector.discover(ofrak_ghidra)
+
+    elif backend == "angr":
+        import ofrak_angr  # type: ignore
+
+        ofrak.injector.discover(ofrak_angr)
+
+    else:
+        LOGGER.warning("No disassembler backend specified, so no disassembly will be possible")
 
     ofrak.run(main, _host, _port)  # type: ignore


### PR DESCRIPTION
**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
* Add an option to set Angr as the disassembler backend when starting the GUI
* Instead of Ghidra being the default backend if none is provided, no backend is used (no disassembly is possible, but this allows the GUI server to be run in an image/install that only has core OFRAK + frontend with no extra dependencies).
* Add a serializer class to "catch" the Angr analysis object so that it is not erroneously serialized when communicating with the frontend. This serializer doesn't actually correctly serialize the object, but instead always serializes it to `None` and raises a hard error on deserializing, as saving disassembler backend metadata is not currently supported.
* A few updates/improvements for the GUI development rules

**Anyone you think should look at this, specifically?**
@rbs-jacob 