### PR TITLE
Update paths for CommentsAttributes and Magic to match their new location

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
+    "prettier": "^2.7.1",
     "prettier-plugin-svelte": "^2.6.0",
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.1.0",

--- a/frontend/src/AttributesView.svelte
+++ b/frontend/src/AttributesView.svelte
@@ -21,7 +21,7 @@
     for (const [attrType, attrs] of Object.entries(resource.get_attributes())) {
       const skipped_attributes = [
         // already shown in the resource tree
-        "ofrak_components.comments.CommentsAttributes",
+        "ofrak.core.comments.CommentsAttributes",
         // verbose and unhelpful
         "ofrak_components.entropy.entropy.DataSummary",
       ];

--- a/frontend/src/ResourceTreeToolbar.svelte
+++ b/frontend/src/ResourceTreeToolbar.svelte
@@ -99,8 +99,8 @@
             }
             const blob = new Blob([data], {
               type:
-                rootResource.get_attributes()["ofrak_components.magic.Magic"]
-                  ?.mime || "",
+                rootResource.get_attributes()["ofrak.core.magic.Magic"]?.mime ||
+                "",
             });
             const blobUrl = URL.createObjectURL(blob);
 

--- a/frontend/src/ofrak/resource.js
+++ b/frontend/src/ofrak/resource.js
@@ -377,10 +377,8 @@ export class Resource {
 
   async get_comments() {
     let attributes = this.get_attributes();
-    if ("ofrak_components.comments.CommentsAttributes" in attributes) {
-      return attributes["ofrak_components.comments.CommentsAttributes"][
-        "comments"
-      ];
+    if ("ofrak.core.comments.CommentsAttributes" in attributes) {
+      return attributes["ofrak.core.comments.CommentsAttributes"]["comments"];
     } else {
       return [];
     }


### PR DESCRIPTION
**Please describe the changes in your request.**
This updates paths for CommentsAttributes and Magic in frontend to reflect the fact that they are in `ofrak.core`.

The incorrect path was causing the `CommentsAttributes` to not appear in the frontend tree view as intended.

I tested these changes by building the tutorial image and validating that the comments were appearing in the resource tree view.

**Anyone you think should look at this, specifically?**
@rbs-jacob 