### PR TITLE
add missing "raise"s to errors which were only instantiated but not r…

### DIFF
--- a/ofrak_core/pytest_ofrak/patterns/pack_unpack_filesystem.py
+++ b/ofrak_core/pytest_ofrak/patterns/pack_unpack_filesystem.py
@@ -38,7 +38,7 @@ class FilesystemPackUnpackVerifyPattern(ABC):
                     self.verify_filesystem_equality(root_path, extract_dir)
         except CalledProcessError as e:
             # Better printing of errors if something goes wrong in test setup/execution
-            ComponentSubprocessError(e)
+            raise ComponentSubprocessError(e)
 
     def _dirs_from_list(self, parent, names, depth):
         # Create a file

--- a/ofrak_core/pytest_ofrak/patterns/unpack_modify_pack.py
+++ b/ofrak_core/pytest_ofrak/patterns/unpack_modify_pack.py
@@ -42,7 +42,7 @@ class UnpackModifyPackPattern(ABC):
             await self.verify(root_resource)
         except CalledProcessError as e:
             # Better printing of errors if something goes wrong in test setup/execution
-            ComponentSubprocessError(e)
+            raise ComponentSubprocessError(e)
 
     @abstractmethod
     async def create_root_resource(self, ofrak_context: OFRAKContext) -> Resource:


### PR DESCRIPTION
…aised

**Link to Related Issue(s)**

When something fails when setting up the test pattern, the error should be raised. A couple of places missed having the `raise` keyword so the exception object was just created but to no end; the tests therefore erroneously passed even if a command failed during setup.

**Please describe the changes in your request.**
Add missing `raise` keyword

**Anyone you think should look at this, specifically?**
