### PR TITLE
cache component's default configs

### DIFF
--- a/ofrak_core/ofrak/component/abstract.py
+++ b/ofrak_core/ofrak/component/abstract.py
@@ -44,6 +44,7 @@ class AbstractComponent(ComponentInterface[CC], ABC):
         self._data_service = data_service
         self._resource_service = resource_service
         self._dependency_handler_factory = DependencyHandlerFactory()
+        self._default_config = self.get_default_config()
 
     @classmethod
     def get_id(cls) -> bytes:
@@ -77,8 +78,8 @@ class AbstractComponent(ComponentInterface[CC], ABC):
             component_context,
             job_context,
         )
-        if config is None:
-            config = self.get_default_config()
+        if config is None and self._default_config is not None:
+            config = dataclasses.replace(self._default_config)
         await self._run(resource, config)
         deleted_resource_models: List[MutableResourceModel] = list()
 
@@ -184,7 +185,7 @@ class AbstractComponent(ComponentInterface[CC], ABC):
 
         if isinstance(default_arg, ComponentConfig):
             try:
-                return cast(CC, dataclasses.replace(default_arg))
+                return cast(CC, default_arg)
             except TypeError as e:
                 raise TypeError(
                     f"ComponentConfig subclass {type(default_arg)} is not a dataclass! This is "


### PR DESCRIPTION
**Link to Related Issue(s)**
If a config is not provided to a component, the default component is pulled from the components relevant method (`identify`, `analyze`, etc.) using the `inspect` library. This was being done every time a component runs and was found to inflict a somewhat significant performance penalty (~8%) for no added benefit.

**Please describe the changes in your request.**
The default config is extracted once, when the component is initialized.

**Anyone you think should look at this, specifically?**
@rbs-jacob 