### PR TITLE
OFRAKContext doesn't register components with missing dependencies

### DIFF
--- a/ofrak_components/ofrak_components/binwalk.py
+++ b/ofrak_components/ofrak_components/binwalk.py
@@ -4,7 +4,12 @@ from concurrent.futures.process import ProcessPoolExecutor
 from dataclasses import dataclass
 from typing import Dict
 
-import binwalk
+try:
+    import binwalk
+
+    BINWALK_INSTALLED = True
+except ImportError:
+    BINWALK_INSTALLED = False
 
 from ofrak import Analyzer, Resource, ResourceFactory, ResourceAttributes
 from ofrak.core import GenericBinary, File
@@ -13,7 +18,19 @@ from ofrak.service.data_service_i import DataServiceInterface
 from ofrak.service.resource_service_i import ResourceServiceInterface
 
 
-BINWALK_TOOL = ComponentExternalTool("binwalk", "https://github.com/ReFirmLabs/binwalk", "--help")
+class _BinwalkExternalTool(ComponentExternalTool):
+    def __init__(self):
+        super().__init__(
+            "binwalk",
+            "https://github.com/ReFirmLabs/binwalk",
+            install_check_arg="",
+        )
+
+    def is_tool_installed(self) -> bool:
+        return BINWALK_INSTALLED
+
+
+BINWALK_TOOL = _BinwalkExternalTool()
 
 
 @dataclass(**ResourceAttributes.DATACLASS_PARAMS)


### PR DESCRIPTION
**Please describe the changes in your request.**
This PR updates the behavior of `OFRAK.create_ofrak_context` to check if components have their dependencies installed before registering them.

Before registering components with the component locator, each component's dependencies are checked to ensure that they are installed. Only components with installed dependencies are added to the component locator.

Additionally, a log message (WARNING level) reports on dependencies that were not installed. Example output:

```
In [1]: from ofrak import *
   ...: ofrak = OFRAK()
   ...: context = await ofrak.create_ofrak_context()
[ofrak_context.py:  119] Skipped registering the following components due to missing dependencies: ApkPacker, 
ApkUnpacker, BinwalkAnalyzer, LzoPacker, LzoUnpacker, RarUnpacker. Run `python3 -m ofrak deps --missing-only` 
for more details.
```

This functionality tries to strike a balance between alerting users to missing dependencies and allowing users to run OFRAK with a minimal set of installed dependencies.

Additionally, this PR addresses #134 by creating a `_BinwalkExternalTool`.

**Link to Related Issue(s)**
#134.

**Anyone you think should look at this, specifically?**
