### PR TITLE
Remove unnecessary, slow resource.save

### DIFF
--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -593,7 +593,6 @@ class FilesystemRoot(ResourceView):
             additional_tags=tags,
             additional_attributes=attributes,
         )
-        await parent_folder.resource.save()
         return new_file
 
     async def remove_file(self, path: str) -> None:


### PR DESCRIPTION
**Please describe the changes in your request.**

Unpacking very large filesystems can be extremely slow. This pull request makes it considerably faster by removing an unnecessary `resource.save` from the `add_file` function in the OFRAK core filesystem functions. 

Run the following code before and after the change to compare the improvement.

``` bash
pushd /tmp

mkdir -p test
for i in {1..50000}; do
    echo "${i}" > "test/${i}.txt"
done
zip -9 -r test.zip test/

python3 <<EOF
import logging
from ofrak import OFRAK

async def main(context):
    root = await context.create_root_resource_from_file("./test.zip")
    await root.unpack()

ofrak = OFRAK(logging.INFO)
ofrak.run(main)
EOF

popd
```

On my system, the original code takes 420 seconds to run this benchmark, and the updated code in this pull request takes 40 seconds. 

**Anyone you think should look at this, specifically?**

@EdwardLarson 
