### PR TITLE
Enables permission re-mapping from patch to destination program 

### DIFF
--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from itertools import chain
-from typing import List, Tuple, Dict, Optional, Iterable
+from typing import List, Tuple, Dict, Optional, Iterable, Mapping
 
 from immutabledict import immutabledict
 
@@ -114,12 +114,16 @@ class Allocatable(ResourceView):
     async def allocate_bom(
         self,
         bom: BOM,
+        permission_map: Optional[Mapping[MemoryPermissions, Iterable[MemoryPermissions]]] = None,
     ) -> PatchRegionConfig:
         """
         Responsible for allocating the patches if free memory is required and
         providing details about where space was made.
 
         :param bom:
+        :param permission_map: a map that assigns patch segment-local permissions to possible
+        destination permissions. available memory pool is evaluated in order!
+        Ex: a developer wants to enable allocation of RO strings from .rodata in an RX .text section.
 
         :return: information required to generate the linker directive script
         """
@@ -134,16 +138,26 @@ class Allocatable(ResourceView):
         for obj, segment in segments_to_allocate:
             vaddr, final_size = 0, 0
             if segment.length > 0:
-                allocs = await self.allocate(
-                    segment.access_perms,
-                    segment.length,
-                    min_fragment_size=segment.length,
-                    alignment=bom.segment_alignment,
+                possible_perms = permission_map[segment.access_perms] or (segment.access_perms,)
+                for candidate_permissions in permission_map[segment.access_perms]:
+                    try:
+                        allocs = await self.allocate(
+                            candidate_permissions,
+                            segment.length,
+                            min_fragment_size=segment.length,
+                            alignment=bom.segment_alignment,
+                        )
+                        allocation = next(iter(allocs))
+                        vaddr = allocation.start
+                        final_size = allocation.length()
+                        break
+                    except FreeSpaceAllocationError:
+                        continue
+            if vaddr == 0 or final_size == 0:
+                raise FreeSpaceAllocationError(
+                    f"Could not find enough free space for access perms {possible_perms} and "
+                    f"length {segment.length}"
                 )
-                allocation = next(iter(allocs))
-                vaddr = allocation.start
-                final_size = allocation.length()
-
             segments_by_object[obj.path].append(
                 Segment(
                     segment_name=segment.segment_name,

--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -140,7 +140,7 @@ class Allocatable(ResourceView):
             if segment.length == 0:
                 continue
             if permission_map is not None:
-                possible_perms = permission_map[segment.access_perms]  # type: ignore
+                possible_perms = permission_map[segment.access_perms]
             else:
                 possible_perms = (segment.access_perms,)
             for candidate_permissions in possible_perms:

--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ofrak-patch-maker` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Added
+- Optional permission map parameter to `Allocatable.allocate_bom`, which enables developers to express where 
+segments of one set of permissions may be placed in the destination binary. For example, a developer may specify
+to place `MemoryPermissions.R` `Segments` in destination program `MemoryRegions` of `MemoryPermissions.R` 
+or `MemoryPermissions.RX`.
+
 ### Changed
 - `PatchMaker` is now initialized with an existing `Toolchain` instance. GNU toolchain implementations are split into separate files.
 - Make toolchain names in `toolchain.conf` more specific:


### PR DESCRIPTION
**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Adds a new parameter to `allocate_bom` which specifies possible destination permissions for the current patch segment.
i.e. Developers can specify that .rodata segments of patches may be stored in the .text section of programs.

**Anyone you think should look at this, specifically?**
@EdwardLarson @whyitfor 