### PR TITLE
Use Ghidra exclusively for examples, test that examples work in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 **/Dockerstub
-examples/Makefile
 **/.git*
 **/.mypy_cache
 **/*.egg-info

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -186,7 +186,7 @@ jobs:
             -c "make -C /ofrak_angr test && make -C /ofrak_capstone test"
 
   ofrak-tutorial:
-    name: Test OFRAK tutorial notebooks
+    name: Test OFRAK examples and tutorial notebooks
     runs-on: ubuntu-latest
     needs: build-base-image
     steps:
@@ -227,4 +227,5 @@ jobs:
             --entrypoint bash \
             redballoonsecurity/ofrak/tutorial:latest \
             -c "python -m ofrak_ghidra.server start \
+                && make -C /examples test \
                 && make -C /ofrak_tutorial test"

--- a/examples/Dockerstub
+++ b/examples/Dockerstub
@@ -1,2 +1,0 @@
-ARG OFRAK_DIR=.
-ADD $OFRAK_DIR/examples /examples

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,16 @@
+PYTHON=python3
+PIP=pip3
+
+.PHONY: install
 install:
 
+.PHONY: develop
 develop:
 
+.PHONY: test
+test:
+	$(PYTHON) -m pytest test_examples.py
+
+.PHONY: dependencies
 dependencies:
 	# Nothing to install

--- a/examples/ex2_simple_code_modification.py
+++ b/examples/ex2_simple_code_modification.py
@@ -12,7 +12,7 @@ int main() {
 ```
 
 The example performs code modification in the input binary (without extension). It leverages
-BinaryNinja to analyze the executable binary, and Keystone to rewrite an instruction so that the
+Ghidra to analyze the executable binary, and Keystone to rewrite an instruction so that the
 binary loops back to its beginning instead of returning and exiting at the end of the main function.
 
 Someone is chasing its tail and never catching it 😹
@@ -21,7 +21,6 @@ import argparse
 import os
 
 import ofrak_ghidra
-import ofrak_capstone
 from ofrak import OFRAK, OFRAKContext, ResourceFilter, ResourceAttributeValueFilter
 from ofrak.core import (
     ProgramAttributes,
@@ -88,6 +87,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     ofrak = OFRAK()
-    ofrak.injector.discover(ofrak_capstone)
     ofrak.injector.discover(ofrak_ghidra)
     ofrak.run(main, args.hello_world_file, args.output_file_name)

--- a/examples/ex6_code_modification_without_extension.py
+++ b/examples/ex6_code_modification_without_extension.py
@@ -40,7 +40,7 @@ import logging
 import os
 import tempfile
 
-import ofrak_binary_ninja
+import ofrak_ghidra
 from ofrak import OFRAK, OFRAKContext, ResourceFilter, ResourceAttributeValueFilter
 from ofrak.core import (
     ProgramAttributes,
@@ -181,5 +181,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     ofrak = OFRAK()
-    ofrak.discover(ofrak_binary_ninja)
+    ofrak.discover(ofrak_ghidra)
     ofrak.run(main, args.hello_world_file, args.print_kitteh_source, args.output_file_name)

--- a/ofrak-tutorial.yml
+++ b/ofrak-tutorial.yml
@@ -10,6 +10,7 @@ packages_paths:
     "disassemblers/ofrak_ghidra",
     "frontend",
     "ofrak_tutorial",
+    "examples"
   ]
 entrypoint: |
     python -m ofrak_ghidra.server start \


### PR DESCRIPTION
**Please describe the changes in your request.**
Refactor example scripts to use Ghidra. Test these examples in CI.

Note that this PR is possible because of #139. Examples 5 and 7 have to account for the discrepancy between the PIE-Elf addresses and the virtual addresses supplied by Ghidra. A more elegant solution, which would not need this workaround, is beyond the scope of this PR: for now, it is advantageous to be able to run the examples in CI and have users run them with publicly available software (examples previously used Binary Ninja backend).

**Anyone you think should look at this, specifically?**
@SamL98, FYI. @EdwardLarson 