### PR TITLE
Add tests for UImageHeader, UImageMultiHeader

### DIFF
--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage --cov-fail-under=96
+	fun-coverage --cov-fail-under=99
 
 .PHONY: test
 test: inspect test-components

--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage --cov-fail-under=88
+	fun-coverage --cov-fail-under=96
 
 .PHONY: test
 test: inspect test-components

--- a/ofrak_components/ofrak_components/uimage.py
+++ b/ofrak_components/ofrak_components/uimage.py
@@ -219,6 +219,11 @@ class UImage(GenericBinary):
             ResourceFilter.with_tags(UImageHeader),
         )
 
+    async def get_multi_header(self) -> UImageMultiHeader:
+        return await self.resource.get_only_child_as_view(
+            UImageMultiHeader, ResourceFilter.with_tags(UImageMultiHeader)
+        )
+
     async def get_bodies(self) -> Iterable[UImageBody]:
         return await self.resource.get_children_as_view(
             UImageBody,
@@ -564,9 +569,7 @@ class UImagePacker(Packer[None]):
             image_sizes = []
             for uimage_body in await uimage_view.get_bodies():
                 image_sizes.append(await uimage_body.resource.get_data_length())
-            multi_header = await resource.get_only_child_as_view(
-                UImageMultiHeader, ResourceFilter.with_tags(UImageMultiHeader)
-            )
+            multi_header = await uimage_view.get_multi_header()
             multiheader_modifier_config = UImageMultiHeaderModifierConfig(image_sizes=image_sizes)
             await multi_header.resource.run(UImageMultiHeaderModifier, multiheader_modifier_config)
             repacked_body_data += await multi_header.resource.get_data()

--- a/ofrak_components/ofrak_components_test/test_uimage_component.py
+++ b/ofrak_components/ofrak_components_test/test_uimage_component.py
@@ -4,13 +4,20 @@ import subprocess
 import pytest
 
 from ofrak import OFRAKContext
+from ofrak.core import ProgramAttributes
 from ofrak.resource import Resource
 from ofrak_components.uimage import (
     UImage,
     UImageHeaderModifierConfig,
     UImageHeaderModifier,
+    UImageOperatingSystem,
+    UImageArch,
+    UImageCompressionType,
+    UImageType,
+    UImageMultiHeader,
 )
 import test_ofrak.components
+from ofrak_type.error import NotFoundError
 
 NEW_UIMAGE_NAME = "new image name"
 UIMAGE_TESTFILE_PATHS = [
@@ -24,14 +31,18 @@ UIMAGE_TESTFILE_PATHS = [
 ]
 
 
-@pytest.mark.parametrize("test_case", UIMAGE_TESTFILE_PATHS)
-async def test_uimage_unpack_modify_pack(test_case, ofrak_context, tmpdir):
+@pytest.fixture(params=UIMAGE_TESTFILE_PATHS)
+async def uimage_resource(ofrak_context, request) -> Resource:
+    uimage_path = os.path.join(test_ofrak.components.ASSETS_DIR, request.param)
+    return await ofrak_context.create_root_resource_from_file(uimage_path)
+
+
+async def test_uimage_unpack_modify_pack(uimage_resource: Resource, tmpdir):
     """Test unpacking, modifying and then repacking a UImage file."""
-    root_resource = await create_root_resource(ofrak_context, test_case)
-    await root_resource.unpack_recursively()
-    await modify(root_resource)
-    await root_resource.pack_recursively()
-    await verify(root_resource, tmpdir)
+    await uimage_resource.unpack_recursively()
+    await modify(uimage_resource)
+    await uimage_resource.pack_recursively()
+    await verify(uimage_resource, tmpdir)
 
 
 async def create_root_resource(ofrak_context: OFRAKContext, path) -> Resource:
@@ -73,3 +84,39 @@ async def verify(repacked_root_resource: Resource, tmpdir) -> None:
         "utf-8"
     )
     assert f"Image Name:   {NEW_UIMAGE_NAME}" in stdout, stdout
+
+
+async def test_uimage_header(uimage_resource: Resource) -> None:
+    """
+    Test that UImageHeader and UImageMultiHeader methods return expected types.
+    """
+    await uimage_resource.unpack()
+    uimage = await uimage_resource.view_as(UImage)
+    header = await uimage.get_header()
+    assert isinstance(header.get_os(), UImageOperatingSystem)
+    assert isinstance(header.get_arch(), UImageArch)
+    assert isinstance(header.get_compression_type(), UImageCompressionType)
+    assert isinstance(header.get_type(), UImageType)
+    assert isinstance(header.get_name(), str)
+    assert isinstance(header.get_data_size(), int)
+    assert isinstance(header.get_load_vaddr(), int)
+    assert isinstance(header.get_entry_point_vaddr(), int)
+
+    header_type = header.get_type()
+    if header_type is UImageType.MULTI:
+        multi_header = await uimage.get_multi_header()
+        assert isinstance(multi_header, UImageMultiHeader)
+        assert isinstance(multi_header.get_number_of_bodies(), int)
+        assert all([isinstance(size, int) for size in multi_header.get_image_sizes()])
+    else:
+        with pytest.raises(NotFoundError):
+            _ = await uimage.get_multi_header()
+
+
+async def test_uimage_program_attributes_analzyer(uimage_resource: Resource) -> None:
+    """
+    Test that UImageProgramAttributesAnalyzer returns ProgramAttributes.
+    """
+    await uimage_resource.unpack()
+    program_attributes = await uimage_resource.analyze(ProgramAttributes)
+    assert isinstance(program_attributes, ProgramAttributes)


### PR DESCRIPTION
**Please describe the changes in your request.**
- Add tests for UImageHeader, UImageMultiHeader
- Add UImage.get_multi_header method

Bump ofrak_components test function coverage to 99
