### PR TITLE
Ignore .rela sections in FEM created by placeholder

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Remove unneeded and slow `.save()` when unpacking filesystems [#171](https://github.com/redballoonsecurity/ofrak/pull/171)
 - Added missing elf section types to ElfSectionType [#178](https://github.com/redballoonsecurity/ofrak/pull/178)
+- Handled .rela placeholder segments in the same fashion as .got [#185](https://github.com/redballoonsecurity/ofrak/pull/185)
 
 ## [2.0.0](https://github.com/redballoonsecurity/ofrak/releases/tag/ofrak-v2.0.0) - 2023-01-03
 ### Added

--- a/ofrak_core/ofrak/core/patch_maker/modifiers.py
+++ b/ofrak_core/ofrak/core/patch_maker/modifiers.py
@@ -187,6 +187,8 @@ class SegmentInjectorModifier(Modifier[SegmentInjectorModifierConfig]):
                 )
             if segment.segment_name.startswith(".bss"):
                 continue
+            if segment.segment_name.startswith(".rela"):
+                continue
             if segment.segment_name.startswith(".got"):
                 # Create new .got and .plt in the exec format here here once we begin supporting
                 # the addition of new dynamic references in our patches.


### PR DESCRIPTION
The same way we do with the .got section, ignore .rela sections in patch maker FEM while injecting. 