### PR TITLE
Decouple patch maker from ofrak

### DIFF
--- a/ofrak_core/ofrak/core/architecture.py
+++ b/ofrak_core/ofrak/core/architecture.py
@@ -1,27 +1,13 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from ofrak.model.resource_model import ResourceAttributes
 
-from ofrak_type.architecture import InstructionSet, SubInstructionSet, ProcessorType
-from ofrak_type.bit_width import BitWidth
-from ofrak_type.endianness import Endianness
+from ofrak_type.architecture import ArchInfo
 
 
 @dataclass(**ResourceAttributes.DATACLASS_PARAMS)
-class ProgramAttributes(ResourceAttributes):
+class ProgramAttributes(ResourceAttributes, ArchInfo):
     """
     Analyzer output containing architecture attributes of a program.
 
-    :ivar isa: Instruction set architecture
-    :ivar sub_isa: Sub instruction set
-    :ivar bit_width: Bits per word
-    :ivar endianness: Endianness as `Endianness.BIG_ENDIAN` or `Endianness.LITTLE_ENDIAN`
-    :ivar processor: Processor type
     """
-
-    isa: InstructionSet
-    sub_isa: Optional[SubInstructionSet]
-    bit_width: BitWidth
-    endianness: Endianness
-    processor: Optional[ProcessorType]

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -99,6 +99,7 @@ class OFRAK:
         logging.basicConfig(level=logging_level, format="[%(filename)15s:%(lineno)5s] %(message)s")
         logging.getLogger().addHandler(logging.FileHandler("/tmp/ofrak.log"))
         logging.getLogger().setLevel(logging_level)
+        logging.captureWarnings(True)
         self.injector = DependencyInjector()
         self._discovered_modules: List[ModuleType] = []
         self._exclude_components_missing_dependencies = exclude_components_missing_dependencies

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -54,6 +54,7 @@ setuptools.setup(
             "mkdocs-material==7.3.3",
             "mkdocs_gen_files==0.3.3",
             "jinja2==3.0.0",
+            "pytkdocs>=0.12.0",
             "PyYAML~=6.0,>=5.4",
         ],
         "test": [

--- a/ofrak_patch_maker/ofrak_patch_maker/model.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/model.py
@@ -36,6 +36,7 @@ class AssembledObject:
     file_format: BinFileType
     segment_map: Mapping[str, Segment]  # segment name to Segment
     symbols: Mapping[str, int]
+    bss_size_required: int
 
 
 @dataclass(frozen=True)
@@ -115,3 +116,4 @@ class BOM:
     object_map: Mapping[str, AssembledObject]
     bss_size_required: int
     entry_point_symbol: Optional[str]
+    segment_alignment: int

--- a/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
@@ -36,6 +36,7 @@ import os
 import tempfile
 from types import ModuleType
 from typing import Optional, List, Dict, Union, Tuple, Iterable, Mapping
+from warnings import warn
 
 from immutabledict import immutabledict
 
@@ -484,8 +485,9 @@ class PatchMaker:
         allocatable,
         bom: BOM,
     ) -> PatchRegionConfig:
-        # raise DeprecationWarning(
-        #     "PatchMaker.allocate_bom(allocatable, bom) is deprecated! Use "
-        #     "allocatable.allocate_bom(bom) instead."
-        # )
+        warn(
+            "PatchMaker.allocate_bom(allocatable, bom) is deprecated! Use "
+            "allocatable.allocate_bom(bom) instead.",
+            category=DeprecationWarning,
+        )
         return await allocatable.allocate_bom(bom)

--- a/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/patch_maker.py
@@ -40,7 +40,7 @@ from typing import Optional, List, Dict, Union, Tuple, Iterable, Mapping
 
 from immutabledict import immutabledict
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak.core.free_space import (
     Allocatable,
 )
@@ -64,7 +64,7 @@ from ofrak_type.memory_permissions import MemoryPermissions
 class PatchMaker:
     def __init__(
         self,
-        program_attributes: ProgramAttributes,
+        program_attributes: ArchInfo,
         toolchain_config: ToolchainConfig,
         toolchain_version: ToolchainVersion,
         platform_includes: Optional[Iterable[str]] = None,
@@ -125,7 +125,7 @@ class PatchMaker:
 
     @staticmethod
     def _get_toolchain(
-        program_attributes: ProgramAttributes,
+        program_attributes: ArchInfo,
         toolchain_config: ToolchainConfig,
         toolchain_version: ToolchainVersion,
         logger: Union[logging.Logger, ModuleType] = logging,

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from os.path import join, split
 from typing import Dict, Iterable, List, Optional, Tuple, Mapping
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.binary_parser.abstract import AbstractBinaryFileParser
 from ofrak_patch_maker.toolchain.model import Segment, ToolchainConfig
 from ofrak_patch_maker.toolchain.utils import get_repository_config
@@ -32,7 +32,7 @@ class Toolchain(ABC):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(),
     ):
@@ -106,7 +106,7 @@ class Toolchain(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def _get_assembler_target(self, processor: ProgramAttributes) -> str:
+    def _get_assembler_target(self, processor: ArchInfo) -> str:
         """
         Red Balloon Security strongly recommends all users provide their specific hardware target
         for best results.
@@ -121,7 +121,7 @@ class Toolchain(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def _get_compiler_target(self, processor: ProgramAttributes) -> Optional[str]:
+    def _get_compiler_target(self, processor: ArchInfo) -> Optional[str]:
         """
         Returns a default compiler target for the provided processor unless one is provided
         in `self._config`.

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
@@ -216,6 +216,16 @@ class Toolchain(ABC):
         """
         return self._config.relocatable
 
+    @property
+    def segment_alignment(self) -> int:
+        """
+        For example, x86 returns 16. This will most often be used when programmatically allocating
+        memory for code/data.
+
+        :return int: required alignment factor for the toolchain/ISA
+        """
+        return 1
+
     def _execute_tool(
         self,
         tool_path: str,
@@ -457,15 +467,6 @@ class Toolchain(ABC):
         :return str: path to the generated linker script
         """
         raise NotImplementedError()
-
-    def get_required_alignment(self, segment: Segment) -> int:
-        """
-        For example, x86 returns 16. This will most often be used when programmatically allocating
-        memory for code/data.
-
-        :return int: required alignment factor for the toolchain/ISA
-        """
-        return 1
 
     def get_bin_file_symbols(self, executable_path: str) -> Dict[str, int]:
         """

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -42,7 +42,7 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
                 #      where we allocated them... e.g. hooks.
                 # The downside is that it applies to all functions in a
                 #      section, so our manual alignment of sections with
-                #      get_required_alignment() doesn't quite make up for it
+                #      segment_alignment doesn't quite make up for it
                 #      if sections contain more than one function =/
                 "-fno-merge-constants",  # avoids sections like .rodata.cst16, .rodata.str1.1 etc
                 "-fno-reorder-functions",
@@ -328,7 +328,8 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
 
         return ld_script_path
 
-    def get_required_alignment(self, segment: Segment) -> int:
+    @property
+    def segment_alignment(self) -> int:
         if self._processor.isa == InstructionSet.X86:
             return 16
         return 1
@@ -499,7 +500,8 @@ class GNU_M68K_LINUX_10_Toolchain(GNU_10_Toolchain):
     def name(self):
         return "GNU_M68K_LINUX_10"
 
-    def get_required_alignment(self, segment: Segment) -> int:
+    @property
+    def segment_alignment(self) -> int:
         return 4
 
     def _get_assembler_target(self, processor: ArchInfo):
@@ -557,7 +559,8 @@ class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
     def name(self):
         return "GNU_AARCH64_LINUX_10"
 
-    def get_required_alignment(self, segment: Segment) -> int:
+    @property
+    def segment_alignment(self) -> int:
         return 4
 
     def _ld_generate_got_region(self, vm_address, length):
@@ -661,5 +664,6 @@ class GNU_AVR_5_Toolchain(Abstract_GNU_Toolchain):
             return self._config.assembler_target
         return InstructionSet.AVR.value.lower()
 
-    def get_required_alignment(self, segment: Segment) -> int:
+    @property
+    def segment_alignment(self) -> int:
         return 2

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -5,7 +5,7 @@ from abc import ABC
 from typing import Iterable, List, Mapping, Optional, Tuple, Dict
 from warnings import warn
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_type.architecture import InstructionSet, SubInstructionSet
 from ofrak_patch_maker.binary_parser.gnu import GNU_ELF_Parser, GNU_V10_ELF_Parser
 from ofrak_patch_maker.toolchain.abstract import Toolchain, RBS_AUTOGEN_WARNING
@@ -23,7 +23,7 @@ from ofrak_type.memory_permissions import MemoryPermissions
 class Abstract_GNU_Toolchain(Toolchain, ABC):
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -106,7 +106,7 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
     def name(self) -> str:
         raise NotImplementedError()
 
-    def _get_compiler_target(self, processor: ProgramAttributes) -> Optional[str]:
+    def _get_compiler_target(self, processor: ArchInfo) -> Optional[str]:
         return self._config.compiler_target
 
     @property
@@ -354,7 +354,7 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
 class GNU_10_Toolchain(Abstract_GNU_Toolchain):
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -385,7 +385,7 @@ class GNU_ARM_NONE_EABI_10_2_1_Toolchain(GNU_10_Toolchain):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -399,7 +399,7 @@ class GNU_ARM_NONE_EABI_10_2_1_Toolchain(GNU_10_Toolchain):
     def name(self):
         return "GNU_ARM_NONE"
 
-    def _get_assembler_target(self, processor: ProgramAttributes):
+    def _get_assembler_target(self, processor: ArchInfo):
         """
         Thumb mode should be defined in the assembler source at the top, using:
 
@@ -427,7 +427,7 @@ class GNU_X86_64_LINUX_EABI_10_3_0_Toolchain(GNU_10_Toolchain):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -447,7 +447,7 @@ class GNU_X86_64_LINUX_EABI_10_3_0_Toolchain(GNU_10_Toolchain):
     def name(self) -> str:
         return "GNU_X86_64_LINUX"
 
-    def _get_assembler_target(self, processor: ProgramAttributes):
+    def _get_assembler_target(self, processor: ArchInfo):
         if self._config.assembler_target:
             return self._config.assembler_target
         return "generic64"
@@ -485,7 +485,7 @@ class GNU_M68K_LINUX_10_Toolchain(GNU_10_Toolchain):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -502,7 +502,7 @@ class GNU_M68K_LINUX_10_Toolchain(GNU_10_Toolchain):
     def get_required_alignment(self, segment: Segment) -> int:
         return 4
 
-    def _get_assembler_target(self, processor: ProgramAttributes):
+    def _get_assembler_target(self, processor: ArchInfo):
         if processor.isa is not InstructionSet.M68K:
             raise ValueError(
                 f"The GNU M68K toolchain does not support ISAs which are not M68K; "
@@ -545,7 +545,7 @@ class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -603,7 +603,7 @@ class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
             f"    }} > {memory_region_name}"
         )
 
-    def _get_assembler_target(self, processor: ProgramAttributes):
+    def _get_assembler_target(self, processor: ArchInfo):
         if processor.isa is not InstructionSet.AARCH64:
             raise ValueError(
                 f"The GNU AARCH64 toolchain does not support ISAs which are not AARCH64; "
@@ -619,7 +619,7 @@ class GNU_AVR_5_Toolchain(Abstract_GNU_Toolchain):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -651,7 +651,7 @@ class GNU_AVR_5_Toolchain(Abstract_GNU_Toolchain):
     def name(self) -> str:
         return "GNU_AVR_5"
 
-    def _get_assembler_target(self, processor: ProgramAttributes) -> str:
+    def _get_assembler_target(self, processor: ArchInfo) -> str:
         if processor.isa is not InstructionSet.AVR:
             raise ValueError(
                 f"The GNU AVR toolchain does not support ISAs which are not AVR; "

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/llvm_12.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/llvm_12.py
@@ -284,7 +284,8 @@ class LLVM_12_0_1_Toolchain(Toolchain):
 
         return ld_script_path
 
-    def get_required_alignment(self, segment: Segment) -> int:
+    @property
+    def segment_alignment(self) -> int:
         # The linker will align function starts to 16-byte boundaries
         # https://patchwork.kernel.org/project/kernel-hardening/patch/20200205223950.1212394-7-kristen@linux.intel.com/
         # Plus, some other memory will also be aligned to 16

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/llvm_12.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/llvm_12.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 from typing import List, Mapping, Optional, Tuple, Dict
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.binary_parser.llvm import LLVM_ELF_Parser, LLVM_MACH_O_Parser
 from ofrak_patch_maker.toolchain.abstract import Toolchain, RBS_AUTOGEN_WARNING
 from ofrak_patch_maker.toolchain.model import (
@@ -23,7 +23,7 @@ class LLVM_12_0_1_Toolchain(Toolchain):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -114,7 +114,7 @@ class LLVM_12_0_1_Toolchain(Toolchain):
     def name(self) -> str:
         return "LLVM_12_0_1"
 
-    def _get_assembler_target(self, processor: ProgramAttributes) -> str:
+    def _get_assembler_target(self, processor: ArchInfo) -> str:
         arch = processor.isa.value
         if self._config.assembler_target:
             return self._config.assembler_target
@@ -125,7 +125,7 @@ class LLVM_12_0_1_Toolchain(Toolchain):
         else:
             raise ToolchainException("Assembler Target not provided and no valid default found!")
 
-    def _get_compiler_target(self, processor: ProgramAttributes) -> Optional[str]:
+    def _get_compiler_target(self, processor: ArchInfo) -> Optional[str]:
         arch = processor.isa.value
         if self._config.compiler_target:
             return self._config.compiler_target

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/vbcc_gnu_hybrid.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/vbcc_gnu_hybrid.py
@@ -8,7 +8,7 @@ import re
 
 from ofrak_patch_maker.toolchain.gnu import Abstract_GNU_Toolchain
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_type.architecture import InstructionSet
 from ofrak_patch_maker.binary_parser.gnu import GNU_ELF_Parser
 from ofrak_patch_maker.toolchain.model import (
@@ -27,7 +27,7 @@ class VBCC_0_9_GNU_Hybrid_Toolchain(Abstract_GNU_Toolchain, ABC):
 
     def __init__(
         self,
-        processor: ProgramAttributes,
+        processor: ArchInfo,
         toolchain_config: ToolchainConfig,
         logger: logging.Logger = logging.getLogger(__name__),
     ):
@@ -164,7 +164,7 @@ class VBCC_0_9_GNU_Hybrid_Toolchain(Abstract_GNU_Toolchain, ABC):
         self._make_gas_compatible(out_file)
         return self.assemble(out_file, header_dirs, out_dir)
 
-    def _get_assembler_target(self, processor: ProgramAttributes):
+    def _get_assembler_target(self, processor: ArchInfo):
         if processor.isa is not InstructionSet.M68K:
             raise ValueError(
                 f"The GNU M68K toolchain does not support ISAs which are not M68K; "

--- a/ofrak_patch_maker/ofrak_patch_maker_test/__init__.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/__init__.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.toolchain.version import ToolchainVersion
 
 CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
@@ -10,5 +10,5 @@ CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 @dataclass
 class ToolchainUnderTest:
     toolchain_version: ToolchainVersion
-    proc: ProgramAttributes
+    proc: ArchInfo
     extension: str

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_aarch64_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_aarch64_toolchain.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.model import (
@@ -35,7 +35,7 @@ AARCH64_EXTENSION = ".aarch64"
     params=[
         ToolchainUnderTest(
             ToolchainVersion.GNU_AARCH64_LINUX_10,
-            ProgramAttributes(
+            ArchInfo(
                 InstructionSet.AARCH64,
                 None,
                 BitWidth.BIT_64,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_arm_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_arm_toolchain.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.model import (
@@ -36,7 +36,7 @@ ARM_EXTENSION = ".arm"
     params=[
         ToolchainUnderTest(
             ToolchainVersion.GNU_ARM_NONE_EABI_10_2_1,
-            ProgramAttributes(
+            ArchInfo(
                 InstructionSet.ARM,
                 SubInstructionSet.ARMv8A,
                 BitWidth.BIT_32,
@@ -47,7 +47,7 @@ ARM_EXTENSION = ".arm"
         ),
         ToolchainUnderTest(
             ToolchainVersion.LLVM_12_0_1,
-            ProgramAttributes(
+            ArchInfo(
                 InstructionSet.ARM,
                 SubInstructionSet.ARMv8A,
                 BitWidth.BIT_32,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_avr_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_avr_toolchain.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.toolchain.version import ToolchainVersion
 from ofrak_patch_maker_test import ToolchainUnderTest
 from ofrak_patch_maker_test.toolchain_asm import (
@@ -22,7 +22,7 @@ AVR_EXTENSION = ".avr"
     params=[
         ToolchainUnderTest(
             ToolchainVersion.GNU_AVR_5,
-            ProgramAttributes(
+            ArchInfo(
                 InstructionSet.AVR,
                 SubInstructionSet.AVR2,
                 BitWidth.BIT_32,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_m68k_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_m68k_toolchain.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.model import (
@@ -35,7 +35,7 @@ M68K_EXTENSION = ".m68k"
     params=[
         ToolchainUnderTest(
             ToolchainVersion.GNU_M68K_LINUX_10,
-            ProgramAttributes(
+            ArchInfo(
                 InstructionSet.M68K,
                 None,
                 BitWidth.BIT_32,
@@ -46,7 +46,7 @@ M68K_EXTENSION = ".m68k"
         ),
         ToolchainUnderTest(
             ToolchainVersion.VBCC_M68K_0_9,
-            ProgramAttributes(
+            ArchInfo(
                 InstructionSet.M68K,
                 None,
                 BitWidth.BIT_32,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_x86_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_x86_toolchain.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.toolchain.version import ToolchainVersion
 from ofrak_patch_maker_test import ToolchainUnderTest
 from ofrak_patch_maker_test.toolchain_c import run_hello_world_test, run_bounds_check_test
@@ -18,7 +18,7 @@ X86_EXTENSION = ".x86"
     params=[
         ToolchainUnderTest(
             ToolchainVersion.GNU_X86_64_LINUX_EABI_10_3_0,
-            ProgramAttributes(
+            ArchInfo(
                 InstructionSet.X86,
                 None,
                 BitWidth.BIT_32,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/toolchain_asm.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/toolchain_asm.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.model import (
@@ -18,7 +18,7 @@ from ofrak_type.memory_permissions import MemoryPermissions
 
 
 def run_challenge_3_reloc_toy_example_test(
-    toolchain: ToolchainVersion, proc: ProgramAttributes, extension: str
+    toolchain: ToolchainVersion, proc: ArchInfo, extension: str
 ):
     """
     Example solution patch for bounds_check challenge.
@@ -171,7 +171,7 @@ def run_challenge_3_reloc_toy_example_test(
     assert get_file_format(exec_path) == tc_config.file_format
 
 
-def run_monkey_patch_test(toolchain: ToolchainVersion, proc: ProgramAttributes, extension: str):
+def run_monkey_patch_test(toolchain: ToolchainVersion, proc: ArchInfo, extension: str):
     """
     Example showing how to manually generate an executable with assembly at client-specified locs.
     """

--- a/ofrak_patch_maker/ofrak_patch_maker_test/toolchain_c.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/toolchain_c.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 
 
-from ofrak.core.architecture import ProgramAttributes
+from ofrak_type import ArchInfo
 from ofrak_type.architecture import InstructionSet
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
@@ -18,7 +18,7 @@ from ofrak_patch_maker.toolchain.version import ToolchainVersion
 from ofrak_type.memory_permissions import MemoryPermissions
 
 
-def run_bounds_check_test(toolchain: ToolchainVersion, proc: ProgramAttributes):
+def run_bounds_check_test(toolchain: ToolchainVersion, proc: ArchInfo):
     """
     Example solution patch for bounds_check challenge.
     """
@@ -87,7 +87,7 @@ def run_bounds_check_test(toolchain: ToolchainVersion, proc: ProgramAttributes):
     assert get_file_format(exec_path) == tc_config.file_format
 
 
-def run_hello_world_test(toolchain: ToolchainVersion, proc: ProgramAttributes):
+def run_hello_world_test(toolchain: ToolchainVersion, proc: ArchInfo):
     """
     Make sure we can run the toolchain components without falling over.
     """

--- a/ofrak_tutorial/notebooks_with_outputs/6_code_insertion_with_extension.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/6_code_insertion_with_extension.ipynb
@@ -694,7 +694,7 @@
       "bss_size_required:             0\n",
       "entry_point_symbol (optional): None\n",
       "\n",
-      "object map[c_patch]:           AssembledObject(path='/tmp/tmplw4ax4l2/hello_world_patch_bom_files/c_patch.c.o', file_format=<BinFileType.ELF: 'elf'>, segment_map=immutabledict({'': Segment(segment_name='', vm_address=0, offset=0, is_entry=False, length=0, access_perms=<MemoryPermissions.R: 4>), '.strtab': Segment(segment_name='.strtab', vm_address=0, offset=280, is_entry=False, length=88, access_perms=<MemoryPermissions.R: 4>), '.text': Segment(segment_name='.text', vm_address=0, offset=64, is_entry=False, length=69, access_perms=<MemoryPermissions.RX: 5>), '.rela.text': Segment(segment_name='.rela.text', vm_address=0, offset=256, is_entry=False, length=24, access_perms=<MemoryPermissions.R: 4>), '.comment': Segment(segment_name='.comment', vm_address=0, offset=133, is_entry=False, length=22, access_perms=<MemoryPermissions.R: 4>), '.note.GNU-stack': Segment(segment_name='.note.GNU-stack', vm_address=0, offset=155, is_entry=False, length=0, access_perms=<MemoryPermissions.R: 4>), '.symtab': Segment(segment_name='.symtab', vm_address=0, offset=160, is_entry=False, length=96, access_perms=<MemoryPermissions.R: 4>)}), symbols=immutabledict({'c_patch.c': 0, 'uppercase_and_print': 0}))\n",
+      "object map[c_patch]:           AssembledObject(path='/tmp/tmpmz0h8jm6/hello_world_patch_bom_files/c_patch.c.o', file_format=<BinFileType.ELF: 'elf'>, segment_map=immutabledict({'.text': Segment(segment_name='.text', vm_address=0, offset=64, is_entry=False, length=69, access_perms=<MemoryPermissions.RX: 5>)}), symbols=immutabledict({'c_patch.c': 0, 'uppercase_and_print': 0}), bss_size_required=0)\n",
       "\n"
      ]
     }

--- a/ofrak_type/ofrak_type/__init__.py
+++ b/ofrak_type/ofrak_type/__init__.py
@@ -1,0 +1,6 @@
+from ofrak_type.architecture import *
+from ofrak_type.bit_width import *
+from ofrak_type.endianness import *
+from ofrak_type.error import *
+from ofrak_type.memory_permissions import *
+from ofrak_type.range import *

--- a/ofrak_type/ofrak_type/architecture.py
+++ b/ofrak_type/ofrak_type/architecture.py
@@ -1,4 +1,10 @@
 from enum import Enum
+from typing import Optional
+
+from dataclasses import dataclass
+
+from ofrak_type.bit_width import BitWidth
+from ofrak_type.endianness import Endianness
 
 
 class InstructionSet(Enum):
@@ -147,3 +153,22 @@ class ProcessorType(Enum):
     COLDFIRE4E = "cfv4e"
     CORTEX_A53 = "cortex-a53"
     AVR = "avr"
+
+
+@dataclass(frozen=True, eq=True)
+class ArchInfo:
+    """
+    Collection of fields used to describe an architecture
+
+    :ivar isa: Instruction set architecture
+    :ivar sub_isa: Sub instruction set
+    :ivar bit_width: Bits per word
+    :ivar endianness: Endianness as `Endianness.BIG_ENDIAN` or `Endianness.LITTLE_ENDIAN`
+    :ivar processor: Processor type
+    """
+
+    isa: InstructionSet
+    sub_isa: Optional[SubInstructionSet]
+    bit_width: BitWidth
+    endianness: Endianness
+    processor: Optional[ProcessorType]


### PR DESCRIPTION
**Link to Related Issue(s)**
`ofrak_patch_maker`'s dependency on OFRAK created a circular dependency. This wasn't necessarily problematic as pip handled it gracefully, but it did preclude a "lightweight" patch maker install without OFRAK.

**Please describe the changes in your request.**

Things were moved/refactored so that `ofrak_patch_maker` doesn't import from `ofrak`.

* `ProgramAttributes` gets a superclass `ArchInfo` defined in `ofrak_type` so that we don't rely on a `ResourceAttributes` for just grouping arch information
* The `BOM` and `AssembledObject` get some additional fields to include enough information that we don't need to call out to a `Toolchain` after creation - required BSS size and alignment, specifically
* The `get_required_alignment` method in `Toolchain` is also changed a bit, to a property, to support this
* `allocate_bom` was moved to `Allocatable`

**Anyone you think should look at this, specifically?**
@andresito00 