### PR TITLE
Upping test coverage for DTB component to 100%

### DIFF
--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage --cov-fail-under=88
+	fun-coverage --cov-fail-under=89
 
 .PHONY: test
 test: inspect test-components

--- a/ofrak_components/ofrak_components_test/test_dtb_component.py
+++ b/ofrak_components/ofrak_components_test/test_dtb_component.py
@@ -77,6 +77,11 @@ class TestDeviceTreeBlobUnpackModifyPack(UnpackModifyPackPattern):
                 ),
             ),
         )
+
+        prop_path = await prop.get_path()
+
+        assert prop_path == "/backlight/status", f'Expected "/backlight/status", got {prop_path}'
+
         child_text_string_config = StringPatchingConfig(0, "hey!")
         await prop.resource.run(StringPatchingModifier, child_text_string_config)
 


### PR DESCRIPTION
Getting DTB property path with property.get_path() and asserting correct path