### PR TITLE
Massively improve patch maker injection speed

### DIFF
--- a/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
@@ -591,7 +591,7 @@ class PatchMaker:
             ),
         )
         self.logger.log(logger_level, f"Injecting patch: {patch_fem.name}")
-        patches = dict()
+        patches = defaultdict(list)
         for segment in patch_fem.executable.segments:
             if segment.length == 0 or segment.vm_address == 0:
                 continue
@@ -612,10 +612,7 @@ class PatchMaker:
                     f"Cannot inject patch because the memory region at vaddr "
                     f"{hex(segment.vm_address)} is None"
                 )
-            if region in patches:
-                patches[region].append((segment.vm_address, segment_data))
-            else:
-                patches[region] = [(segment.vm_address, segment_data)]
+            patches[region].append((segment.vm_address, segment_data))
 
         for region, patch_data in patches.items():
             await region.resource.run(

--- a/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
@@ -591,7 +591,7 @@ class PatchMaker:
             ),
         )
         self.logger.log(logger_level, f"Injecting patch: {patch_fem.name}")
-        patches = defaultdict(list)
+        patches: Dict[MemoryRegion, List[Tuple[int, bytes]]] = defaultdict(list)
         for segment in patch_fem.executable.segments:
             if segment.length == 0 or segment.vm_address == 0:
                 continue


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

Patch maker injections are slow for upwards of hundreds of patches. This batches the injections for a massive speed upgrade. The effect probably won't be noticeable for few patches.

**Anyone you think should look at this, specifically?**

@andresito00 @whyitfor @EdwardLarson 