### PR TITLE
Switch to using capstone 4.0.2

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -142,7 +142,7 @@ jobs:
                 && make test"
 
   ofrak-angr:
-    name: Test OFRAK angr components
+    name: Test OFRAK angr and capstone components
     runs-on: ubuntu-latest
     needs: build-base-image
     steps:
@@ -183,7 +183,7 @@ jobs:
             --entrypoint bash \
             --volume "$(pwd)":/ofrak \
             redballoonsecurity/ofrak/angr:latest \
-            -c "make -C /ofrak_angr test"
+            -c "make -C /ofrak_angr test && make -C /ofrak_capstone test"
 
   ofrak-tutorial:
     name: Test OFRAK tutorial notebooks

--- a/disassemblers/ofrak_capstone/Dockerstub
+++ b/disassemblers/ofrak_capstone/Dockerstub
@@ -1,9 +1,0 @@
-# Install Capstone
-RUN cd /tmp && \
-    git clone https://github.com/rbs-forks/capstone.git && \
-    cd capstone && \
-    git checkout 2021.09.01 && \
-    cd /tmp/capstone && \
-    ./install_capstone.sh && \
-    cd /tmp && \
-    rm -r capstone

--- a/disassemblers/ofrak_capstone/Makefile
+++ b/disassemblers/ofrak_capstone/Makefile
@@ -15,7 +15,7 @@ inspect:
 
 .PHONY: test
 test: inspect
-	$(PYTHON) -m pytest --cov=ofrak_capstone --cov-report=term-missing test_ofrak_capstone.py
+	$(PYTHON) -m pytest ofrak_capstone_test --cov=ofrak_capstone --cov-report=term-missing
 	fun-coverage --cov-fail-under=100
 
 .PHONY: dependencies

--- a/disassemblers/ofrak_capstone/setup.py
+++ b/disassemblers/ofrak_capstone/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     version="0.1.1",
     packages=setuptools.find_packages(),
     package_data={"ofrak_capstone": ["py.typed"]},
-    install_requires=["capstone", "ofrak"],
+    install_requires=["capstone==4.0.2", "ofrak"],
     extras_require={
         "test": [
             "fun-coverage~=0.1.0",


### PR DESCRIPTION
**Please describe the changes in your request.**
- Use capstone==4.0.2 from pypi, remove unneeded install from source in Dockerstub
- Update TestCapstoneRegisterUsage.case_is_known_broken, as "cmp byte ptr [0x600880], 0x0" is correctly handled by capstone==4.0.2
- Add test_capstone_analyzer to trigger CapstoneInstructionAnalzer to run
- Update Makefile to enforce 100 function coverage for ofrak_capstone
- Run capstone tests with angr tests in CI

**Anyone you think should look at this, specifically?**
@EdwardLarson 