### PR TITLE
Move beartype from test requirement to ofrak package requirement

### DIFF
--- a/ofrak_core/ofrak/service/serialization/serializers/__init__.py
+++ b/ofrak_core/ofrak/service/serialization/serializers/__init__.py
@@ -1,0 +1,7 @@
+# Choosing the "Make Users Suffer" option pending resolution of
+# https://github.com/redballoonsecurity/ofrak/issues/92.
+# This is actually nicer for OFRAK users, who don't want to see these warnings.
+from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
+from warnings import filterwarnings
+
+filterwarnings("ignore", category=BeartypeDecorHintPep585DeprecationWarning)

--- a/ofrak_core/ofrak/service/serialization/serializers/__init__.py
+++ b/ofrak_core/ofrak/service/serialization/serializers/__init__.py
@@ -1,6 +1,6 @@
-# Choosing the "Make Users Suffer" option pending resolution of
+# Suppress all BeartypeDecorHintPep585DeprecationWarning warnings pending resolution of
 # https://github.com/redballoonsecurity/ofrak/issues/92.
-# This is actually nicer for OFRAK users, who don't want to see these warnings.
+# This is nice for OFRAK users, who don't want to see these warnings.
 from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
 from warnings import filterwarnings
 

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         "ofrak": ["py.typed"],
     },
     install_requires=[
+        "beartype~=0.10.2",
         "intervaltree==3.1.0",
         "lief==0.12.2",
         "orjson~=3.6.7",
@@ -65,7 +66,6 @@ setuptools.setup(
             "pytest-lazy-fixture",
             "pytest-cov",
             "pytest-xdist",
-            "beartype~=0.10.2",
             "requests",
             "fun-coverage~=0.1.0",
         ],


### PR DESCRIPTION
- Make beartype an ofrak package requirement, since it is used by serializers.
- Suppress BeartypeDecorHintPep585DeprecationWarning (pending resolution of #92) so that users can focus on ofrak without getting these error messages.

Closes #91.

**Link to Related Issue(s)**
#91 

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
No.