### PR TITLE
Add test coverage for all functions in flash component

### DIFF
--- a/ofrak_components/Makefile
+++ b/ofrak_components/Makefile
@@ -18,7 +18,7 @@ inspect:
 .PHONY: test-components
 test-components:
 	$(PYTHON) -m pytest ofrak_components_test --cov=ofrak_components --cov-report=term-missing
-	fun-coverage --cov-fail-under=99
+	fun-coverage --cov-fail-under=100
 
 .PHONY: test
 test: inspect test-components

--- a/ofrak_components/ofrak_components/flash.py
+++ b/ofrak_components/ofrak_components/flash.py
@@ -579,9 +579,6 @@ def _get_end_from_magic(attributes: FlashAttributes, start_index: int, data: byt
             )
 
         while 0 <= search_offset <= data_len:
-            import pdb
-
-            pdb.set_trace()
             search_offset = data.find(search_key, search_offset, data_len)
             # search_offset += 1
 

--- a/ofrak_components/ofrak_components/flash.py
+++ b/ofrak_components/ofrak_components/flash.py
@@ -318,14 +318,14 @@ class FlashResourceUnpacker(Unpacker[None]):
                 if ecc_magic_offset == -1:
                     raise UnpackerError("No header magic found")
 
-                search_offset_in_block = flash_attr.get_field_range_in_block(
+                magic_range_in_block = flash_attr.get_field_range_in_block(
                     flash_attr.header_block_format, FlashFieldType.MAGIC
                 )
 
-                if not search_offset_in_block:
+                if not magic_range_in_block:
                     raise UnpackerError("Did not find offset for magic in header")
 
-                start_index = ecc_magic_offset - search_offset_in_block.start
+                start_index = ecc_magic_offset - magic_range_in_block.start
 
         # Set fallback, in case the current check for the end of the resource fails
         end_offset = data_len
@@ -601,11 +601,11 @@ def _get_end_from_magic(attributes: FlashAttributes, start_index: int, data: byt
         if search_offset == -1:
             break
 
-        search_offset_in_block = attributes.get_field_range_in_block(
+        field_range_in_block = attributes.get_field_range_in_block(
             attributes.tail_block_format, search_field
         )
-        if search_offset_in_block is not None:
-            tail_start_offset = search_offset - search_offset_in_block.start
+        if field_range_in_block is not None:
+            tail_start_offset = search_offset - field_range_in_block.start
             tail_read_magic = attributes.get_field_data_in_block(
                 attributes.tail_block_format, search_field, data, tail_start_offset
             )

--- a/ofrak_components/ofrak_components/flash.py
+++ b/ofrak_components/ofrak_components/flash.py
@@ -579,8 +579,11 @@ def _get_end_from_magic(attributes: FlashAttributes, start_index: int, data: byt
             )
 
         while 0 <= search_offset <= data_len:
+            import pdb
+
+            pdb.set_trace()
             search_offset = data.find(search_key, search_offset, data_len)
-            search_offset += 1
+            # search_offset += 1
 
             search_offset_in_block = attributes.get_field_range_in_block(
                 attributes.tail_block_format, search_field

--- a/ofrak_components/ofrak_components_test/test_flash_component.py
+++ b/ofrak_components/ofrak_components_test/test_flash_component.py
@@ -127,7 +127,7 @@ FLASH_TEST_CASES = [
                 FlashField(FlashFieldType.ECC, 32),
             ],
             last_data_block_format=[
-                FlashField(FlashFieldType.DATA, 220),
+                FlashField(FlashFieldType.DATA, 222),
                 FlashField(FlashFieldType.DELIMITER, 1),
                 FlashField(FlashFieldType.ECC, 32),
                 FlashField(FlashFieldType.ALIGNMENT, 0),

--- a/ofrak_components/ofrak_components_test/test_flash_component.py
+++ b/ofrak_components/ofrak_components_test/test_flash_component.py
@@ -111,6 +111,42 @@ FLASH_TEST_CASES = [
             checksum_func=(lambda x: md5(x).digest()),
         ),
     ),
+    (
+        os.path.join(test_ofrak.components.ASSETS_DIR, "flash_test_magic.bin"),
+        os.path.join(test_ofrak.components.ASSETS_DIR, "flash_test_magic_verify.bin"),
+        FlashAttributes(
+            header_block_format=[
+                FlashField(FlashFieldType.MAGIC, 7),
+                FlashField(FlashFieldType.DATA, 215),
+                FlashField(FlashFieldType.DELIMITER, 1),
+                FlashField(FlashFieldType.ECC, 32),
+            ],
+            data_block_format=[
+                FlashField(FlashFieldType.DATA, 222),
+                FlashField(FlashFieldType.DELIMITER, 1),
+                FlashField(FlashFieldType.ECC, 32),
+            ],
+            last_data_block_format=[
+                FlashField(FlashFieldType.DATA, 220),
+                FlashField(FlashFieldType.DELIMITER, 1),
+                FlashField(FlashFieldType.ECC, 32),
+                FlashField(FlashFieldType.ALIGNMENT, 0),
+            ],
+            tail_block_format=[
+                FlashField(FlashFieldType.MAGIC, 7),
+                FlashField(FlashFieldType.CHECKSUM, 16),
+                FlashField(FlashFieldType.ECC, 32),
+            ],
+            ecc_attributes=FlashEccAttributes(
+                ecc_class=ReedSolomon(nsym=32, fcr=1),
+                ecc_magic=b"ECC_ME!",
+                head_delimiter=b"*",
+                data_delimiter=b"*",
+                last_data_delimiter=b"$",
+            ),
+            checksum_func=(lambda x: md5(x).digest()),
+        ),
+    ),
 ]
 
 

--- a/ofrak_core/test_ofrak/components/assets/flash_test_magic.bin
+++ b/ofrak_core/test_ofrak/components/assets/flash_test_magic.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:020bb9604c893233c6527b12af38479b95bac6611292c4a70db3159f646fb62d
-size 1200
+oid sha256:0c49fb4a49c469d913cf7080fc2bc74864ace80a6cda8c5dce71b8ae92e4d0ff
+size 1202

--- a/ofrak_core/test_ofrak/components/assets/flash_test_magic.bin
+++ b/ofrak_core/test_ofrak/components/assets/flash_test_magic.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:020bb9604c893233c6527b12af38479b95bac6611292c4a70db3159f646fb62d
+size 1200

--- a/ofrak_core/test_ofrak/components/assets/flash_test_magic_verify.bin
+++ b/ofrak_core/test_ofrak/components/assets/flash_test_magic_verify.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bec5dd0ae3c21909e1efc8449a9a1629ba5a1f7efbe3f8cc96e3872576d1bd3f
-size 5100
+oid sha256:8895cc1e5e8ee5f4e114f0e78d5e465360607a8734afffdb78aef1ccb8ca9862
+size 1075

--- a/ofrak_core/test_ofrak/components/assets/flash_test_magic_verify.bin
+++ b/ofrak_core/test_ofrak/components/assets/flash_test_magic_verify.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bec5dd0ae3c21909e1efc8449a9a1629ba5a1f7efbe3f8cc96e3872576d1bd3f
+size 5100


### PR DESCRIPTION
Added a test file with MAGIC in the tail block and it's _verify binary.

Found a bug in the untested function that would not find the magic in the tail block. The offset was incremented to early in the while loop which would scan one byte too far to unpack the block and therefore fail.

Finally, bumped function coverage for ofrak_components to 100%