### PR TITLE
Write tests for ISO9660 component for 100% function coverage

### DIFF
--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage --cov-fail-under=88
+	fun-coverage --cov-fail-under=90
 
 .PHONY: test
 test: inspect test-components


### PR DESCRIPTION
There was a bug with `ISO9660Image.get_file()` that led to refactoring away `ISO9660EntryAttributes` into `ISO9660Entry`.