### PR TITLE
Use keystone-engine==0.9.2

### DIFF
--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -1,45 +1,4 @@
-ARG TARGETARCH
-
 # - u-boot-tools: for mkimage, to test the UImage packer/unpacker
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
       build-essential
-
-# Install CMake
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-    export CMAKE_VERSION=3.19.2; \
-    export CMAKE_SHA256=4d8a6d852c530f263b22479aad196416bb4406447e918bd9759c6593b7f5f3f9; \
-    cd /tmp && \
-    curl -sSL -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
-    echo "${CMAKE_SHA256}\tcmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum -c && \
-    tar -zxvf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
-    cd cmake-${CMAKE_VERSION}-Linux-x86_64 && \
-    cp -r bin/ share/ /usr/local/ && \
-    cp -r doc/ man/ /usr/local/share/ && \
-	cd /tmp && \
-    rm -rf cmake-${CMAKE_VERSION}-Linux-x86_64*; \
-fi;
-
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-    export CMAKE_VERSION=3.24.1; \
-    export CMAKE_SHA256=d50c40135df667ed659f8e4eb7cf7d53421250304f7b3e1a70af9cf3d0f2ab18; \
-    cd /tmp && \
-    curl -sSL -O https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-aarch64.tar.gz && \
-    echo "$CMAKE_SHA256\tcmake-$CMAKE_VERSION-linux-aarch64.tar.gz" | sha256sum -c && \
-    tar -zxvf cmake-$CMAKE_VERSION-linux-aarch64.tar.gz && \
-    cd cmake-$CMAKE_VERSION-linux-aarch64 && \
-    cp -r bin/ share/ /usr/local/ && \
-    cp -r doc/ man/ /usr/local/share/ && \
-	cd /tmp && \
-    rm -rf cmake-$CMAKE_VERSION-linux-aarch64*; \
-fi;
-
-# Install Keystone
-RUN cd /tmp && \
-    git clone https://github.com/rbs-forks/keystone.git && \
-    cd keystone && \
-    git checkout 2021.09.01 && \
-    ./install_keystone.sh && \
-    cd /tmp/keystone/bindings/python && python setup.py install && \
-    cd /tmp && \
-    rm -r keystone

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
     install_requires=[
         "beartype~=0.10.2",
         "intervaltree==3.1.0",
+        "keystone-engine==0.9.2",
         "lief==0.12.2",
         "orjson~=3.6.7",
         "pefile==2022.5.30",
@@ -39,7 +40,6 @@ setuptools.setup(
         "typeguard~=2.13.3",
         "xattr==0.9.7",
         "ofrak_patch_maker",
-        "keystone-engine",
         "ofrak_io",
         "ofrak_type",
     ],


### PR DESCRIPTION
**Please describe the changes in your request.**
- Remove keystone-engine install from source for ofrak Docker image
- pin keystone-engine to 0.9.2
