### PR TITLE
PIE support for Angr

### DIFF
--- a/disassemblers/ofrak_angr/ofrak_angr/components/angr_analyzer.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/angr_analyzer.py
@@ -106,5 +106,10 @@ class AngrCodeRegionModifier(Modifier):
             angr_analysis = await root_resource.analyze(AngrAnalysis)
             obj = angr_analysis.project.loader.main_object
 
-            new_cr = CodeRegion(code_region.virtual_address + obj.min_addr, code_region.size)
-            code_region.resource.add_view(new_cr)
+            if obj is not None:
+                new_cr = CodeRegion(code_region.virtual_address + obj.min_addr, code_region.size)
+                code_region.resource.add_view(new_cr)
+            else:
+                LOGGER.warning(
+                    f"There is no angr main object for resource {root_resource}. Something went wrong."
+                )

--- a/disassemblers/ofrak_angr/ofrak_angr/components/angr_analyzer.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/angr_analyzer.py
@@ -9,6 +9,7 @@ from ofrak.model.resource_model import ResourceAttributeDependency
 from ofrak.resource import Resource
 
 import angr.project
+from ofrak.core.elf.model import Elf, ElfHeader, ElfType
 from ofrak_angr.components.identifiers import AngrAnalysisResource
 from ofrak_angr.model import AngrAnalysis
 from ofrak.component.modifier import Modifier
@@ -83,37 +84,31 @@ class AngrCodeRegionModifier(Modifier):
     id = b"AngrCodeRegionModifier"
     targets = (CodeRegion,)
 
-    async def modify(self, resource: Resource, config: Optional[AngrCodeRegionModifierConfig]):
+    async def modify(self, resource: Resource, config=None):
         code_region  = await resource.view_as(CodeRegion)
-        obj = config.angr_analysis.project.loader.main_object
 
-        program = await resource.get_only_ancestor_as_view(
-            Program, r_filter=ResourceFilter(tags=[Program])
+        root_resource = await resource.get_only_ancestor(
+            ResourceFilter(tags=[AngrAnalysisResource], include_self=True)
         )
 
-        ofrak_code_regions = await program.resource.get_descendants_as_view(
-            CodeRegion, r_filter=ResourceFilter(tags=[CodeRegion])
-        )
-        backend_code_regions = [CodeRegion(s.vaddr, s.memsize) for s in obj.segments]
+        fixup_address = False
 
-        ofrak_code_regions = sorted(ofrak_code_regions, key=lambda cr: cr.virtual_address)
-        backend_code_regions = sorted(backend_code_regions, key=lambda cr: cr.virtual_address)
-
-        if len(ofrak_code_regions) > 0:
-            relative_va = code_region.virtual_address - ofrak_code_regions[0].virtual_address
-
-            for backend_cr in backend_code_regions:
-                backend_relative_va = (
-                    backend_cr.virtual_address - backend_code_regions[0].virtual_address
-                )
-
-                if backend_relative_va == relative_va and backend_cr.size == code_region.size:
-                    resource.add_view(backend_cr)
-                    return
-
-            LOGGER.debug(
-                f"No code region with relative offset {relative_va} and size {code_region.size} found in Angr"
+        # We only want to adjust the address of a CodeRegion if the original binary is position-independent.
+        # Implement PIE-detection for other file types as necessary.
+        if root_resource.has_tag(Elf):
+            elf_header = await root_resource.get_only_descendant_as_view(
+                ElfHeader, r_filter=ResourceFilter(tags=[ElfHeader])
             )
+
+            if elf_header is not None and elf_header.e_type == ElfType.ET_DYN.value:
+                fixup_address = True
         else:
-            LOGGER.debug("No OFRAK code regions to match in Angr")
+            LOGGER.warning(f"Have not implemented PIE-detection for {root_resource}. The address of {code_region} will likely be incorrect.")
+
+        if fixup_address:
+            angr_analysis = await root_resource.analyze(AngrAnalysis)
+            obj = angr_analysis.project.loader.main_object
+
+            new_cr = CodeRegion(code_region.virtual_address + obj.min_addr, code_region.size)
+            code_region.resource.add_view(new_cr)
 

--- a/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
@@ -32,7 +32,6 @@ class AngrCodeRegionUnpacker(CodeRegionUnpacker):
         angr_analysis = await root_resource.analyze(AngrAnalysis)
 
         ## Fixup the CodeRegion's virtual address after analyzing with angr.
-        # await resource.run(AngrCodeRegionModifier, AngrCodeRegionModifierConfig(angr_analysis))
         await resource.run(AngrCodeRegionModifier, None)
 
         cr_vaddr_range = cr_view.vaddr_range()

--- a/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
@@ -26,6 +26,9 @@ LOGGER = logging.getLogger(__name__)
 
 class AngrCodeRegionUnpacker(CodeRegionUnpacker):
     async def unpack(self, resource: Resource, config: Optional[AngrAnalyzerConfig] = None):
+        ## Prepare CR unpacker
+        cr_view = await resource.view_as(CodeRegion)
+
         ## Run AngrAnalyzer
         root_resource = await resource.get_only_ancestor(
             ResourceFilter(tags=[AngrAnalysisResource], include_self=True)
@@ -33,10 +36,9 @@ class AngrCodeRegionUnpacker(CodeRegionUnpacker):
         angr_analysis = await root_resource.analyze(AngrAnalysis)
 
         ## Fixup the CodeRegion's virtual address after analyzing with angr.
-        await resource.run(AngrCodeRegionModifier, AngrCodeRegionModifierConfig(angr_analysis))
+        # await resource.run(AngrCodeRegionModifier, AngrCodeRegionModifierConfig(angr_analysis))
+        await resource.run(AngrCodeRegionModifier, None)
 
-        ## Prepare CR unpacker
-        cr_view = await resource.view_as(CodeRegion)
         cr_vaddr_range = cr_view.vaddr_range()
 
         ## Fetch and create complex blocks to populate the CR with

--- a/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
@@ -13,11 +13,7 @@ from ofrak.core.complex_block import ComplexBlock, ComplexBlockUnpacker
 from ofrak.core.data import DataWord
 from ofrak.resource import Resource
 from ofrak.service.resource_service_i import ResourceFilter
-from ofrak_angr.components.angr_analyzer import (
-    AngrAnalyzerConfig, 
-    AngrCodeRegionModifierConfig, 
-    AngrCodeRegionModifier
-)
+from ofrak_angr.components.angr_analyzer import AngrAnalyzerConfig, AngrCodeRegionModifier
 from ofrak_angr.components.identifiers import AngrAnalysisResource
 from ofrak_angr.model import AngrAnalysis
 


### PR DESCRIPTION
Uses PIE detection for ELF's to fixup the virtual address of CodeRegion's. Support for other filetypes (PE, Mach-O, etc.) should be added as needed.
