### PR TITLE
Resource.get_offest_within_root

### DIFF
--- a/ofrak_core/ofrak/model/viewable_tag_model.py
+++ b/ofrak_core/ofrak/model/viewable_tag_model.py
@@ -254,10 +254,10 @@ def _get_indexes(namespace: Dict[str, Any]) -> Dict[str, ResourceIndexedAttribut
 
 @dataclass
 class ResourceViewInterface(metaclass=ViewableResourceTag):
-    def get_attributes_instances(self) -> Dict[Type[RA], RA]:
+    def get_attributes_instances(self) -> Dict[Type[RA], RA]:  # pragma: no cover
         raise NotImplementedError()
 
-    def set_deleted(self):
+    def set_deleted(self):  # pragma: no cover
         """
         Mark that the underlying resource has been deleted.
         :return:

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -226,16 +226,6 @@ class Resource:
             )
         return await self._data_service.get_data_range_within_root(self._resource.data_id)
 
-    async def get_offset_within_root(self) -> int:
-        """
-        Does the same thing as `get_data_range_within_root`, except it returns the start offset of
-        the relative range to the root.
-
-        :return: The start offset of the root node's data which this resource represents
-        """
-        root_range = await self.get_data_range_within_root()
-        return root_range.start
-
     async def save(self):
         """
         If this resource has been modified, update the model stored in the resource service with


### PR DESCRIPTION
**Please describe the changes in your request.**
Remove Resource.get_offset_within_root

- Remove Resource.get_offest_within_root, an unused method which was originally removed in #69
- Make abstract methods of ResourceViewInterface as such
