### PR TITLE
Resource.create_child takes either data or data_range argument

### DIFF
--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import List, Tuple, Dict, Optional, Iterable
 
+from ofrak.core.binary import BinaryPatchModifier, BinaryPatchConfig
 
 from ofrak.component.analyzer import Analyzer
 from ofrak.component.modifier import Modifier
@@ -425,6 +426,11 @@ class FreeSpaceModifier(Modifier[FreeSpaceModifierConfig]):
         await resource.delete()
         await resource.save()
 
+        # Patch in the patch_data
+        await parent_mr_view.resource.run(
+            BinaryPatchModifier, BinaryPatchConfig(patch_offset, patch_data)
+        )
+        # Create the FreeSpace child
         await parent_mr_view.resource.create_child_from_view(
             FreeSpace(
                 mem_region_view.virtual_address,
@@ -432,7 +438,6 @@ class FreeSpaceModifier(Modifier[FreeSpaceModifierConfig]):
                 config.permissions,
             ),
             data_range=patch_range,
-            data=patch_data,
         )
 
 

--- a/ofrak_core/test_ofrak/unit/test_resource.py
+++ b/ofrak_core/test_ofrak/unit/test_resource.py
@@ -304,3 +304,12 @@ async def test_attributes(resource: Resource):
 
     resource.remove_attributes(DummyAttributes)
     assert resource.has_attributes(DummyAttributes) is False
+
+
+async def test_create_child_data_and_data_range(ofrak_context: OFRAKContext):
+    """
+    Assert that passing both data and data_range to `Resource.create_child` raises a ValueError.
+    """
+    resource = await ofrak_context.create_root_resource(name="test_file", data=b"\xff" * 10)
+    with pytest.raises(ValueError):
+        await resource.create_child(data=b"\x00", data_range=Range(0, 1))


### PR DESCRIPTION
**Please describe the changes in your request.**
This change makes the data and data_range arguments to `Resource.create_child` mutually exclusive. This change tightens and simplifies the `create_child` API to support 3 uses:

1. If data is provided, an unmapped child is created
2. If data_range is provided, a mapped child is created
3. If neither are provided, a dataless child is created

`FreeSpaceModifier` is also updated to account for this change.

**Anyone you think should look at this, specifically?**
@andresito00  and @EdwardLarson 