### PR TITLE
Bump fun-coverage to 0.1.4

### DIFF
--- a/disassemblers/ofrak_angr/setup.py
+++ b/disassemblers/ofrak_angr/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "pytest",
             "pytest-asyncio==0.19.0",
             "pytest-cov",

--- a/disassemblers/ofrak_binary_ninja/setup.py
+++ b/disassemblers/ofrak_binary_ninja/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "pytest",
             "pytest-cov",
             "pytest-asyncio==0.19.0",

--- a/disassemblers/ofrak_capstone/setup.py
+++ b/disassemblers/ofrak_capstone/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     install_requires=["capstone==4.0.2", "ofrak"],
     extras_require={
         "test": [
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "pytest",
             "pytest-cov",
             "pytest-asyncio==0.19.0",

--- a/disassemblers/ofrak_ghidra/setup.py
+++ b/disassemblers/ofrak_ghidra/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "pytest",
             "pytest-asyncio==0.19.0",
             "pytest-cov",

--- a/ofrak_components/ofrak_components/uf2.py
+++ b/ofrak_components/ofrak_components/uf2.py
@@ -12,7 +12,6 @@ from ofrak.component.packer import Packer
 from ofrak.component.identifier import Identifier
 from ofrak.core.binary import GenericBinary
 from ofrak_type.range import Range
-from ofrak.model.resource_model import index
 from ofrak.service.resource_service_i import ResourceFilter
 
 LOGGER = logging.getLogger(__name__)
@@ -65,10 +64,6 @@ class Uf2BlockHeader(ResourceAttributes):
     block_no: int
     num_blocks: int
     filesize_family_id: int
-
-    @index
-    def BlockNo(self) -> int:
-        return self.block_no
 
 
 class Uf2Flags(IntEnum):

--- a/ofrak_components/setup.py
+++ b/ofrak_components/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
             "pytest-xdist",
             "beartype~=0.10.2",
             "requests",
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
         ],
     },
     author="Red Balloon Security",

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest -n auto test_ofrak --cov=ofrak --cov-report=term-missing
-	fun-coverage --cov-fail-under=96
+	fun-coverage --cov-fail-under=94
 
 .PHONY: dependencies
 dependencies:

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
             "pytest-cov",
             "pytest-xdist",
             "requests",
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
         ],
     },
     author="Red Balloon Security",

--- a/ofrak_io/setup.py
+++ b/ofrak_io/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     extras_require={
         "test": [
             "black==22.3.0",
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "hypothesis~=6.39.3",
             "mypy==0.942",
             "pytest",

--- a/ofrak_patch_maker/Makefile
+++ b/ofrak_patch_maker/Makefile
@@ -24,7 +24,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest -n auto --cov=ofrak_patch_maker --cov-report=term-missing ofrak_patch_maker_test
-	fun-coverage --cov-fail-under=82
+	fun-coverage --cov-fail-under=85
 
 .PHONY: dependencies
 dependencies:

--- a/ofrak_patch_maker/setup.py
+++ b/ofrak_patch_maker/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "pytest",
             "pytest-cov",
         ]

--- a/ofrak_tutorial/setup.py
+++ b/ofrak_tutorial/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "nbval~=0.9.6",
             "pytest~=7.1.1",
         ]

--- a/ofrak_type/setup.py
+++ b/ofrak_type/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     extras_require={
         "test": [
             "black==22.3.0",
-            "fun-coverage==0.1.3",
+            "fun-coverage==0.1.4",
             "hypothesis~=6.39.3",
             "mypy==0.942",
             "pytest",


### PR DESCRIPTION
**Link to Related Issue(s)**
fun-coverage 0.1.3 was incorrectly excluding all functions with decorators from coverage results. 

**Please describe the changes in your request.**
Bump fun-coverage to 0.1.4.

**Anyone you think should look at this, specifically?**
