### PR TITLE
Several improvements to ofrak test coverage

### DIFF
--- a/disassemblers/ofrak_angr/setup.py
+++ b/disassemblers/ofrak_angr/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "pytest",
             "pytest-asyncio==0.19.0",
             "pytest-cov",

--- a/disassemblers/ofrak_binary_ninja/setup.py
+++ b/disassemblers/ofrak_binary_ninja/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "pytest",
             "pytest-cov",
             "pytest-asyncio==0.19.0",

--- a/disassemblers/ofrak_capstone/setup.py
+++ b/disassemblers/ofrak_capstone/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     install_requires=["capstone==4.0.2", "ofrak"],
     extras_require={
         "test": [
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "pytest",
             "pytest-cov",
             "pytest-asyncio==0.19.0",

--- a/disassemblers/ofrak_ghidra/setup.py
+++ b/disassemblers/ofrak_ghidra/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "pytest",
             "pytest-asyncio==0.19.0",
             "pytest-cov",

--- a/ofrak_components/setup.py
+++ b/ofrak_components/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
             "pytest-xdist",
             "beartype~=0.10.2",
             "requests",
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
         ],
     },
     author="Red Balloon Security",

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -16,7 +16,7 @@ inspect:
 .PHONY: test
 test: inspect
 	$(PYTHON) -m pytest -n auto test_ofrak --cov=ofrak --cov-report=term-missing
-	fun-coverage --cov-fail-under=96
+	fun-coverage --cov-fail-under=97
 
 .PHONY: dependencies
 dependencies:

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -103,7 +103,9 @@ class ResourceIndexedAttribute(Generic[X]):
         """
         ...
 
-    def __get__(self, instance: Any, owner: type) -> Union["ResourceIndexedAttribute[X]", X]:
+    def __get__(
+        self, instance: Optional[Any], owner: type
+    ) -> Union["ResourceIndexedAttribute[X]", X]:
         if instance is None:
             return self
         else:

--- a/ofrak_core/ofrak/model/viewable_tag_model.py
+++ b/ofrak_core/ofrak/model/viewable_tag_model.py
@@ -269,8 +269,8 @@ class ResourceViewInterface(metaclass=ViewableResourceTag):
         """
         raise NotImplementedError()
 
-    @classmethod
-    def create(cls: Type[RVI], resource_model: ResourceModel) -> RVI:
+    @classmethod  # pragma: no cover
+    def create(cls: Type[RVI], resource_model: ResourceModel) -> RVI:  # pragma: no cover
         raise NotImplementedError()
 
 

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
             "pytest-cov",
             "pytest-xdist",
             "requests",
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
         ],
     },
     author="Red Balloon Security",

--- a/ofrak_io/setup.py
+++ b/ofrak_io/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     extras_require={
         "test": [
             "black==22.3.0",
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "hypothesis~=6.39.3",
             "mypy==0.942",
             "pytest",

--- a/ofrak_patch_maker/setup.py
+++ b/ofrak_patch_maker/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "pytest",
             "pytest-cov",
         ]

--- a/ofrak_tutorial/setup.py
+++ b/ofrak_tutorial/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "nbval~=0.9.6",
             "pytest~=7.1.1",
         ]

--- a/ofrak_type/setup.py
+++ b/ofrak_type/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     extras_require={
         "test": [
             "black==22.3.0",
-            "fun-coverage==0.1.4",
+            "fun-coverage==0.2.0",
             "hypothesis~=6.39.3",
             "mypy==0.942",
             "pytest",


### PR DESCRIPTION
**Please describe the changes in your request.**
- Bump fun-coverage to 0.2.0
- Fix signature of function in resource_model.py
- Mark all methods of ResourceViewInterface as no cover (one was missed in #111)
- Bump ofrak function coverage to 97

**Anyone you think should look at this, specifically?**
