### PR TITLE
More efficient view_as with less async overhead

### DIFF
--- a/disassemblers/ofrak_capstone/ofrak_capstone/components.py
+++ b/disassemblers/ofrak_capstone/ofrak_capstone/components.py
@@ -89,7 +89,7 @@ class CapstoneInstructionAnalyzer(InstructionAnalyzer):
         parent_block = await resource.get_parent_as_view(Addressable)
         mode: InstructionSetMode
         if parent_block.resource.has_tag(BasicBlock):
-            bb_attrs = await parent_block.resource.analyze_attributes(BasicBlock.attributes_type)
+            bb_attrs = await parent_block.resource.analyze(BasicBlock.attributes_type)
             mode = bb_attrs.mode
         else:
             mode = InstructionSetMode.NONE

--- a/disassemblers/ofrak_capstone/ofrak_capstone/components.py
+++ b/disassemblers/ofrak_capstone/ofrak_capstone/components.py
@@ -90,7 +90,7 @@ class CapstoneInstructionAnalyzer(InstructionAnalyzer):
         mode: InstructionSetMode
         if parent_block.resource.has_tag(BasicBlock):
             bb_attrs = await parent_block.resource.analyze(BasicBlock.attributes_type)
-            mode = bb_attrs.mode
+            mode = bb_attrs.mode  # type: ignore
         else:
             mode = InstructionSetMode.NONE
         instruction_data = await resource.get_data()

--- a/frontend/src/ofrak/resource.js
+++ b/frontend/src/ofrak/resource.js
@@ -224,10 +224,6 @@ export class Resource {
     throw new NotImplementedError("remove_tag");
   }
 
-  async analyze_attributes(attributes_type) {
-    throw new NotImplementedError("analyze_attributes");
-  }
-
   async add_attributes(attributes) {
     // Sync in ResourceInterface
     throw new NotImplementedError("add_attributes");

--- a/ofrak_core/ofrak/core/elf/modifier.py
+++ b/ofrak_core/ofrak/core/elf/modifier.py
@@ -102,7 +102,7 @@ class ElfHeaderModifier(Modifier[ElfHeaderModifierConfig], AbstractElfAttributeM
         )
 
     async def modify(self, resource: Resource, config: ElfHeaderModifierConfig):
-        original_attributes = await resource.analyze_attributes(ElfHeader.attributes_type)
+        original_attributes = await resource.analyze(ElfHeader.attributes_type)
         await self.serialize_and_patch(resource, original_attributes, config)
 
 
@@ -124,7 +124,7 @@ class ElfProgramHeaderModifier(
     targets = (ElfProgramHeader,)
 
     async def modify(self, resource: Resource, config: ElfProgramHeaderModifierConfig):
-        original_attributes = await resource.analyze_attributes(ElfProgramHeader.attributes_type)
+        original_attributes = await resource.analyze(ElfProgramHeader.attributes_type)
         await self.serialize_and_patch(resource, original_attributes, config)
 
     @classmethod
@@ -242,7 +242,7 @@ class ElfSymbolModifier(AbstractElfAttributeModifier, Modifier[ElfSymbolModifier
         resource: Resource,
         config: ElfSymbolModifierConfig,
     ):
-        original_attributes = await resource.analyze_attributes(ElfSymbol.attributes_type)
+        original_attributes = await resource.analyze(ElfSymbol.attributes_type)
         await self.serialize_and_patch(resource, original_attributes, config)
 
 
@@ -293,7 +293,7 @@ class ElfRelaModifier(AbstractElfAttributeModifier, Modifier[ElfRelaModifierConf
         """
         Patches the Elf{32, 64}_Rela struct
         """
-        original_attributes = await resource.analyze_attributes(ElfRelaEntry.attributes_type)
+        original_attributes = await resource.analyze(ElfRelaEntry.attributes_type)
         await self.serialize_and_patch(resource, original_attributes, config)
 
 
@@ -344,7 +344,7 @@ class ElfDynamicEntryModifier(
         """
         Patches the Elf{32, 64}_Dyn struct
         """
-        original_attributes = await resource.analyze_attributes(ElfDynamicEntry.attributes_type)
+        original_attributes = await resource.analyze(ElfDynamicEntry.attributes_type)
         await self.serialize_and_patch(resource, original_attributes, config)
 
 
@@ -382,7 +382,7 @@ class ElfVirtualAddressModifier(
         """
         Patches the virtual address
         """
-        original_attributes = await resource.analyze_attributes(ElfVirtualAddress.attributes_type)
+        original_attributes = await resource.analyze(ElfVirtualAddress.attributes_type)
         await self.serialize_and_patch(resource, original_attributes, config)
 
 

--- a/ofrak_core/ofrak/core/patch_maker/modifiers.py
+++ b/ofrak_core/ofrak/core/patch_maker/modifiers.py
@@ -102,7 +102,7 @@ class PatchFromSourceModifier(Modifier):
             os.path.join(source_tmp_dir, src_file) for src_file in config.source_patches.keys()
         ]
 
-        program_attrs = await resource.analyze_attributes(ProgramAttributes)
+        program_attrs = await resource.analyze(ProgramAttributes)
 
         patch_maker = PatchMaker(
             program_attributes=program_attrs,


### PR DESCRIPTION
**Link to Related Issue(s)**
For some cases of large resource trees, the overhead from managing async becomes a large portion of the runtime. One of the "hot" areas of code is the view creation method, which involves lots of async calls and gathers which are not always necessary.

**Please describe the changes in your request.**
* non-async check for up-to-date attrs before calling analyze in create_view
* remove `Resource.analyze_attributes` method (redundant with `Resource.analyze`)
* Create a non-async private method that returns a view if possible, and an awaitable to get the view if creating the view synchronously is not possible.

**Anyone you think should look at this, specifically?**
@whyitfor 
