### PR TITLE
Fix issue installing ofrak-core-dev configuration

### DIFF
--- a/ofrak-core-dev.yml
+++ b/ofrak-core-dev.yml
@@ -7,4 +7,5 @@ packages_paths:
     "ofrak_io",
     "ofrak_patch_maker",
     "ofrak_core",
+    "frontend",
   ]


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix error installing `ofrak-core-dev.yaml` configuration build

**Link to Related Issue(s)**
No open issues that I found but the error I received:
```
$ python3 build_image.py --config ofrak-core-dev.yml --base --finish
...
...
...
make -C ofrak_core develop
make[1]: Entering directory '/ofrak_core'
if [ -d /ofrak_gui ] ; then \
	cp -r /ofrak_gui ofrak/gui/public ; \
else \
	pushd ../frontend ; \
	npm run build ; \
	popd ; \
	cp -r ../frontend/public ofrak/gui/public ; \
fi
/bin/sh: 4: pushd: not found
/bin/sh: 5: npm: not found
/bin/sh: 6: popd: not found
cp: cannot stat '../frontend/public': No such file or directory
make[1]: Leaving directory '/ofrak_core'
make[1]: *** [Makefile:25: ofrak/gui/public] Error 1
make: *** [Makefile:5: develop] Error 2
The command '/bin/sh -c make $INSTALL_TARGET' returned a non-zero code: 2
Error running command: 'docker build -t redballoonsecurity/ofrak/core-dev:0be8d018 -t redballoonsecurity/ofrak/core-dev:latest -f finish.Dockerfile --build-arg INSTALL_TARGET=develop .'
Exit status: 2
make: *** [Makefile:14: image] Error 2
```

**Please describe the changes in your request.**
Adds 'frontend' to package_paths necessary for the config since ofrak-core now depends on the gui files being present.

**Anyone you think should look at this, specifically?**
@whyitfor 