### PR TITLE
Remove MemoryOverlapError

### DIFF
--- a/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
@@ -1,24 +1,21 @@
 import logging
-from typing import Optional
-from ofrak_type.architecture import InstructionSetMode
-from ofrak.core.basic_block import BasicBlock
-from ofrak.core.data import DataWord
-from ofrak.core.memory_region import MemoryOverlapError
-from ofrak_angr.components.angr_analyzer import AngrAnalyzerConfig
-from ofrak_type.range import Range
 from typing import Iterable, Tuple
-
-from ofrak.service.resource_service_i import ResourceFilter
-from ofrak.core.code_region import CodeRegionUnpacker, CodeRegion
-from ofrak.core.complex_block import ComplexBlock, ComplexBlockUnpacker
-from ofrak.resource import Resource
-
-from ofrak_angr.components.identifiers import AngrAnalysisResource
-from ofrak_angr.model import AngrAnalysis
-
-from archinfo.arch_arm import get_real_address_if_arm
+from typing import Optional
 
 from angr.knowledge_plugins.functions.function import Function as AngrFunction
+from archinfo.arch_arm import get_real_address_if_arm
+from ofrak_type.architecture import InstructionSetMode
+from ofrak_type.range import Range
+
+from ofrak.core.basic_block import BasicBlock
+from ofrak.core.code_region import CodeRegionUnpacker, CodeRegion
+from ofrak.core.complex_block import ComplexBlock, ComplexBlockUnpacker
+from ofrak.core.data import DataWord
+from ofrak.resource import Resource
+from ofrak.service.resource_service_i import ResourceFilter
+from ofrak_angr.components.angr_analyzer import AngrAnalyzerConfig
+from ofrak_angr.components.identifiers import AngrAnalysisResource
+from ofrak_angr.model import AngrAnalysis
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,14 +36,7 @@ class AngrCodeRegionUnpacker(CodeRegionUnpacker):
         num_overlapping_cbs = 0
 
         for complex_block in self._angr_get_complex_blocks(angr_analysis, cr_vaddr_range):
-            try:
-                await cr_view.create_child_region(complex_block)
-            except MemoryOverlapError as e:
-                num_overlapping_cbs += 1
-                LOGGER.debug(
-                    f"Skipped complex block at {complex_block.virtual_address:#x} because that would have resulted in overlap: {e}"
-                )
-                continue
+            await cr_view.create_child_region(complex_block)
 
         if num_overlapping_cbs > 0:
             LOGGER.warning(

--- a/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/blocks/unpackers.py
@@ -5,21 +5,20 @@ from typing import Optional
 from warnings import warn
 
 from binaryninja import BinaryView, Endianness, TypeClass
-
-from ofrak_type.range import Range
 from ofrak_type.architecture import InstructionSetMode
-from ofrak.model.component_model import ComponentConfig
-from ofrak.service.resource_service_i import ResourceFilter
+from ofrak_type.range import Range
+
 from ofrak.core.architecture import ProgramAttributes
+from ofrak.core.basic_block import BasicBlock
 from ofrak.core.code_region import CodeRegionUnpacker, CodeRegion
 from ofrak.core.complex_block import ComplexBlock, ComplexBlockStructureError, ComplexBlockUnpacker
-from ofrak.core.basic_block import BasicBlock
-from ofrak.core.memory_region import MemoryOverlapError
-from ofrak.core.program import Program
 from ofrak.core.data import DataWord
+from ofrak.core.program import Program
+from ofrak.model.component_model import ComponentConfig
+from ofrak.resource import Resource
+from ofrak.service.resource_service_i import ResourceFilter
 from ofrak_binary_ninja.components.identifiers import BinaryNinjaAnalysisResource
 from ofrak_binary_ninja.model import BinaryNinjaAnalysis
-from ofrak.resource import Resource
 
 LOGGER = logging.getLogger(__name__)
 
@@ -49,16 +48,7 @@ class BinaryNinjaCodeRegionUnpacker(CodeRegionUnpacker):
             binaryview, region_start_vaddr, region_end_vaddr
         ):
             cb_view = ComplexBlock(cb_start_ea, cb_end_ea - cb_start_ea, cb_name)
-            try:
-                await region_view.create_child_region(
-                    cb_view, additional_attributes=(program_attrs,)
-                )
-            except MemoryOverlapError as e:
-                LOGGER.debug(
-                    f"Skipped complex block at {cb_start_ea:#x} because that would have resulted in overlap: {e}"
-                )
-                skip_count += 1
-                continue
+            await region_view.create_child_region(cb_view, additional_attributes=(program_attrs,))
 
         if skip_count > 0:
             LOGGER.warning(

--- a/ofrak_core/ofrak/core/memory_region.py
+++ b/ofrak_core/ofrak/core/memory_region.py
@@ -11,18 +11,6 @@ from ofrak_type.range import Range
 LOGGER = logging.getLogger(__file__)
 
 
-class MemoryOverlapError(RuntimeError):
-    """
-    Error raised when a memory region overlaps with an existing child memory region.
-    """
-
-    def __init__(self, new_region: "MemoryRegion", existing_region: "MemoryRegion"):
-        message = f"New MemoryRegion {new_region} overlaps with an existing child {existing_region}"
-        super().__init__(message)
-        self.new_region = new_region
-        self.existing_region = existing_region
-
-
 @dataclass
 class MemoryRegion(Addressable):
     """
@@ -103,7 +91,6 @@ class MemoryRegion(Addressable):
         :param child_mr: the child memory region
         :param additional_attributes: additional attributes passed to the child memory region
 
-        :raises OverlapError: if the child to be created overlaps with an existing child node
         :raises ValueError: if the child's end offset is larger than the memory region's size
         :return: the created child resource
         """

--- a/ofrak_core/test_ofrak/components/test_memory_region.py
+++ b/ofrak_core/test_ofrak/components/test_memory_region.py
@@ -1,0 +1,16 @@
+from ofrak.core import MemoryRegion
+
+
+def test_memory_region_str():
+    memory_region = MemoryRegion(0x100, 0x20)
+    assert str(memory_region) == "MemoryRegion(0x100-0x120)"
+
+
+def test_memory_region_hash():
+    region_a = MemoryRegion(0x40, 0x10)
+    region_b = MemoryRegion(0x40, 0x5)
+    region_c = MemoryRegion(0x100, 0x5)
+    memory_bank = {region_a, region_b}
+    assert region_a in memory_bank
+    assert region_b in memory_bank
+    assert region_c not in memory_bank


### PR DESCRIPTION
**Please describe the changes in your request.**
- Remove MemoryOverlapError (and its error handling). Like OverlapError(#144), this error is never raised
- Add unit tests for `MemoryRegion.{__str__, __hash__}`

**Anyone you think should look at this, specifically?**
@EdwardLarson 