### PR TITLE
Feature/pip install ofrak angr capstone

### DIFF
--- a/disassemblers/ofrak_angr/CHANGELOG.md
+++ b/disassemblers/ofrak_angr/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to `ofrak-angr` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+## 1.0.0 - 2022-01-25
+### Added
+Initial release. Hello world!

--- a/disassemblers/ofrak_angr/README.md
+++ b/disassemblers/ofrak_angr/README.md
@@ -1,5 +1,74 @@
-# OFRAK angr Components
-Use [angr](https://angr.io/) to unpack Code Regions and Complex Blocks.
+# OFRAK
+OFRAK (Open Firmware Reverse Analysis Konsole) is a binary analysis and modification platform that combines the ability to unpack, analyze, modify, and repack binaries.
+
+
+# Package: ofrak_angr
+
+```
+OFRAK
+└───ofrak
+│   └───disassemblers
+│       └───ofrak_angr  <-- //YOU ARE HERE//
+│       |   └───components
+│       |       └───blocks
+│       |       |   └───unpackers.py
+│       |       └───angr_analyzer.py
+│       |       └───identifiers.py
+│       └───ofrak_binary_ninja
+│       └───ofrak_capstone
+│       └───ofrak_ghidra
+└───ofrak_type
+└───ofrak_io
+└───ofrak_patch_maker
+└───ofrak_tutorial
+``` 
+
+This package contains OFRAK components utilizing [angr](https://angr.io/) to unpack Code Regions and Complex Blocks:
+* `AngrCodeRegionUnpacker` for unpacking `CodeRegion`s into their constituent `ComplexBlock`
+* `AngrComplexBlockUnpacker` unpacking `ComplexBlock`s into their constituent `BasicBlock`s
+* `AngrAnalyzer` for analyzing resources with angr
+* `AngrAnalysisIdentifier` for identifying resources which can be analyzed with angr
+
+
+Note that this package does not contain a component to unpack `BasicBlock`s into `Instruction`s; use `ofrak_angr` in conjunction with `ofrak_capstone` if you want to unpack all the way down to the instruction level.
+
+
+After installing the package, it can be used in an OFRAK script by adding the following to the setup step:
+
+```python
+import ofrak_angr
+...
+ofrak = OFRAK()
+... # Other setup steps
+ofrak.discover(ofrak_angr)
+```
+
+It can be used from the CLI by adding the `--backend angr` flag to the OFRAK CLI command.
+
+## Testing
+The tests for `ofrak_angr`  require the tests to be installed for the core OFRAK module. These must
+first be installed after downloading the [OFRAK source code](https://github.com/redballoonsecurity/ofrak).
+
+Then, the `ofrak_angr` tests can be run with:
+
+```python
+pytest --pyargs ofrak_angr_test
+
+```
+
+## Testing
+This package maintains 100% test coverage of functions.
+
+## License
+The code in this repository comes with an [OFRAK Community License](https://github.com/redballoonsecurity/ofrak/blob/master/LICENSE), which is intended for educational uses, personal development, or just having fun.
+
+Users interested in using OFRAK for commercial purposes can request the Pro or Enterprise License. See [OFRAK Licensing](https://ofrak.com/license/) for more information.
+
+## Documentation
+OFRAK has general documentation and API documentation, which can be viewed at <https://ofrak.com/docs>.
+
+
+# Description
 
 Once angr's CFG is processed into OFRAK, the hierarchy of the non-overlapping packing structure of an executable is expected to look like this:
   - Code Regions
@@ -7,7 +76,7 @@ Once angr's CFG is processed into OFRAK, the hierarchy of the non-overlapping pa
       - Basic Blocks
       - DataWords
 
-OFRAK works on packing structures of data on real memory addresses. angr reflects memory addresses as it appears to a program running inside of it. As such, certain tranformations have to be made from angr's analysis before exporting to OFRAK, including:
+OFRAK works on packing structures of data on real memory addresses. angr reflects memory addresses as it appears to a program running inside of it. As such, certain transformations have to be made from angr's analysis before exporting to OFRAK, including:
   - Retrieving real memory addresses from the thumb-mode addresses returned by angr; and
   - Expanding function ranges returned by angr to include literal pools, before exporting that as part of a Complex Block
 
@@ -30,21 +99,8 @@ config = AngrAnalyzerConfig(project.analyses.CFGEmulated, {"normalize": True, "e
 ```
 
 
-# Prerequisites
 ## Docker
 The following command will build an OFRAK with angr capabilities.
 ```bash
 python3 build_image.py --config ofrak-angr.yml --base --finish
 ```
-
-## MacOS
-1. Create a virtual environment to which you will install code:
-    ```
-    % python3 -m venv venv
-    % source venv/bin/activate
-    ```
-2. Install `ofrak` and its dependencies.
-3. Finally, run `make {install, develop, test}`
-
-## Testing
-This package maintains 100% test coverage of functions.

--- a/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Iterable, Tuple
 from typing import Optional
+from warnings import warn
 
 from angr.knowledge_plugins.functions.function import Function as AngrFunction
 from archinfo.arch_arm import get_real_address_if_arm
@@ -149,6 +150,15 @@ class AngrComplexBlockUnpacker(ComplexBlockUnpacker):
                 bb_exit_addr = get_real_address_if_arm(
                     angr_analysis.project.arch, angr_cb_basic_blocks[(idx + 1)].addr
                 )
+
+            if (bb_addr + bb.size) > cb_vaddr_range.end or bb_addr < cb_vaddr_range.start:
+                warning_string = (
+                    f"Basic block {bb_addr:#x} does not fall within "
+                    f"complex block {cb_vaddr_range.start:#x} at "
+                    f"addresses {cb_vaddr_range.start:#x}-{cb_vaddr_range.end:#x}"
+                )
+                warn(RuntimeWarning(warning_string))
+                continue
 
             yield BasicBlock(
                 bb_addr,

--- a/disassemblers/ofrak_angr/setup.py
+++ b/disassemblers/ofrak_angr/setup.py
@@ -15,26 +15,18 @@ class egg_info_ex(egg_info):
         egg_info.run(self)
 
 
-with open("LICENSE") as f:
-    license = "".join(["\n", f.read()])
+with open("README.md") as f:
+    long_description = f.read()
 
 setuptools.setup(
     name="ofrak_angr",
-    version="0.1.0",
-    author="Red Balloon Security",
-    author_email="ofrak@redballoonsecurity.com",
+    version="1.0.0",
     description="OFRAK angr Components",
-    url="",  # TODO
-    packages=[
-        "ofrak_angr",
-    ],
+    packages=setuptools.find_packages(exclude=["ofrak_angr_test", "ofrak_angr_test.*"]),
     package_data={"ofrak_angr": ["py.typed"]},
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent",
-    ],
     install_requires=[
         "angr==9.2.6",
+        "ofrak",
     ],
     extras_require={
         "test": [
@@ -46,8 +38,29 @@ setuptools.setup(
         ],
         "graphical": ["pygraphviz"],
     },
+    author="Red Balloon Security",
+    author_email="ofrak@redballoonsecurity.com",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://ofrak.com/",
+    download_url="https://github.com/redballoonsecurity/ofrak",
+    project_urls={
+        "Documentation": "https://ofrak.com/docs/",
+        "Community License": "https://github.com/redballoonsecurity/ofrak/blob/master/LICENSE",
+        "Commercial Licensing Information": "https://ofrak.com/license/",
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+        "License :: Other/Proprietary License",
+        "License :: Free To Use But Restricted",
+        "License :: Free For Home Use",
+        "Topic :: Security",
+        "Typing :: Typed",
+    ],
     python_requires=">=3.7",
-    license=license,
+    license="Proprietary",
+    license_files=["LICENSE"],
     cmdclass={"egg_info": egg_info_ex},
     entry_points={"ofrak.packages": ["ofrak_angr_pkg = ofrak_angr"]},
 )

--- a/disassemblers/ofrak_capstone/CHANGELOG.md
+++ b/disassemblers/ofrak_capstone/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to `ofrak-capstone` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+## 1.0.0 - 2022-01-25
+### Added
+Initial release. Hello world!

--- a/disassemblers/ofrak_capstone/setup.py
+++ b/disassemblers/ofrak_capstone/setup.py
@@ -20,8 +20,8 @@ with open("README.md") as f:
 
 setuptools.setup(
     name="ofrak_capstone",
-    version="0.1.1",
-    packages=setuptools.find_packages(),
+    version="1.0.0",
+    packages=setuptools.find_packages(exclude=["ofrak_capstone_test", "ofrak_capstone_test.*"]),
     package_data={"ofrak_capstone": ["py.typed"]},
     install_requires=["capstone==4.0.2", "ofrak"],
     extras_require={


### PR DESCRIPTION
**Link to Related Issue(s)**
ofrak_angr and ofrak_capstone have purely Python dependencies, but weren't pip installable.

There was also a bug with ofrak_angr's complex block unpacker, where it didn't appropriately catch and warn when a basic block would be created outside the parent's range (as the ofrak_binary_ninja unpacker does)

**Please describe the changes in your request.**

Prep ofrak_angr and ofrak_capstone for pypi release, fix that bug.

**Anyone you think should look at this, specifically?**
