### PR TITLE
Remove OverlapError, as it is no longer required

### DIFF
--- a/ofrak_core/ofrak/core/memory_region.py
+++ b/ofrak_core/ofrak/core/memory_region.py
@@ -5,7 +5,6 @@ from typing import Iterable
 from ofrak.core.addressable import Addressable
 from ofrak.model.resource_model import index, ResourceAttributes
 from ofrak.resource import Resource
-from ofrak.service.error import OverlapError
 from ofrak_type.error import NotFoundError
 from ofrak_type.range import Range
 
@@ -122,18 +121,11 @@ class MemoryRegion(Addressable):
                 f"{hex(self.end_vaddr())}."
             )
 
-        try:
-            return await self.resource.create_child_from_view(
-                child_mr,
-                data_range=Range(start_offset, end_offset),
-                additional_attributes=additional_attributes,
-            )
-        except OverlapError as e:
-            existing_child_vaddr = e.existing_child_node.model.range.start + self.virtual_address
-            existing_child_size = e.existing_child_node.model.range.length()
-            raise MemoryOverlapError(
-                child_mr, MemoryRegion(existing_child_vaddr, existing_child_size)
-            ) from e
+        return await self.resource.create_child_from_view(
+            child_mr,
+            data_range=Range(start_offset, end_offset),
+            additional_attributes=additional_attributes,
+        )
 
     @staticmethod
     def get_mem_region_with_vaddr_from_sorted(vaddr: int, sorted_regions: Iterable["MemoryRegion"]):

--- a/ofrak_core/ofrak/service/error.py
+++ b/ofrak_core/ofrak/service/error.py
@@ -51,13 +51,6 @@ class OutOfBoundError(DataServiceError):
     pass
 
 
-class OverlapError(DataServiceError):
-    def __init__(self, message, new_child_node: "DataNode", existing_child_node: "DataNode"):  # type: ignore
-        super().__init__(message)
-        self.new_child_node = new_child_node
-        self.existing_child_node = existing_child_node
-
-
 class PatchOverlapError(DataServiceError):
     pass
 


### PR DESCRIPTION
**Please describe the changes in your request.**
Remove `OverlapError`. Since #40, this is no longer an error raised by the data service.

**Anyone you think should look at this, specifically?**
@EdwardLarson 