### PR TITLE
move ENTRYPOINT definition out of Dockerstubs and into build YAML

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -33,6 +33,7 @@ class OfrakImageConfig:
     extra_build_args: Optional[List[str]]
     install_target: InstallTarget
     cache_from: List[str]
+    entrypoint: Optional[str]
 
     def validate_serial_txt_existence(self):
         """
@@ -158,6 +159,7 @@ def parse_args() -> OfrakImageConfig:
         config_dict.get("extra_build_args"),
         InstallTarget(args.target),
         args.cache_from,
+        config_dict.get("entrypoint"),
     )
     image_config.validate_serial_txt_existence()
     return image_config
@@ -232,6 +234,8 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
         ]
     )
     dockerfile_finish_parts.append(f'RUN printf "{finish_makefile}" >> Makefile\n')
+    if config.entrypoint is not None:
+        dockerfile_finish_parts.append(f"ENTRYPOINT {config.entrypoint}")
     return "".join(dockerfile_finish_parts)
 
 

--- a/frontend/Dockerstub
+++ b/frontend/Dockerstub
@@ -10,7 +10,3 @@ COPY $OFRAK_DIR/examples /examples
 
 RUN apt-get update && apt-get install --yes nginx
 RUN python3 -m pip install --upgrade aiohttp
-
-ENTRYPOINT nginx \
-  & python3 -m ofrak_ghidra.server start \
-  & python3 /ofrak_server.py 0.0.0.0 8877

--- a/ofrak-dev.yml
+++ b/ofrak-dev.yml
@@ -18,3 +18,7 @@ extra_build_args:
   ["--secret",
    "id=serial,src=serial.txt"
   ]
+entrypoint: |
+    nginx \
+      & python3 -m ofrak_ghidra.server start \
+      & python3 /ofrak_server.py 0.0.0.0 8877

--- a/ofrak-ghidra.yml
+++ b/ofrak-ghidra.yml
@@ -11,3 +11,7 @@ packages_paths:
     "disassemblers/ofrak_ghidra",
     "frontend",
   ]
+entrypoint: |
+    nginx \
+      & python3 -m ofrak_ghidra.server start \
+      & python3 /ofrak_server.py 0.0.0.0 8877

--- a/ofrak-tutorial.yml
+++ b/ofrak-tutorial.yml
@@ -12,3 +12,10 @@ packages_paths:
     "frontend",
     "ofrak_tutorial",
   ]
+entrypoint: |
+    python -m ofrak_ghidra.server start \
+        && jupyter notebook \
+            --no-browser \
+            --allow-root \
+            --ip 0.0.0.0 \
+            --notebook-dir "/ofrak_tutorial/notebooks"

--- a/ofrak_tutorial/Dockerstub
+++ b/ofrak_tutorial/Dockerstub
@@ -2,10 +2,3 @@ ARG OFRAK_DIR=.
 COPY $OFRAK_DIR/mkdocs.yml /mkdocs.yml
 COPY $OFRAK_DIR/docs /docs
 COPY $OFRAK_DIR/examples /examples
-
-ENTRYPOINT python -m ofrak_ghidra.server start \
-    && jupyter notebook \
-        --no-browser \
-        --allow-root \
-        --ip 0.0.0.0 \
-        --notebook-dir "/ofrak_tutorial/notebooks"


### PR DESCRIPTION
**Link to Related Issue(s)**
Some Dockerstubs defined ENTRYPOINTs which were confusing to track down and could overwrite each other.

**Please describe the changes in your request.**
This adds an optional field to our OFRAK Docker build config for the entrypoint of the finished image. This way, when you build an image it is very clear what the entrypoint will be.

**Anyone you think should look at this, specifically?**
@rbs-jacob 