### PR TITLE
Add cross-browser checkbox component

### DIFF
--- a/frontend/src/Checkbox.svelte
+++ b/frontend/src/Checkbox.svelte
@@ -1,0 +1,53 @@
+<style>
+  label {
+    margin-left: 1em;
+    margin-right: 1em;
+    display: inline-flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center;
+    align-content: stretch;
+    white-space: nowrap;
+    user-select: none;
+    cursor: pointer;
+  }
+
+  label input[type="checkbox"] {
+    display: none;
+  }
+
+  label input[type="checkbox"] + span {
+    width: 1em;
+    height: 1em;
+    background: var(--main-bg-color);
+    color: var(--main-fg-color);
+    border: 1px solid var(--main-fg-color);
+    margin-left: 2ch;
+    box-sizing: content-box;
+  }
+
+  label input[type="checkbox"]:checked + span::after {
+    content: "";
+    display: block;
+    position: relative;
+    margin: 0.25em;
+    width: 0.5em;
+    height: 0.5em;
+    color: var(--main-fg-color);
+    background: var(--main-fg-color);
+    border: none;
+  }
+</style>
+
+<script>
+  export let checked, value;
+
+  $: value = checked;
+</script>
+
+<label>
+  <slot />
+  <input type="checkbox" bind:checked="{checked}" />
+  <span></span>
+</label>

--- a/frontend/src/FindReplaceView.svelte
+++ b/frontend/src/FindReplaceView.svelte
@@ -60,42 +60,6 @@
     box-shadow: inset 0 -1px 0 var(--main-fg-color);
   }
 
-  /* Adapted from: https://moderncss.dev/pure-css-custom-checkbox-style/ */
-  input[type="checkbox"] {
-    flex-grow: 0;
-    margin-left: 1ch;
-    /*
-    appearance: none;
-    background-color: var(--main-bg-color);
-    margin: 0;
-    color: currentColor;
-    width: 1em;
-    height: 1em;
-    border: 1px solid currentColor;
-    display: grid;
-    place-content: center;
-    */
-  }
-
-  /*
-  input[type="checkbox"]:focus {
-    box-shadow: none;
-  }
-
-  input[type="checkbox"]::before {
-    content: "";
-    width: 0.45em;
-    height: 0.45em;
-    transform: scale(0);
-    transition: 120ms transform ease-in-out;
-    box-shadow: inset 1em 1em var(--main-fg-color);
-  }
-
-  input[type="checkbox"]:checked::before {
-    transform: scale(1);
-  }
-  */
-
   label {
     margin-bottom: 1em;
     display: flex;
@@ -123,6 +87,7 @@
 </style>
 
 <script>
+  import Checkbox from "./Checkbox.svelte";
   import { selected, selectedResource } from "./stores.js";
 
   export let modifierView;
@@ -177,14 +142,12 @@
       <input type="text" bind:value="{toReplace}" />
     </label>
     <div class="row">
-      <label>
+      <Checkbox bind:checked="{nullTerminated}">
         Null terminate replacement string
-        <input type="checkbox" bind:checked="{nullTerminated}" />
-      </label>
-      <label>
+      </Checkbox>
+      <Checkbox bind:checked="{allowOverflow}">
         Allow overflowing replaced string
-        <input type="checkbox" bind:checked="{allowOverflow}" />
-      </label>
+      </Checkbox>
     </div>
     {#if errorMessage}
       <p class="error">

--- a/frontend/src/SearchView.svelte
+++ b/frontend/src/SearchView.svelte
@@ -60,12 +60,6 @@
     box-shadow: inset 0 -1px 0 var(--main-fg-color);
   }
 
-  /* Adapted from: https://moderncss.dev/pure-css-custom-checkbox-style/ */
-  input[type="checkbox"] {
-    flex-grow: 0;
-    margin-left: 1ch;
-  }
-
   label {
     margin-bottom: 1em;
     display: flex;
@@ -90,20 +84,13 @@
   .error {
     margin-top: 2em;
   }
-
-  .treebox {
-    flex-grow: 1;
-    padding-left: 1em;
-    overflow-x: scroll;
-    white-space: nowrap;
-    text-align: left;
-  }
 </style>
 
 <script>
-  import { selected, selectedResource } from "./stores.js";
+  import { selectedResource } from "./stores.js";
   import { calculator } from "./helpers";
   import ResourceTreeNode from "./ResourceTreeNode.svelte";
+  import Checkbox from "./Checkbox.svelte";
 
   export let modifierView, resourceNodeDataMap;
   let searchInput,
@@ -114,13 +101,6 @@
     errorMessage;
 
   const searchTarget = $selectedResource;
-
-  function refreshResource() {
-    // Force hex view refresh with colors
-    const originalSelected = $selected;
-    $selected = undefined;
-    $selected = originalSelected;
-  }
 
   async function search() {
     if (searchTarget) {
@@ -184,10 +164,7 @@
       </label>
     {/if}
     <div class="row">
-      <label>
-        Range
-        <input type="checkbox" bind:checked="{rangeSearch}" />
-      </label>
+      <Checkbox bind:checked="{rangeSearch}">Range</Checkbox>
     </div>
     {#if errorMessage}
       <p class="error">


### PR DESCRIPTION
**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

Previously, inconsistently-styled, native checkboxes were used for boolean inputs in the GUI. This PR adds custom, cross-browser, cross-platform, consistently-styled checkbox components.

Before:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/99368685/211649592-1ddae9f0-da33-46ef-9255-91b4d1016f7f.png">

After:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/99368685/211649492-6dedb211-68cd-4122-96a7-02fd1486bb84.png">

**Anyone you think should look at this, specifically?**

@EdwardLarson 