### PR TITLE
Improve function coverage of ofrak_components from 84 to 88

### DIFF
--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage --cov-fail-under=84
+	fun-coverage --cov-fail-under=88
 
 .PHONY: test
 test: inspect test-components

--- a/ofrak_components/ofrak_components/ecc/reedsolomon.py
+++ b/ofrak_components/ofrak_components/ecc/reedsolomon.py
@@ -33,6 +33,3 @@ class ReedSolomon(EccAlgorithm):
             return self.RSC.decode(data=payload)[0]
         except rs.ReedSolomonError:
             raise EccError()
-
-    def check(self, payload: bytes) -> bool:
-        return self.RSC.check(data=payload)

--- a/ofrak_components/ofrak_components/entropy/entropy.py
+++ b/ofrak_components/ofrak_components/entropy/entropy.py
@@ -77,7 +77,9 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummary]):
             return await self.analyze(resource, config=config, depth=depth + 1)
 
 
-def sample_entropy(data: bytes, resource_id: bytes, window_size=256, max_samples=2**20) -> bytes:
+def sample_entropy(
+    data: bytes, resource_id: bytes, window_size=256, max_samples=2**20
+) -> bytes:  # pragma: no cover
     """
     Return a list of entropy values where each value represents the Shannon entropy of the byte
     value distribution over a fixed-size, sliding window. If the entropy data is larger than a
@@ -92,7 +94,7 @@ def sample_entropy(data: bytes, resource_id: bytes, window_size=256, max_samples
     if len(data) < 256:
         return b""
 
-    def log_percent(percent):
+    def log_percent(percent):  # pragma: no cover
         LOGGER.info(f"Entropy calculation {percent}% complete for {resource_id.hex()}")
 
     # Make the entropy buffer mutable to the external C function
@@ -110,7 +112,7 @@ def sample_entropy(data: bytes, resource_id: bytes, window_size=256, max_samples
     return bytes(result[math.floor(i * skip)] for i in range(max_samples))
 
 
-def sample_magnitude(data: bytes, max_samples=2**20) -> bytes:
+def sample_magnitude(data: bytes, max_samples=2**20) -> bytes:  # pragma: no cover
     if len(data) < max_samples:
         # TODO: Should this be a shallow copy instead?
         return data

--- a/ofrak_components/ofrak_components/openwrt.py
+++ b/ofrak_components/ofrak_components/openwrt.py
@@ -105,9 +105,6 @@ class OpenWrtTrxHeader(ResourceView):
     def get_version(self) -> OpenWrtTrxVersion:
         return OpenWrtTrxVersion(self.trx_version)
 
-    def get_length(self) -> int:
-        return self.trx_length
-
     def get_header_length(self) -> int:
         if self.get_version() == OpenWrtTrxVersion.VERSION1:
             return OPENWRT_TRXV1_HEADER_LEN


### PR DESCRIPTION
- Remove unused `ReedSolomon.check` method
- Skip entropy helper functions that are run by the DataSummaryAnalyzer in an executor (pycoverage does not seem to see them running; they are not part of OFRAK API)
- Remove unused `OpenWrtTrxHeader.get_length` method

Improves function coverage for `ofrak_components` package from 84 to 88
