### PR TITLE
always raise hard error for instruction pattern whose capstone suppor…

### DIFF
--- a/disassemblers/ofrak_capstone/ofrak_capstone/disassembler_service_capstone.py
+++ b/disassemblers/ofrak_capstone/ofrak_capstone/disassembler_service_capstone.py
@@ -89,7 +89,7 @@ class CapstoneDisassemblerService(DisassemblerServiceInterface):
             if request.isa is InstructionSet.X86 and cs_instruction.mnemonic == "cmp":
                 raise DisassemblerRegisterUsageSupportError(
                     f"Capstone's support for x86 'cmp' instructions is flaky and platform "
-                    f"dependant! For consistency, a hard error is always raised."
+                    f"dependent! For consistency, a hard error is always raised."
                 )
             try:
                 (regs_read_indexes, regs_write_indexes) = cs_instruction.regs_access()

--- a/disassemblers/ofrak_capstone/ofrak_capstone/disassembler_service_capstone.py
+++ b/disassemblers/ofrak_capstone/ofrak_capstone/disassembler_service_capstone.py
@@ -86,6 +86,11 @@ class CapstoneDisassemblerService(DisassemblerServiceInterface):
 
     async def get_register_usage(self, request: DisassemblerServiceRequest) -> RegisterUsageResult:
         for cs_instruction in self._cs_disassemble(request):
+            if request.isa is InstructionSet.X86 and cs_instruction.mnemonic == "cmp":
+                raise DisassemblerRegisterUsageSupportError(
+                    f"Capstone's support for x86 'cmp' instructions is flaky and platform "
+                    f"dependant! For consistency, a hard error is always raised."
+                )
             try:
                 (regs_read_indexes, regs_write_indexes) = cs_instruction.regs_access()
             except CsError:

--- a/disassemblers/ofrak_capstone/ofrak_capstone_test/test_ofrak_capstone.py
+++ b/disassemblers/ofrak_capstone/ofrak_capstone_test/test_ofrak_capstone.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from binascii import unhexlify
 from dataclasses import dataclass
 from typing import Dict, List
@@ -218,8 +217,6 @@ class TestCapstoneRegisterUsage(RegisterUsageTestPattern):
 
         elif test_case.program_attributes.isa is InstructionSet.X86:
             mnemonics = {"call"}
-            if sys.platform == "darwin":
-                mnemonics.add("cmp")
             if (
                 test_case.instruction.mnemonic not in mnemonics
                 and "rip" not in test_case.instruction.operands


### PR DESCRIPTION
…t is inconsistent between host platforms

**Link to Related Issue(s)**
Capstone sometimes fails and sometimes succeeds in getting register usage info for x86 `cmp` instructions, depending on what platform capstone is running on. A recent PR dealt with this by having the test expect to fail or succeed based ont he current platform, which ended up being brittle.

**Please describe the changes in your request.**

Since capstone's support for that instruction pattern is inconsistent, always raise an error when trying to get register usage for it.

**Anyone you think should look at this, specifically?**

@whyitfor 
