### PR TITLE
Add GUI minimap explanation to the OFRAK docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@ ofrak_patch_maker/technical_docs/vbcc.pdf filter=lfs diff=lfs merge=lfs -text
 ofrak_core/test_ofrak/components/assets/* filter=lfs diff=lfs merge=lfs -text
 ofrak_core/test_ofrak/components/assets/README.md !filter !diff !merge text
 ofrak_tutorial/assets/* filter=lfs diff=lfs merge=lfs -text
+docs/user-guide/gui/assets/* filter=lfs diff=lfs merge=lfs -text

--- a/docs/user-guide/gui/assets/image1.png
+++ b/docs/user-guide/gui/assets/image1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14f935e55439580e5b62e594355752f4757478c618a2eb0c72b3c36877344740
+size 66133

--- a/docs/user-guide/gui/assets/image2.png
+++ b/docs/user-guide/gui/assets/image2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26ee0302cc6633c60f477f666b8157a73e922c12f0a82beb998c54e55fa2167c
+size 66271

--- a/docs/user-guide/gui/assets/image25.png
+++ b/docs/user-guide/gui/assets/image25.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25010990db9de2caceeb84416e9c0b7b7b3610ea561cef393aaa0b853d1ba717
+size 472461

--- a/docs/user-guide/gui/assets/image3.png
+++ b/docs/user-guide/gui/assets/image3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb50a1fc8b8f7035a4f383ddd86cb71db1431ec06d7831ecdaee09ff778357f7
+size 56734

--- a/docs/user-guide/gui/assets/image4.png
+++ b/docs/user-guide/gui/assets/image4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6240f68e7d5acd4a81c90b50c7f7c4c8fcad7f5521cf57167053aa6d6137717
+size 478357

--- a/docs/user-guide/gui/assets/image5.png
+++ b/docs/user-guide/gui/assets/image5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dbc56271487b44f25ce6bc5441f0c70cf639cf4fe7588c14a8c7e96536be902
+size 544730

--- a/docs/user-guide/gui/assets/image6.png
+++ b/docs/user-guide/gui/assets/image6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096ac1bdd338309c3614207bb50bae6d693027f6327435432dcfb001734b4f30
+size 527046

--- a/docs/user-guide/gui/assets/image7.png
+++ b/docs/user-guide/gui/assets/image7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6df01c6b2dadfc9b6e13932ba33c4829484cdd040478d86c055e3d708be230b2
+size 16013

--- a/docs/user-guide/gui/assets/image7.png
+++ b/docs/user-guide/gui/assets/image7.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6df01c6b2dadfc9b6e13932ba33c4829484cdd040478d86c055e3d708be230b2
-size 16013
+oid sha256:3e1f68fcf9475f9bc4fc73165fdd946dcbe27bd64832d8c25df836efc6943709
+size 461974

--- a/docs/user-guide/gui/minimap.md
+++ b/docs/user-guide/gui/minimap.md
@@ -21,9 +21,9 @@ view is currently displaying.
 
 The default mode of the minimap is "magnitude view" mode. In this simple mode,
 each byte of the data is mapped to a grayscale color. Lower byte values create
-darker pixels. For example the minimum byte value of 0x00 (0) maps to pure
-black, and the maximum byte value of 0xFF (255) maps to pure white. The values
-in between map to corresponding shades of gray.
+darker pixels. For example the minimum byte value of `0x00` (0) maps to pure
+black, and the maximum byte value of `0xFF` (255) maps to pure white. The
+values in between map to corresponding shades of gray.
 
 ![](assets/image6.png)
 
@@ -57,11 +57,13 @@ distribution quantifies how close that distribution is to uniformly random. In
 concrete terms, if you make a histogram of the byte occurrences in a range of
 data, the entropy of that histogram is a measure of how flat the bars are. For
 example:
+
 - The bars in this histogram are very flat since each byte is approximately
   equally likely to occur. Thus, this data has high entropy -- the bytes are
   very random.
 
   ![Chart](assets/image2.png)
+
 - The bars in this histogram show that some bytes are much more likely to occur
   than others. Even though every byte value has some chance of occurring, the
   values at the middle of the range are more likely, and more predictable.
@@ -69,6 +71,7 @@ example:
   first.
 
   ![Chart](assets/image1.png)
+
 - There is only one bar in this histogram -- this range of data consists
   entirely of one repeating byte value. Thus, this data is entirely
   predictable, and has the lowest possible entropy value: 0.
@@ -84,7 +87,7 @@ this.
 
 Specifically, in OFRAK, entropy is calculated over a 256-byte sliding window
 that moves forward by one byte for each pixel in the minimap. The calculated
-entropies are mapped to values between 0x00 and 0xFF with higher entropy
+entropies are mapped to values between `0x00` and `0xFF` with higher entropy
 corresponding to lighter gray pixels and lower entropy corresponding to darker
 gray pixels, as in the magnitude mode.
 

--- a/docs/user-guide/gui/minimap.md
+++ b/docs/user-guide/gui/minimap.md
@@ -1,0 +1,81 @@
+# Minimap View
+
+Clicking the minimap scrolls the hex view to the corresponding part of the
+data. A red box overlaid on the minimap shows what part of the data the hex
+view is currently displaying.
+
+## Magnitude View
+
+The default mode of the minimap is "magnitude view" mode. In this simple mode,
+each byte of the data is mapped to a grayscale color. Lower byte values create
+darker pixels. For example the minimum byte value of 0x00 (0) maps to pure
+black, and the maximum byte value of 0xFF (255) maps to pure white. The values
+in between map to corresponding shades of gray.
+
+![](assets/image6.png)
+
+## Byteclass View
+
+The minimap's "byteclass view" mode is very similar to the magnitude view. Like
+the magnitude view, the color of each pixel is based on the value of its
+corresponding byte. Unlike the magnitude view, byte values are grouped into
+discrete buckets called "byteclasses."
+
+![](assets/image7.png)
+
+Byteclass mode is most useful for quickly finding strings by looking for yellow
+regions of the data with values in the ASCII range. Both magnitude mode and
+byteclass mode are also handy for identifying padding regions, headers, and
+data (such as symbols) that are aligned at regular intervals.
+
+![](assets/image5.png)
+
+## Entropy View 
+
+The minimap's "entropy view" mode displays regions with highly random data
+across the binary. This is particularly useful for finding compressed and
+encrypted data ranges.
+
+[Shannon entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)),
+named for Claude Shannon, is a fundamental concept from information theory that
+is used to characterize how random and unpredictable the information in a
+sample of bytes is. Intuitively, the Shannon entropy of a probability
+distribution quantifies how close that distribution is to uniformly random. In
+concrete terms, if you make a histogram of the byte occurrences in a range of
+data, the entropy of that histogram is a measure of how flat the bars are. For
+example:
+- The bars in this histogram are very flat since each byte is approximately
+  equally likely to occur. Thus, this data has high entropy -- the bytes are
+  very random.
+
+  ![Chart](assets/image2.png)
+- The bars in this histogram show that some bytes are much more likely to occur
+  than others. Even though every byte value has some chance of occurring, the
+  values at the middle of the range are more likely, and more predictable.
+  Thus, this data range is less random, and therefore lower entropy, than the
+  first.
+
+  ![Chart](assets/image1.png)
+- There is only one bar in this histogram -- this range of data consists
+  entirely of one repeating byte value. Thus, this data is entirely
+  predictable, and has the lowest possible entropy value: 0.
+
+  ![Chart](assets/image3.png)
+
+Since Shannon entropy gives concrete, numerical bounds on how random or
+predictable a sample of data can be, it becomes possible to calculate and
+visualize the relative levels of randomness between regions of data. Simply
+compute a byte occurrence histogram across a region, then calculate the entropy
+of the distribution and compare. The entropy view in the OFRAK GUI does exactly
+this.
+
+Specifically, in OFRAK, entropy is calculated over a 256-byte sliding window
+that moves forward by one byte for each pixel in the minimap. The calculated
+entropies are mapped to values between 0x00 and 0xFF with higher entropy
+corresponding to lighter gray pixels and lower entropy corresponding to darker
+gray pixels, as in the magnitude mode.
+
+Since compressed and encrypted data generally have high entropy, this minimap
+view makes it easy to find and navigate to such data.
+
+![](assets/image25.png)

--- a/docs/user-guide/gui/minimap.md
+++ b/docs/user-guide/gui/minimap.md
@@ -1,5 +1,18 @@
 # Minimap View
 
+The “minimap view” (“minimap” for short) on the far right of the GUI (see
+figure below) is one way OFRAK helps users. The minimap visually represents all
+the data of a selected binary. Each pixel in the minimap corresponds to one
+byte of the resource's binary data, with the color of each pixel determined by
+the corresponding byte.
+
+![](assets/image4.png)
+
+The minimap accelerates exploring and navigating to the most important parts of
+the binary. Unlike the hex view (directly to the left of the minimap), which
+only shows a portion of a resource's binary data at a time, the minimap
+provides a bird's eye view of the entire resource. 
+
 Clicking the minimap scrolls the hex view to the corresponding part of the
 data. A red box overlaid on the minimap shows what part of the data the hex
 view is currently displaying.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,10 +51,10 @@ nav:
   - Home: "index.md"
   - Environment Setup: "environment-setup.md"
   - Getting Started: "getting-started.md"
+  - GUI: 
+    - Minimap View: "user-guide/gui/minimap.md"
   - Examples: examples/
   - User Guide:
-      - GUI: 
-        - Minimap View: "user-guide/gui/minimap.md"
       - Resource: "user-guide/resource.md"
       - ResourceView: "user-guide/resource_view.md"
       - Components:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,8 @@ nav:
   - Getting Started: "getting-started.md"
   - Examples: examples/
   - User Guide:
+      - GUI: 
+        - Minimap View: "user-guide/gui/minimap.md"
       - Resource: "user-guide/resource.md"
       - ResourceView: "user-guide/resource_view.md"
       - Components:


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

This pull request adds documentation for the minimap portion of the GUI frontend, and sets up a folder in the docs directory for future documenting of the GUI.

**Anyone you think should look at this, specifically?**

@whyitfor 