### PR TITLE
Bump mkdocs to 1.2.3, address misc. errors in OFRAK Docs

### DIFF
--- a/docs/user-guide/flash_component.md
+++ b/docs/user-guide/flash_component.md
@@ -40,7 +40,7 @@ Tail Block
 | --------- | --------- | -------- | --- |
 | 1 byte | 4 bytes | 16 bytes | 32 bytes |
 
-This format is interesting because it has a different sized tail block as well as different delimiters to represent the type of block. The [FlashUnpacker][ofrak_component.flash.FlashResourceUnpacker] is able to handle these different types of fields by providing attributes in [FlashAttributes][ofrak_component.flash.FlashAttributes] that also includes a [FlashEccAttributes][ofrak_component.flash.FlashEccAttributes]. We will describe the other parts of these attributes and how to use them later in this page.
+This format is interesting because it has a different sized tail block as well as different delimiters to represent the type of block. The [FlashUnpacker][ofrak_components.flash.FlashResourceUnpacker] is able to handle these different types of fields by providing attributes in [FlashAttributes][ofrak_components.flash.FlashAttributes] that also includes a [FlashEccAttributes][ofrak_components.flash.FlashEccAttributes]. We will describe the other parts of these attributes and how to use them later in this page.
 
 ### Types of Fields
 The class [FlashFieldType][ofrak_components.flash.FlashFieldType] contains field types that are commonly encountered in flash dumps:

--- a/ofrak_components/setup.py
+++ b/ofrak_components/setup.py
@@ -36,15 +36,6 @@ setuptools.setup(
         "reedsolo==1.5.4",
     ],
     extras_require={
-        "docs": [
-            "mkdocs==1.2.2",
-            "mkdocs-autorefs==0.3.0",
-            "mkdocstrings==0.16.2",
-            "mkdocs-literate-nav==0.4.0",
-            "mkdocs-material==7.3.3",
-            "mkdocs_gen_files==0.3.3",
-            "jinja2==3.0.0",
-        ],
         "test": [
             "ofrak[test]",
             "autoflake==1.4",

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -581,19 +581,6 @@ class Resource:
         | ``data`` param not `None` | Child mapped, ``data`` patched into child (and parent) | Child unmapped, child's data set to ``data`` |
         | ``data`` param   `None`   | Child mapped, parent's data untouched                  | Child is dataless                            |
 
-        There are two additional data-centric parameters: ``data_after`` and ``data_before``.
-        These can only be used in combination with ``data_range``; zero, one, or both of them may
-        be used. These are useful in special cases when 1) the parent resource allows data
-        overlaps and 2) the new child already has some sibling resources who also map the parent's
-        data and overlap with the new child's data. These parameters hint to the data service what
-        order the children's data is
-        arranged, which may be useful in the future when patching the resource. For example,
-        if 3 resources A, B, and C are all created with `data_range=Range(2,2)`, and later each of
-        them are individually patched, the data service needs these hints to know whether the
-        children's data should be mapped into the parent's data as `aaabbbccc`, `aaacccbbb`,
-        `bbbaaaccc`, etc.
-        This should not happen often.
-
         :param tags: [tags][ofrak.model.tag_model.ResourceTag] to add to the new child
         :param attributes: [attributes][ofrak.model.resource_model.ResourceAttributes] to add to
         the new child
@@ -601,8 +588,6 @@ class Resource:
         the resource has no data. Defaults to `None`.
         :param data_range: The range of the parent's data which the new child maps. If `None` (
         default), the child will not map the parent's data.
-        :param data_after: The sibling resource whose data is sequentially after the new resource
-        :param data_before: The sibling resource whose data is sequentially before the new resource
         :return:
         """
         if data_range is not None:
@@ -949,10 +934,6 @@ class Resource:
 
         :param patch_range: The range of binary data in this resource to replace
         :param data: The bytes to replace part of this resource's data with
-        :param after: If the patched resource's data overlaps another resources, this hints to the
-        data service that the data added by patch should be after the data of resource ``after``
-        :param before: If the patched resource's data overlaps another resources, this hints to the
-        data service that the data added by patch should be before the data of resource ``before``
         :return:
         """
         if not self._component_context:

--- a/ofrak_core/ofrak/service/resource_service_i.py
+++ b/ofrak_core/ofrak/service/resource_service_i.py
@@ -307,6 +307,6 @@ class ResourceServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
 
         :param resource_id: The ID of the resource to delete
 
-        :return all of the models that were deleted
+        :return: all of the models that were deleted
         """
         raise NotImplementedError()

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     ],
     extras_require={
         "docs": [
-            "mkdocs==1.2.2",
+            "mkdocs==1.2.3",
             "mkdocs-autorefs==0.3.0",
             "mkdocstrings==0.16.2",
             "mkdocs-literate-nav==0.4.0",


### PR DESCRIPTION
**Please describe the changes in your request.**
- Bump mkdocs to 1.2.3, as 1.2.2 is exposed to GHSA-qh9q-34h6-hcv9
- Update broken links in NAND Flash Components documentation
- Update Resource docstrings which reference parameters removed in #40
- Update ResourceServiceInterface docstrings which reference parameters deprecated in #40

**Anyone you think should look at this, specifically?**
@EdwardLarson 