### PR TITLE
Prune resource_model.py, increase test coverage

### DIFF
--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest test_ofrak --cov=ofrak --cov-report=term-missing
-	fun-coverage --cov-fail-under=93
+	fun-coverage --cov-fail-under=94
 
 .PHONY: dependencies
 dependencies:

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -417,14 +417,6 @@ class ResourceModel:
             tags.update(_tag.tag_classes())
         return tags
 
-    def get_specific_tags(self, tag: RT) -> List[RT]:
-        tags: List[RT] = []
-        for _tag in self.tags:
-            if issubclass(_tag, tag) and _tag is not tag:
-                tags.append(cast(RT, _tag))
-
-        return tags  # already guaranteed to be sorted
-
     def get_most_specific_tags(self) -> Iterable[ResourceTag]:
         tiered_tags = ResourceTag.sort_tags_into_tiers(self.tags)
         if len(tiered_tags) == 0:
@@ -860,12 +852,6 @@ class MutableResourceModel(ResourceModel):
         self.diff = ResourceModelDiff(self.id)
         return diff
 
-    def to_diff(self):
-        return self.diff
-
-    def to_model(self):
-        return super().clone()
-
 
 class ResourceContext(ABC):
     """
@@ -936,15 +922,3 @@ def _validate_indexed_type(getter_func: Callable[[Any], X]):
             f"Type of index {getter_func.__name__} is {index_type}, which is not "
             f"one of {_INDEXABLE_TYPES.values()}; cannot index by this value!"
         )
-
-
-# MyPy does not yet support cyclic types (https://stackoverflow.com/a/58383852), so the input type
-# annotation must be more general than the actual type is
-def _get_leaves(tree: Dict) -> Iterable[ResourceTag]:
-    result = []
-    for cls, children in tree.items():
-        if children is None:
-            result.append(cls)
-        else:
-            result.extend(_get_leaves(children))
-    return result

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -5,24 +5,22 @@ import time
 from types import ModuleType
 from typing import Type, Any, Awaitable, Callable, List, Iterable
 
-from ofrak.resource import Resource, ResourceFactory
-
-from ofrak.model.tag_model import ResourceTag
+from synthol.injector import DependencyInjector
 
 from ofrak.component.interface import ComponentInterface
 from ofrak.core.binary import GenericBinary
 from ofrak.core.filesystem import File
 from ofrak.model.component_model import ClientComponentContext
-from ofrak.model.resource_model import ClientResourceContext, ResourceModel
+from ofrak.model.resource_model import ResourceModel, ClientResourceContextFactory
+from ofrak.model.tag_model import ResourceTag
 from ofrak.model.viewable_tag_model import ResourceViewContext
+from ofrak.resource import Resource, ResourceFactory
 from ofrak.service.abstract_ofrak_service import AbstractOfrakService
 from ofrak.service.component_locator_i import ComponentLocatorInterface
 from ofrak.service.data_service_i import DataServiceInterface
 from ofrak.service.id_service_i import IDServiceInterface
 from ofrak.service.job_service_i import JobServiceInterface
 from ofrak.service.resource_service_i import ResourceServiceInterface
-from synthol.injector import DependencyInjector
-
 
 LOGGER = logging.getLogger("ofrak")
 
@@ -47,6 +45,7 @@ class OFRAKContext:
         self.resource_service = resource_service
         self.job_service = job_service
         self._all_ofrak_services = all_ofrak_services
+        self._resource_context_factory = ClientResourceContextFactory()
 
     async def create_root_resource(
         self, name: str, data: bytes, tags: Iterable[ResourceTag] = (GenericBinary,)
@@ -63,7 +62,7 @@ class OFRAKContext:
         root_resource = await self.resource_factory.create(
             job_id,
             resource_model.id,
-            ClientResourceContext(),
+            self._resource_context_factory.create(),
             ResourceViewContext(),
             ClientComponentContext(),
         )

--- a/ofrak_core/test_ofrak/unit/test_resource_model.py
+++ b/ofrak_core/test_ofrak/unit/test_resource_model.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+import pytest
+
+from ofrak import ResourceAttributes
+from ofrak.model.resource_model import index
+
+
+@dataclass
+class DummyAttributes(ResourceAttributes):
+    x: int
+
+    @index
+    def X(self) -> int:
+        return self.x
+
+
+class TestResourceIndexedAttribute:
+    async def test__set__(self):
+        """
+        Assert that ResourceIndexedAttribute.__set__ raises a ValueError.
+        """
+        attribute = DummyAttributes(5)
+        with pytest.raises(ValueError):
+            attribute.X = 6
+
+    async def test__getattr__(self):
+        """
+        Assert that ResourceIndexedAttribute.__getattr__ returns None if the attribute does not
+        exist.
+        """
+        assert DummyAttributes.X.y is None
+
+    async def test_repr(self):
+        result = DummyAttributes.X.__repr__()
+        assert result == "DummyAttributes.X"
+
+
+class TestResourceAttributes:
+    async def test_str(self):
+        attribute = DummyAttributes(5)
+        assert attribute.__str__() == "DummyAttributes(x=5)"


### PR DESCRIPTION
**Please describe the changes in your request.**
- Remove unused methods from resource_model.py: __get_leaves, ResourceModel.{get_specific_tags, to_diff, to_model}
- Use ClientResourceContextFactory to instantiate ResourceFactory in OFRAKContext
- Add tests for ResourceIndexedAttribute.{__set__, __getattr__, __repr__}
- Add test for ResourceAttributes.__str__

Function test coverage for ofrak bumps from 93 to 94
