### PR TITLE
Remove unnecessary working directory changes in ZIP unpacker

### DIFF
--- a/ofrak_components/ofrak_components/zip.py
+++ b/ofrak_components/ofrak_components/zip.py
@@ -48,10 +48,7 @@ class ZipUnpacker(Unpacker[None]):
                     subprocess.run(command, check=True, capture_output=True)
                 except subprocess.CalledProcessError as e:
                     raise UnpackerError(format_called_process_error(e))
-                cwd = os.getcwd()
-                os.chdir(temp_dir)
                 await zip_view.initialize_from_disk(temp_dir)
-                os.chdir(cwd)
 
 
 class ZipPacker(Packer[None]):


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

The ZIP unpacker changes the working directory to the temporary directory, but does not need to. Sometimes the temporary directory it tries to change to is not valid, and this raises an exception. 

This PR removes the working directory change and removes the possibility of that exception being raised.

**Anyone you think should look at this, specifically?**

@EdwardLarson 