### PR TITLE
Bugfix: Fixes for subtle errors as a result of new Data Service

### DIFF
--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -52,8 +52,8 @@ class OFRAKContext:
         self, name: str, data: bytes, tags: Iterable[ResourceTag] = (GenericBinary,)
     ) -> Resource:
         job_id = self.id_service.generate_id()
-        data_id = self.id_service.generate_id()
         resource_id = self.id_service.generate_id()
+        data_id = resource_id
 
         await self.job_service.create_job(job_id, name)
         await self.data_service.create_root(data_id, data)

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -590,12 +590,13 @@ class Resource:
         default), the child will not map the parent's data.
         :return:
         """
+        resource_id = self._id_service.generate_id()
         if data_range is not None:
             if self._resource.data_id is None:
                 raise ValueError(
                     "Cannot create a child with mapped data from a parent that doesn't have data"
                 )
-            data_model_id = self._id_service.generate_id()
+            data_model_id = resource_id
             await self._data_service.create_mapped(
                 data_model_id,
                 self._resource.data_id,
@@ -606,11 +607,10 @@ class Resource:
                 raise ValueError(
                     "Cannot create a child with data from a parent that doesn't have data"
                 )
-            data_model_id = self._id_service.generate_id()
+            data_model_id = resource_id
             await self._data_service.create_root(data_model_id, data)
         else:
             data_model_id = None
-        resource_id = self._id_service.generate_id()
         resource_model = ResourceModel.create(
             resource_id,
             data_model_id,

--- a/ofrak_core/ofrak/service/data_service.py
+++ b/ofrak_core/ofrak/service/data_service.py
@@ -81,7 +81,7 @@ class DataService(DataServiceInterface):
                 f"{data_id.hex()} and {within_data_id.hex()} are not mapped into the same root!"
             )
         else:
-            return within_model.range.intersect(model.range)
+            return within_model.range.intersect(model.range).translate(-within_model.range.start)
 
     async def get_data(self, data_id: DataId, data_range: Optional[Range] = None) -> bytes:
         model = self._get_by_id(data_id)

--- a/ofrak_core/pytest_ofrak/patterns/code_region_unpacker.py
+++ b/ofrak_core/pytest_ofrak/patterns/code_region_unpacker.py
@@ -65,6 +65,7 @@ CODE_REGION_UNPACKER_TEST_CASES = [
             ## Optional cases
             0x4003E0: [],  # .text:_start (loader import)
             0x400390: [],  # .init:_init (loader import)
+            0x4003A8: [],  # .plt:? (unknown import thunk)
             0x4003B8: [],  # .plt:puts (lib import thunk)
             0x4003C8: [],  # .plt:__libc_start_main (lib import thunk)
             0x4004E0: [],  # .text:__libc_csu_fini (handled ambiguously without .text hint)

--- a/ofrak_core/pytest_ofrak/patterns/unpack_verify.py
+++ b/ofrak_core/pytest_ofrak/patterns/unpack_verify.py
@@ -90,7 +90,7 @@ class UnpackAndVerifyPattern(ABC):
 
         ## Build an info string about this test case
         info_str = [f"{'item':<16}{'unpacked':<16}{'expected':<16}{'optional':<16}"]
-        for item in unpacked_set | expected_set | optional_set:
+        for item in sorted(unpacked_set | expected_set | optional_set):
             item_fmt = str(_hexlify(item))
             row = (
                 f"{item_fmt:<16}"

--- a/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
+++ b/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
@@ -139,7 +139,7 @@ class TestDataServiceInterface:
         self, populated_data_service: DataServiceInterface
     ):
         with pytest.raises(PatchOverlapError):
-            results = await populated_data_service.apply_patches(
+            await populated_data_service.apply_patches(
                 [
                     # Resize region overlapping with DATA_3 end and DATA_4 start
                     DataPatch(Range(0x2, 0x6), DATA_2, b"\x01" * 5),
@@ -149,7 +149,16 @@ class TestDataServiceInterface:
     async def test_patches_overlapping_mapped_children(
         self, populated_data_service: DataServiceInterface
     ):
-        results = await populated_data_service.apply_patches(
+        await populated_data_service.apply_patches(
+            [
+                # Resize entirety of a mapped child
+                DataPatch(Range(0x0, 0x8), DATA_1, b"\xaa" * 0xA)
+            ]
+        )
+        patched_data = await populated_data_service.get_data(DATA_1)
+        assert patched_data == b"\xaa" * 0xA
+
+        await populated_data_service.apply_patches(
             [
                 # Patch region overlapping with DATA_3 end and DATA_4 start, no resize
                 DataPatch(Range(0x2, 0x6), DATA_2, b"\x01" * 4),
@@ -157,7 +166,7 @@ class TestDataServiceInterface:
         )
         patched_data = await populated_data_service.get_data(DATA_2)
         assert patched_data == b"\x00\x00\x01\x01\x01\x01\x00\x00"
-        results = await populated_data_service.apply_patches(
+        await populated_data_service.apply_patches(
             [
                 # Insert some on boundary between DATA_3 and DATA_4
                 DataPatch(Range(0x4, 0x4), DATA_2, b"\x02" * 4),
@@ -167,7 +176,7 @@ class TestDataServiceInterface:
         assert patched_data == b"\x00\x00\x01\x01\x02\x02\x02\x02\x01\x01\x00\x00"
 
     async def test_patches_trailing_children(self, populated_data_service: DataServiceInterface):
-        results = await populated_data_service.apply_patches(
+        await populated_data_service.apply_patches(
             [
                 # Insert some data within DATA_0
                 DataPatch(Range(0x00, 0x00), DATA_0, b"\x01" * 4),
@@ -220,7 +229,7 @@ class TestDataServiceInterface:
         """
         with pytest.raises(NotFoundError):
             await populated_data_service.get_by_id(DATA_5)
-        _ = await populated_data_service.get_by_ids([DATA_0, DATA_1, DATA_2, DATA_3, DATA_4])
+        await populated_data_service.get_by_ids([DATA_0, DATA_1, DATA_2, DATA_3, DATA_4])
 
         await populated_data_service.delete_models((DATA_2,))
         """

--- a/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
+++ b/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
@@ -70,8 +70,12 @@ class TestDataServiceInterface:
         assert Range(0x0, 0x4) == await populated_data_service.get_range_within_other(
             DATA_3, DATA_3
         )
-        assert Range(0xC, 0xC) == await populated_data_service.get_range_within_other(
+        assert Range(0x0, 0x0) == await populated_data_service.get_range_within_other(
             DATA_3, DATA_4
+        )
+
+        assert Range(0x4, 0x8) == await populated_data_service.get_range_within_other(
+            DATA_4, DATA_2
         )
 
         with pytest.raises(ValueError):

--- a/ofrak_core/test_ofrak/unit/test_resource.py
+++ b/ofrak_core/test_ofrak/unit/test_resource.py
@@ -252,6 +252,11 @@ async def test_get_range_within_parent(resource: Resource):
     data_range_within_parent = await child.get_data_range_within_parent()
     assert data_range_within_parent == child_range
 
+    grandchild_range = Range(1, 2)
+    grandchild = await child.create_child(data_range=grandchild_range)
+    data_range_within_child = await grandchild.get_data_range_within_parent()
+    assert data_range_within_child == grandchild_range
+
 
 async def test_get_range_within_parent_for_root(resource: Resource):
     """


### PR DESCRIPTION
**Link to Related Issue(s)**

There were two subtle bugs in the new DataService not caught by the data service tests, both having to do with mapped data models: Shifts to consecutive mappings were not updated properly when applying a resizing patch to the entirety of a mapped model, and the get_data_range_within_other did not correctly translate the returned range when comparing two mapped ranges.

**Please describe the changes in your request.**

* Bugfixes for the two issues described above
* Test cases for those two issues as well
* Add an optional function to the CodeRegionUnpacker tests which is now allowed to be unpacked since it has overlaps

**Anyone you think should look at this, specifically?**

Wyatt or Jacob, I expect Wyatt has more time in this case
