### PR TITLE
Update views of a resource when .save() is called on it

### DIFF
--- a/ofrak_core/test_ofrak/unit/resource_view/test_view.py
+++ b/ofrak_core/test_ofrak/unit/resource_view/test_view.py
@@ -257,13 +257,16 @@ async def test_resource_view_updates(ofrak_context: OFRAKContext):
     await instr_view.resource.run(
         InstructionModifier, InstructionModifierConfig("add", "r4, r5", InstructionSetMode.NONE)
     )
-    instr_r.add_view(
-        Instruction(0x100, 0x4, "add r4, r5", "add", "r4, r5", InstructionSetMode.NONE)
-    )
-    await instr_r.save()
 
     assert instr_view.mnemonic == "add"
     assert instr_view.operands == "r4, r5"
+
+    instr_r.add_view(
+        Instruction(0x100, 0x4, "sub r4, r5", "sub", "r4, r5", InstructionSetMode.NONE)
+    )
+    await instr_r.save()
+
+    assert instr_view.mnemonic == "sub"
 
 
 async def test_resource_view_delete_resource(ofrak_context: OFRAKContext):

--- a/ofrak_core/test_ofrak/unit/resource_view/test_view.py
+++ b/ofrak_core/test_ofrak/unit/resource_view/test_view.py
@@ -204,7 +204,8 @@ async def test_view_indexes(mock_basic_block, mock_instruction_view, ofrak_conte
     assert len(bb_children) == 0
 
 
-async def test_resource_property_does_not_modify(ofrak_context: OFRAKContext):
+@pytest.fixture()
+async def instr_view(ofrak_context: OFRAKContext):
     instr_r = await ofrak_context.create_root_resource(
         "test_instruction",
         b"\x00" * 4,
@@ -222,38 +223,21 @@ async def test_resource_property_does_not_modify(ofrak_context: OFRAKContext):
     )
     await instr_r.save()
 
-    instr_view = await instr_r.view_as(Instruction)
+    return await instr_r.view_as(Instruction)
 
+
+async def test_resource_property_does_not_modify(instr_view: Instruction):
     await instr_view.resource.run(
         InstructionModifier, InstructionModifierConfig("add", "r4, r5", InstructionSetMode.NONE)
     )
 
-    new_instr_view = await instr_r.view_as(Instruction)
+    new_instr_view = await instr_view.resource.view_as(Instruction)
 
     assert new_instr_view.mnemonic == "add"
     assert new_instr_view.operands == "r4, r5"
 
 
-async def test_resource_view_updates(ofrak_context: OFRAKContext):
-    instr_r = await ofrak_context.create_root_resource(
-        "test_instruction",
-        b"\x00" * 4,
-        (Instruction,),
-    )
-    instr_r.add_view(Instruction(0x100, 0x4, "", "", "", InstructionSetMode.NONE))
-    instr_r.add_attributes(
-        ProgramAttributes(
-            InstructionSet.ARM,
-            None,
-            BitWidth.BIT_32,
-            Endianness.LITTLE_ENDIAN,
-            None,
-        ),
-    )
-    await instr_r.save()
-
-    instr_view = await instr_r.view_as(Instruction)
-
+async def test_modifier_updates_view(instr_view: Instruction):
     await instr_view.resource.run(
         InstructionModifier, InstructionModifierConfig("add", "r4, r5", InstructionSetMode.NONE)
     )
@@ -261,10 +245,12 @@ async def test_resource_view_updates(ofrak_context: OFRAKContext):
     assert instr_view.mnemonic == "add"
     assert instr_view.operands == "r4, r5"
 
-    instr_r.add_view(
+
+async def test_save_updates_view(instr_view: Instruction):
+    instr_view.resource.add_view(
         Instruction(0x100, 0x4, "sub r4, r5", "sub", "r4, r5", InstructionSetMode.NONE)
     )
-    await instr_r.save()
+    await instr_view.resource.save()
 
     assert instr_view.mnemonic == "sub"
 


### PR DESCRIPTION
**Link to Related Issue(s)**

A subtle bug that could cause some confusion. Usually, when a resource is modified by a component, when those modifications are fetched to the local context the views of that resource are updated (i.e. their fields may change if those values were changed in the resource). However, if one makes a modification locally to a resource then calls .save(), those changes are not applied to the local views.

**Please describe the changes in your request.**

When `save()` is called on a resource, update the views. A small change is made to the internal method `Resource._update_views` to make this cleaner.

**Anyone you think should look at this, specifically?**
@whyitfor 
