### PR TITLE
add GenericBinary tag to children of UBI resources if they have data,…

### DIFF
--- a/ofrak_core/ofrak/core/ubi.py
+++ b/ofrak_core/ofrak/core/ubi.py
@@ -2,8 +2,10 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 import logging
-from typing import List
+from typing import List, Tuple
 import os
+
+from ofrak.model.tag_model import ResourceTag
 
 from ofrak import Identifier, Analyzer
 from ofrak.component.packer import Packer
@@ -189,7 +191,7 @@ class UbiUnpacker(Unpacker[None]):
                 with open(f_path, "rb") as f:
                     data = f.read()
                     if len(data) > 0:
-                        other_tags = (GenericBinary,)
+                        other_tags: Tuple[ResourceTag, ...] = (GenericBinary,)
                     else:
                         other_tags = ()
                     await resource.create_child_from_view(

--- a/ofrak_core/ofrak/core/ubi.py
+++ b/ofrak_core/ofrak/core/ubi.py
@@ -187,7 +187,14 @@ class UbiUnpacker(Unpacker[None]):
                     f"/img-{ubi_view.image_seq}_vol-{vol.name}.ubifs"
                 )
                 with open(f_path, "rb") as f:
-                    await resource.create_child_from_view(vol, data=f.read())
+                    data = f.read()
+                    if len(data) > 0:
+                        other_tags = (GenericBinary,)
+                    else:
+                        other_tags = ()
+                    await resource.create_child_from_view(
+                        vol, data=data, additional_tags=other_tags
+                    )
 
 
 class UbiPacker(Packer[None]):


### PR DESCRIPTION
… so auto identifying and unpacking them further works

**One sentence summary of this PR (This should go in the CHANGELOG!)**
add GenericBinary tag to children of UBI resources if they have data, so auto identifying and unpacking them further works

**Link to Related Issue(s)**
Without this tag, auto identifying and unpacking them does not work. So if there is e.g. a squashfs filesystem in a UbiVolume, it wouldn't be identified and unpacked.

**Please describe the changes in your request.**
dd GenericBinary tag to children of UBI resources if they have data

**Anyone you think should look at this, specifically?**
@whyitfor 
