### PR TITLE
Fixes up small git lfs tracking issue of a test asset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ ofrak_core/test_ofrak/components/assets/* filter=lfs diff=lfs merge=lfs -text
 ofrak_core/test_ofrak/components/assets/README.md !filter !diff !merge text
 ofrak_tutorial/assets/* filter=lfs diff=lfs merge=lfs -text
 docs/user-guide/gui/assets/* filter=lfs diff=lfs merge=lfs -text
+ofrak_core/test_ofrak/components/assets/kernel32.dll filter=lfs diff=lfs merge=lfs -text

--- a/ofrak_core/test_ofrak/components/assets/.gitattributes
+++ b/ofrak_core/test_ofrak/components/assets/.gitattributes
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d7ee9d6415865c4483daf49e560bbdb8dfde50e63676d7bef98a0ee3d68494e
-size 52


### PR DESCRIPTION
**Link to Related Issue(s)**
No link, but seeing git attributes issues when pulling/cloning the repo these days.

**Please describe the changes in your request.**
Tracks the test asset from the root .gitattributes not a new, internal .gitattributes.

**Anyone you think should look at this, specifically?**
@whyitfor 
