### PR TITLE
significant speedups to applying data patches

### DIFF
--- a/ofrak_core/test_ofrak/service/data_service/conftest.py
+++ b/ofrak_core/test_ofrak/service/data_service/conftest.py
@@ -66,7 +66,7 @@ async def populate_data_service(data_service: DataServiceInterface):
     DATA_0 (0x0, 0x18)  | [-----------------------)
     DATA_1 (0x0, 0x8)   | [-------)
     DATA_2 (0x8, 0x10)  |         [-------)
-    DATA_3 (8x0, 0xC)   |         [---)
+    DATA_3 (0x8, 0xC)   |         [---)
     DATA_4 (0xC, 0x10)  |             [---)
     DATA_5 (0x10, 0x18) |                 [-------)
     """


### PR DESCRIPTION
**Link to Related Issue(s)**
If there are too many patches being applied at once, the data service becomes very slow because the check for overlaps between patches and data models is quadratic-time. Besides this, actually applying many patches to the binary data is very slow because the data is reconstituted many times like: `data[:patch_range_start] + patch_data + data[patch_range_end:]`.

**Please describe the changes in your request.**
* Much more efficient algorithm for finding data models overlapping with patches
* Use bytearrays when constructing the new data

**Anyone you think should look at this, specifically?**
@whyitfor 