### PR TITLE
rename references to AutoAttributes in frontend

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -179,5 +179,5 @@
 {/if}
 
 <div class="bottomright">
-  <p><a href="https://ofrak.com" target="_blank" rel="noreferrer">v0.6.0</a></p>
+  <p><a href="https://ofrak.com" target="_blank" rel="noreferrer">v2.1.1</a></p>
 </div>

--- a/frontend/src/AssemblyView.svelte
+++ b/frontend/src/AssemblyView.svelte
@@ -46,11 +46,11 @@
       blocks.sort((a, b) => {
         const aAddress =
           a[0]?.model?.attributes[
-            "ofrak.model._auto_attributes.AddressableAutoAttributes"
+            "ofrak.model._auto_attributes.AttributesType[Addressable]"
           ]?.virtual_address;
         const bAddress =
           b[0]?.model?.attributes[
-            "ofrak.model._auto_attributes.AddressableAutoAttributes"
+            "ofrak.model._auto_attributes.AttributesType[Addressable]"
           ]?.virtual_address;
         return aAddress - bAddress;
       });
@@ -97,7 +97,7 @@
             {instructionOrDataWord
               .get_attributes()
               [
-                "ofrak.model._auto_attributes.AddressableAutoAttributes"
+                "ofrak.model._auto_attributes.AttributesType[Addressable]"
               ].virtual_address.toString(16)
               .padStart(8, "0") + ":"}
           </div>
@@ -130,11 +130,11 @@
         {#each block as instruction}
           <div>
             {instruction.get_attributes()[
-              "ofrak.model._auto_attributes.InstructionAutoAttributes"
+              "ofrak.model._auto_attributes.AttributesType[Instruction]"
             ].mnemonic +
               " " +
               instruction.get_attributes()[
-                "ofrak.model._auto_attributes.InstructionAutoAttributes"
+                "ofrak.model._auto_attributes.AttributesType[Instruction]"
               ].operands}
           </div>
         {/each}
@@ -150,7 +150,7 @@
           <!--        unpacked data word value not yet available as attribute -->
           <!--          0x{dataWord-->
           <!--            .get_attributes()-->
-          <!--            .DataWordAutoAttributes.unpacked.toString(16)}-->
+          <!--            .AttributesType[DataWord].unpacked.toString(16)}-->
           [literal]
         </div>
       {/each}

--- a/frontend/src/ResourceTreeToolbar.svelte
+++ b/frontend/src/ResourceTreeToolbar.svelte
@@ -110,7 +110,7 @@
             a.target = "_blank";
             a.download =
               rootResource.get_attributes()[
-                "ofrak.model._auto_attributes.FilesystemEntryAutoAttributes"
+                "ofrak.model._auto_attributes.AttributesType[FilesystemEntry]"
               ]?.name || "";
             a.click();
 

--- a/frontend/src/helpers.js
+++ b/frontend/src/helpers.js
@@ -39,7 +39,8 @@ export function hexToByteArray(hex) {
  */
 export function cleanOfrakType(t) {
   const elements = t.split(".");
-  return elements[elements.length - 1];
+  const last = elements[elements.length - 1];
+  return last.replace(/AttributesType\[(.*)\]/, "$1");
 }
 
 /***

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
+## [2.1.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.0...ofrak-v2.1.1) - 2023-01-25
+### Fixed
+- GUI uses correct attribute class names again (not *AutoAttributes)
+
 ## [2.1.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.0.0...ofrak-v2.1.0) - 2023-01-20
 ### Added
 - `LiefAddSegmentConfig` now has an optional `physical_address` argument.

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -30,7 +30,7 @@ entropy_so = setuptools.Extension(
 
 setuptools.setup(
     name="ofrak",
-    version="2.1.0",
+    version="2.1.1",
     description="A binary analysis and modification platform",
     packages=setuptools.find_packages(exclude=["test_ofrak", "test_ofrak.*"]),
     package_data={


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

GUI uses correct attribute class names again (not *AutoAttributes)

**Link to Related Issue(s)**

We changed the name scheme for auto-generated attributes classes, and the GUI was still in some cases trying to use the old names, which caused errors.

**Please describe the changes in your request.**

Update the names used in the GUI appropriately.

**Anyone you think should look at this, specifically?**
