### PR TITLE
APIs to integrate GUI more deeply into OFRAK workflows

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Move GUI server to `ofrak_core`, startup GUI through CLI, add testing for server, make GUI pip installable. [#168](https://github.com/redballoonsecurity/ofrak/pull/168)
   - `python -m ofrak gui` starts the OFRAK GUI server.
 - UBI and UBIFS filesystem analyzers / unpackers / packers added. [#173](https://github.com/redballoonsecurity/ofrak/pull/173), [#177](https://github.com/redballoonsecurity/ofrak/pull/177)
+- Add APIs to open GUI in a script or after CLI commands complete.
 
 ### Changed
 - Refactored `DataService` internals to more efficiently find resources affected by patches [#140](https://github.com/redballoonsecurity/ofrak/pull/140)

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Move GUI server to `ofrak_core`, startup GUI through CLI, add testing for server, make GUI pip installable. [#168](https://github.com/redballoonsecurity/ofrak/pull/168)
   - `python -m ofrak gui` starts the OFRAK GUI server.
 - UBI and UBIFS filesystem analyzers / unpackers / packers added. [#173](https://github.com/redballoonsecurity/ofrak/pull/173), [#177](https://github.com/redballoonsecurity/ofrak/pull/177)
-- Add APIs to open GUI in a script or after CLI commands complete.
-- Installing ofrak also installs it as a console tool, so for example `ofrak unpack ...` works, instead of requiring `python -m ofrak unpack...`
+- Add APIs to open GUI in a script or after CLI commands complete. [#181](https://github.com/redballoonsecurity/ofrak/pull/181)
+- Installing ofrak also installs it as a console tool, so for example `ofrak unpack ...` works, instead of requiring `python -m ofrak unpack...` [#181](https://github.com/redballoonsecurity/ofrak/pull/181)
 
 ### Changed
 - Refactored `DataService` internals to more efficiently find resources affected by patches [#140](https://github.com/redballoonsecurity/ofrak/pull/140)

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - `python -m ofrak gui` starts the OFRAK GUI server.
 - UBI and UBIFS filesystem analyzers / unpackers / packers added. [#173](https://github.com/redballoonsecurity/ofrak/pull/173), [#177](https://github.com/redballoonsecurity/ofrak/pull/177)
 - Add APIs to open GUI in a script or after CLI commands complete.
+- Installing ofrak also installs it as a console tool, so for example `ofrak unpack ...` works, instead of requiring `python -m ofrak unpack...`
 
 ### Changed
 - Refactored `DataService` internals to more efficiently find resources affected by patches [#140](https://github.com/redballoonsecurity/ofrak/pull/140)

--- a/ofrak_core/ofrak/__main__.py
+++ b/ofrak_core/ofrak/__main__.py
@@ -8,7 +8,7 @@ from ofrak.cli.command.unpack import UnpackCommand
 from ofrak.cli.ofrak_cli import OFRAKCommandLineInterface
 
 
-def main():
+def main():  # pragma: no cover
     ofrak_cli = OFRAKCommandLineInterface(
         (ListCommand(), DepsCommand(), IdentifyCommand(), UnpackCommand(), GUICommand())
     )

--- a/ofrak_core/ofrak/__main__.py
+++ b/ofrak_core/ofrak/__main__.py
@@ -7,8 +7,13 @@ from ofrak.cli.command.list import ListCommand
 from ofrak.cli.command.unpack import UnpackCommand
 from ofrak.cli.ofrak_cli import OFRAKCommandLineInterface
 
-if __name__ == "__main__":
+
+def main():
     ofrak_cli = OFRAKCommandLineInterface(
         (ListCommand(), DepsCommand(), IdentifyCommand(), UnpackCommand(), GUICommand())
     )
     ofrak_cli.parse_and_run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/ofrak_core/ofrak/cli/command/gui.py
+++ b/ofrak_core/ofrak/cli/command/gui.py
@@ -1,11 +1,9 @@
 import logging
-import webbrowser
 from argparse import ArgumentDefaultsHelpFormatter, Namespace
 
-from ofrak.gui.server import start_server
-from ofrak.ofrak_context import OFRAKContext
-
 from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
+from ofrak.gui.server import open_gui
+from ofrak.ofrak_context import OFRAKContext
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,8 +35,5 @@ class GUICommand(OfrakCommandRunsScript):
         return gui_parser
 
     async def ofrak_func(self, ofrak_context: OFRAKContext, args: Namespace):  # pragma: no cover
-        url = f"http://{args.hostname}:{args.port}"
-        print(f"GUI is being served on {url}")
-        webbrowser.open(url)
-
-        await start_server(ofrak_context, args.hostname, args.port)  # type: ignore
+        server = await open_gui(args.hostname, args.port)
+        await server.run_until_cancelled()

--- a/ofrak_core/ofrak/cli/command/gui.py
+++ b/ofrak_core/ofrak/cli/command/gui.py
@@ -3,14 +3,14 @@ import webbrowser
 from argparse import ArgumentDefaultsHelpFormatter, Namespace
 
 from ofrak.gui.server import start_server
-from ofrak.ofrak_context import OFRAK
+from ofrak.ofrak_context import OFRAKContext
 
-from ofrak.cli.ofrak_cli import OFRAKEnvironment, OfrakCommand
+from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
 
 LOGGER = logging.getLogger(__name__)
 
 
-class GUICommand(OfrakCommand):
+class GUICommand(OfrakCommandRunsScript):
     def create_parser(self, ofrak_subparsers):
         gui_parser = ofrak_subparsers.add_parser(
             "gui",
@@ -33,64 +33,12 @@ class GUICommand(OfrakCommand):
             help="Set GUI server host port.",
             default=8080,
         )
-        gui_parser.add_argument(
-            "-b",
-            "--backend",
-            action="store",
-            help="Set GUI server backend.",
-            default=None,
-        )
-        gui_parser.add_argument(
-            "-v",
-            "--verbose",
-            action="store_true",
-            help="Enable verbose mode for debugging",
-            default=None,
-        )
-        gui_parser.add_argument(
-            "-q",
-            "--quiet",
-            action="store_true",
-            help="Enable quiet mode to minimize logging",
-            default=None,
-        )
+        self.add_ofrak_arguments(gui_parser)
         return gui_parser
 
-    def run(self, ofrak_env: OFRAKEnvironment, args: Namespace):  # pragma: no cover
-        if args.verbose is True:
-            ofrak = OFRAK(logging.DEBUG)
-
-        elif args.quiet is True:
-            ofrak = OFRAK(logging.WARNING)
-
-        else:
-            ofrak = OFRAK(logging.INFO)
-
-        if args.backend is not None:
-            if args.backend.lower() == "binary-ninja":
-                import ofrak_capstone  # type: ignore
-                import ofrak_binary_ninja  # type: ignore
-
-                ofrak.injector.discover(ofrak_capstone)
-                ofrak.injector.discover(ofrak_binary_ninja)
-
-            elif args.backend.lower() == "ghidra":
-                import ofrak_ghidra  # type: ignore
-
-                ofrak.injector.discover(ofrak_ghidra)
-
-            elif args.backend.lower() == "angr":
-                import ofrak_capstone  # type: ignore
-                import ofrak_angr  # type: ignore
-
-                ofrak.injector.discover(ofrak_capstone)
-                ofrak.injector.discover(ofrak_angr)
-
-        else:
-            LOGGER.warning("No disassembler backend specified, so no disassembly will be possible")
-
+    async def ofrak_func(self, ofrak_context: OFRAKContext, args: Namespace):  # pragma: no cover
         url = f"http://{args.hostname}:{args.port}"
         print(f"GUI is being served on {url}")
         webbrowser.open(url)
 
-        ofrak.run(start_server, args.hostname, args.port)  # type: ignore
+        await start_server(ofrak_context, args.hostname, args.port)  # type: ignore

--- a/ofrak_core/ofrak/cli/command/identify.py
+++ b/ofrak_core/ofrak/cli/command/identify.py
@@ -1,8 +1,10 @@
 import argparse
+import webbrowser
 
 from ofrak import OFRAKContext
 from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
 from ofrak.core.magic import Magic
+from ofrak.gui.server import start_server
 from ofrak.resource import Resource
 
 
@@ -17,6 +19,29 @@ class IdentifyCommand(OfrakCommandRunsScript):
         subparser.add_argument("filename", help="File to identify")
         self.add_ofrak_arguments(subparser)
 
+        # GUI args
+        subparser.add_argument(
+            "--gui",
+            action="store_true",
+            help="Open the OFRAK GUI after unpacking",
+            default=False,
+        )
+        subparser.add_argument(
+            "-gH",
+            "--gui-hostname",
+            action="store",
+            help="Set GUI server host address.",
+            default="127.0.0.1",
+        )
+        subparser.add_argument(
+            "-gp",
+            "--gui-port",
+            action="store",
+            type=int,
+            help="Set GUI server host port.",
+            default=8080,
+        )
+
         return subparser
 
     async def ofrak_func(self, ofrak_context: OFRAKContext, args: argparse.Namespace):
@@ -25,6 +50,12 @@ class IdentifyCommand(OfrakCommandRunsScript):
 
         await root_resource.identify()
         print(await IdentifyCommand.print_info(root_resource))
+
+        if args.gui:
+            url = f"http://{args.gui_hostname}:{args.gui_port}/#{root_resource.get_id().hex()}"
+            print(f"GUI is being served on {url}")
+            webbrowser.open(url)
+            await start_server(ofrak_context, host=args.gui_hostname, port=args.gui_port)
 
     @staticmethod
     async def print_info(resource: Resource) -> str:

--- a/ofrak_core/ofrak/cli/command/identify.py
+++ b/ofrak_core/ofrak/cli/command/identify.py
@@ -1,10 +1,9 @@
 import argparse
-import webbrowser
 
 from ofrak import OFRAKContext
 from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
 from ofrak.core.magic import Magic
-from ofrak.gui.server import start_server
+from ofrak.gui.server import open_gui
 from ofrak.resource import Resource
 
 
@@ -52,10 +51,8 @@ class IdentifyCommand(OfrakCommandRunsScript):
         print(await IdentifyCommand.print_info(root_resource))
 
         if args.gui:
-            url = f"http://{args.gui_hostname}:{args.gui_port}/#{root_resource.get_id().hex()}"
-            print(f"GUI is being served on {url}")
-            webbrowser.open(url)
-            await start_server(ofrak_context, host=args.gui_hostname, port=args.gui_port)
+            server = await open_gui(args.gui_hostname, args.gui_port, focus_resource=root_resource)
+            await server.run_until_cancelled()
 
     @staticmethod
     async def print_info(resource: Resource) -> str:

--- a/ofrak_core/ofrak/cli/command/unpack.py
+++ b/ofrak_core/ofrak/cli/command/unpack.py
@@ -1,4 +1,5 @@
 import os.path
+import webbrowser
 from typing import Optional
 
 from ofrak import OFRAKContext, Resource
@@ -10,6 +11,7 @@ import sys
 
 from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
 from ofrak.core import FilesystemEntry
+from ofrak.gui.server import start_server
 
 
 class UnpackCommand(OfrakCommandRunsScript):
@@ -34,6 +36,30 @@ class UnpackCommand(OfrakCommandRunsScript):
             " will be created in the same directory as the file being unpacked.",
         )
         subparser.add_argument("filename", help="File to unpack")
+
+        # GUI args
+        subparser.add_argument(
+            "--gui",
+            action="store_true",
+            help="Open the OFRAK GUI after unpacking",
+            default=False,
+        )
+        subparser.add_argument(
+            "-gH",
+            "--gui-hostname",
+            action="store",
+            help="Set GUI server host address.",
+            default="127.0.0.1",
+        )
+        subparser.add_argument(
+            "-gp",
+            "--gui-port",
+            action="store",
+            type=int,
+            help="Set GUI server host port.",
+            default=8080,
+        )
+
         self.add_ofrak_arguments(subparser)
 
         return subparser
@@ -82,6 +108,12 @@ class UnpackCommand(OfrakCommandRunsScript):
             f.write(info_dump)
 
         print(info_dump)
+
+        if args.gui:
+            url = f"http://{args.gui_hostname}:{args.gui_port}/#{root_resource.get_id().hex()}"
+            print(f"GUI is being served on {url}")
+            webbrowser.open(url)
+            await start_server(ofrak_context, host=args.gui_hostname, port=args.gui_port)
 
     async def resource_tree_to_files(self, resource: Resource, path):
         children_dir = path + ".ofrak_children"

--- a/ofrak_core/ofrak/cli/command/unpack.py
+++ b/ofrak_core/ofrak/cli/command/unpack.py
@@ -34,6 +34,14 @@ class UnpackCommand(OfrakCommandRunsScript):
             help="Directory to write unpacked resource tree to. If no directory is given, a new one"
             " will be created in the same directory as the file being unpacked.",
         )
+        subparser.add_argument(
+            "--recursive",
+            "-r",
+            action="store_true",
+            default=False,
+            help="Unpack recursively: all resources unpacked from the root will be unpack, as "
+            "well as all resources unpacked from those, and so.",
+        )
         subparser.add_argument("filename", help="File to unpack")
 
         # GUI args
@@ -67,7 +75,10 @@ class UnpackCommand(OfrakCommandRunsScript):
         print(f"Unpacking file: {args.filename}\n")
         root_resource = await ofrak_context.create_root_resource_from_file(args.filename)
 
-        await root_resource.unpack()
+        if args.recursive:
+            await root_resource.unpack_recursively()
+        else:
+            await root_resource.unpack()
 
         if args.output_directory:
             extraction_dir = Path(args.output_directory)

--- a/ofrak_core/ofrak/cli/command/unpack.py
+++ b/ofrak_core/ofrak/cli/command/unpack.py
@@ -1,5 +1,4 @@
 import os.path
-import webbrowser
 from typing import Optional
 
 from ofrak import OFRAKContext, Resource
@@ -11,7 +10,7 @@ import sys
 
 from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
 from ofrak.core import FilesystemEntry
-from ofrak.gui.server import start_server
+from ofrak.gui.server import open_gui
 
 
 class UnpackCommand(OfrakCommandRunsScript):
@@ -110,10 +109,8 @@ class UnpackCommand(OfrakCommandRunsScript):
         print(info_dump)
 
         if args.gui:
-            url = f"http://{args.gui_hostname}:{args.gui_port}/#{root_resource.get_id().hex()}"
-            print(f"GUI is being served on {url}")
-            webbrowser.open(url)
-            await start_server(ofrak_context, host=args.gui_hostname, port=args.gui_port)
+            server = await open_gui(args.gui_hostname, args.gui_port, focus_resource=root_resource)
+            await server.run_until_cancelled()
 
     async def resource_tree_to_files(self, resource: Resource, path):
         children_dir = path + ".ofrak_children"

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -3,6 +3,7 @@ import functools
 import json
 import logging
 import os
+from collections import defaultdict
 from typing import (
     Iterable,
     Optional,
@@ -146,7 +147,9 @@ class AiohttpOFRAKServer:
             ]
         )
 
-        self._job_ids: Dict[str, bytes] = dict()
+        self._job_ids: Dict[str, bytes] = defaultdict(
+            lambda: ofrak_context.id_service.generate_id()
+        )
 
     async def start(self):  # pragma: no cover
         """

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -3,6 +3,7 @@ import functools
 import json
 import logging
 import os
+import webbrowser
 from collections import defaultdict
 from typing import (
     Iterable,
@@ -22,6 +23,8 @@ from aiohttp.web_exceptions import HTTPBadRequest
 from aiohttp.web_request import Request
 from aiohttp.web_response import Response
 from aiohttp.web_fileresponse import FileResponse
+
+from ofrak.ofrak_context import get_current_ofrak_context
 from ofrak_type.error import NotFoundError
 from ofrak_type.range import Range
 
@@ -159,6 +162,13 @@ class AiohttpOFRAKServer:
         await self.runner.setup()
         server = web.TCPSite(self.runner, host=self._host, port=self._port)
         await server.start()
+
+    async def stop(self):  # pragma: no cover
+        """
+        Stop the server.
+        """
+        await self.runner.server.shutdown()
+        await self.runner.cleanup()
 
     async def run_until_cancelled(self):  # pragma: no cover
         """
@@ -430,8 +440,18 @@ class AiohttpOFRAKServer:
         del resource_model_fields["component_versions"]
         del resource_model_fields["components_by_attributes"]
 
+    def open_resource_in_browser(self, resource: Optional[Resource]):  # pragma: no cover
+        if resource is None:
+            url = f"http://{self._host}:{self._port}/"
+        else:
+            url = f"http://{self._host}:{self._port}/#{resource.get_id().hex()}"
+        print(f"GUI is being served on {url}")
+        webbrowser.open(url)
 
-async def start_server(ofrak_context: OFRAKContext, host: str, port: int):  # pragma: no cover
+
+async def start_server(
+    ofrak_context: OFRAKContext, host: str, port: int
+) -> AiohttpOFRAKServer:  # pragma: no cover
     # Force using the correct PJSON serialization with the expected structure. Otherwise the
     # dependency injector may accidentally use the Stashed PJSON serialization service,
     # which returns PJSON that has a different, problematic structure.
@@ -446,7 +466,7 @@ async def start_server(ofrak_context: OFRAKContext, host: str, port: int):  # pr
     server = await ofrak_context.injector.get_instance(AiohttpOFRAKServer)
     await server.start()
 
-    await server.run_until_cancelled()
+    return server
 
 
 def respond_with_error(error: Exception, error_cls: Type[SerializedError]) -> Response:
@@ -468,3 +488,17 @@ def get_query_string_as_pjson(request: Request) -> Dict[str, PJSONType]:
     or 1 as '1', which isn't valid PJSON. We fix this by applying `json.loads` on each parameter.
     """
     return {key: json.loads(value) for key, value in request.query.items()}
+
+
+async def open_gui(
+    host: str,
+    port: int,
+    focus_resource: Optional[Resource] = None,
+    ofrak_context: Optional[OFRAKContext] = None,
+) -> AiohttpOFRAKServer:  # pragma: no cover
+    if ofrak_context is None:
+        ofrak_context = get_current_ofrak_context()
+
+    server = await start_server(ofrak_context, host, port)
+    server.open_resource_in_browser(focus_resource)
+    return server

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -5,6 +5,7 @@ import time
 from types import ModuleType
 from typing import Type, Any, Awaitable, Callable, List, Iterable
 
+from ofrak_type import InvalidStateError
 from synthol.injector import DependencyInjector
 
 from ofrak.component.interface import ComponentInterface
@@ -85,9 +86,12 @@ class OFRAKContext:
         return root_resource
 
     async def start_context(self):
+        globals()["_ofrak_context"] = self
         await asyncio.gather(*(service.run() for service in self._all_ofrak_services))
 
     async def shutdown_context(self):
+        if "_ofrak_context" in globals():
+            del globals()["_ofrak_context"]
         await asyncio.gather(*(service.shutdown() for service in self._all_ofrak_services))
         logging.shutdown()
 
@@ -200,3 +204,13 @@ class OFRAK:
         )
 
         return audited_components
+
+
+def get_current_ofrak_context() -> OFRAKContext:
+    # TODO: This is a brittle MVP, creating multiple simultaneous contexts in a single process
+    #  will probably break it!
+    ctx = globals().get("_ofrak_context")
+    if ctx is None:
+        raise InvalidStateError("Not in an OFRAK context!")
+    else:
+        return ctx

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -86,6 +86,10 @@ class OFRAKContext:
         return root_resource
 
     async def start_context(self):
+        if "_ofrak_context" in globals():
+            raise InvalidStateError(
+                "Cannot start OFRAK context as a context has already been started in this process!"
+            )
         globals()["_ofrak_context"] = self
         await asyncio.gather(*(service.run() for service in self._all_ofrak_services))
 

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -115,7 +115,10 @@ setuptools.setup(
     license="Proprietary",
     license_files=["LICENSE"],
     cmdclass={"egg_info": egg_info_ex},
-    entry_points={"ofrak.packages": ["ofrak_pkg = ofrak"]},
+    entry_points={
+        "ofrak.packages": ["ofrak_pkg = ofrak"],
+        "console_scripts": ["ofrak = ofrak.__main__:main"],
+    },
     ext_modules=[entropy_so],
     include_package_data=True,
 )

--- a/ofrak_core/test_ofrak/unit/test_ofrak_cli.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_cli.py
@@ -193,6 +193,7 @@ async def all_expected_analysis(ofrak_context: OFRAKContext):
         expected_tags = test_resource.get_most_specific_tags()
         expected_attributes = test_resource.get_model().attributes.values()
         all_expected_analysis[filename] = expected_tags, expected_attributes
+    await ofrak_context.shutdown_context()
     return all_expected_analysis
 
 
@@ -232,6 +233,7 @@ async def all_expected_hashes(ofrak_context: OFRAKContext):
                 if len(data) > 0:
                     expected_hashes.add(hashlib.sha256(data).hexdigest())
         all_expected_hashes[filename] = expected_hashes
+    await ofrak_context.shutdown_context()
     return all_expected_hashes
 
 


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add APIs to open GUI in a script or after CLI commands complete.

**Link to Related Issue(s)**

**Please describe the changes in your request.**
* Add flags to open GUI after `inject` or `unpack` completes
* Add `-r` flag to `unpack` command, to unpack recursively
* Add `get_current_ofrak_context` which... gets the current OFRAK context, so this can be done in any arbitrary place in a script or component and one doesn't have to keep passing the context around. It uses a global variable for this and is therefore fairly brittle, and would break if two contexts are created concurrently. I added a check and error raise for this so it won't be a silent bug.
* Add `open_gui` function to simply start the server and open a browser window. It returns the server, so it's up to the user to do `run_until_complete` if they want to, but it leaves it open for other conditions to exit (not implemented).
* Add a `console_scripts` entrypoint for ofrak so that the CLI can be run a normal CLI tool, not only as a python3 module (i.e. you can run `ofrak unpack ...` instead of `python3 -m ofrak unpack ...`


New options for `unpack`:
```
optional arguments:
  -h, --help            show this help message and exit
  -o OUTPUT_DIRECTORY, --output_directory OUTPUT_DIRECTORY
                        Directory to write unpacked resource tree to. If no
                        directory is given, a new one will be created in the
                        same directory as the file being unpacked.
  --recursive, -r       Unpack recursively: all resources unpacked from the
                        root will be unpack, as well as all resources unpacked
                        from those, and so.
  --gui                 Open the OFRAK GUI after unpacking
  -gH GUI_HOSTNAME, --gui-hostname GUI_HOSTNAME
                        Set GUI server host address.
  -gp GUI_PORT, --gui-port GUI_PORT
                        Set GUI server host port.
...
```

Example usage of `open_gui` etc. in a script:

```
async def main(context: OFRAKContext, outfile):
    root = await load_and_unpack(context)
    await add_program_attributes(root)
    ofrak_gui = await open_gui("0.0.0.0", 80, root)
    source_bundle = await add_source_bundle(root)
    ofrak_gui.open_resource_in_browser(source_bundle.resource)
    await perform_function_replacement(root, source_bundle)
    await root.flush_to_disk(outfile)

    await ofrak_gui.run_until_cancelled()
```


**Anyone you think should look at this, specifically?**
@rbs-jacob @whyitfor 