### PR TITLE
Pin BinaryNinja version to 3.2.3814.

### DIFF
--- a/disassemblers/ofrak_binary_ninja/Dockerstub
+++ b/disassemblers/ofrak_binary_ninja/Dockerstub
@@ -1,4 +1,8 @@
 RUN apt-get install -y libdbus-1-3
 ARG OFRAK_DIR=.
 COPY $OFRAK_DIR/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh /tmp/
-RUN --mount=type=secret,id=serial /tmp/install_binary_ninja_headless_linux.sh && rm /tmp/install_binary_ninja_headless_linux.sh
+COPY $OFRAK_DIR/disassemblers/ofrak_binary_ninja/pin_version.py /tmp/
+RUN --mount=type=secret,id=serial --mount=type=secret,id=license.dat,dst=/root/.binaryninja/license.dat /tmp/install_binary_ninja_headless_linux.sh && \
+  python3 /tmp/pin_version.py "3.2.3814 Headless" && \
+  rm /tmp/install_binary_ninja_headless_linux.sh && \
+  rm /tmp/pin_version.py

--- a/disassemblers/ofrak_binary_ninja/pin_version.py
+++ b/disassemblers/ofrak_binary_ninja/pin_version.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2015-2023 Vector 35 Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import argparse
+
+from binaryninja.update import (
+    UpdateChannel,
+    are_auto_updates_enabled,
+    set_auto_updates_enabled,
+    is_update_installation_pending,
+    install_pending_update,
+)
+from binaryninja import core_version
+
+
+def main(version_string: str):
+    """
+    Switch BinaryNinja core version based on the given "version_string".
+
+    This implements a version switch similar to
+    https://github.com/Vector35/binaryninja-api/blob/dev/python/examples/version_switcher.py,
+    albeit without needing user input.
+    """
+    version = get_version(version_string)
+    if version.version == core_version():
+        print(f"Already running {version_string}")
+        return
+    if are_auto_updates_enabled():
+        set_auto_updates_enabled(False)
+    version.update()
+    if is_update_installation_pending:
+        install_pending_update()
+    return
+
+
+def get_version(version_string: str):
+    channel = list(UpdateChannel)[0]
+    for version in channel.versions:
+        if version.version == version_string:
+            return version
+    raise ValueError(f"Cannot find {version_string}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", type=str)
+    args = parser.parse_args()
+    main(args.version)

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -132,7 +132,7 @@ See [the Ghidra user guide](./user-guide/ghidra.md) for more information about u
 
 ### Binary Ninja
 
-Note that Binary Ninja is not distributed with OFRAK. **You need to have a valid headless BinaryNinja license to build and run the image.** For more details, see the [Docker commands that are run](https://github.com/redballoonsecurity/ofrak/blob/master/disassemblers/ofrak_binary_ninja/Dockerstub).
+Note that Binary Ninja is not distributed with OFRAK. **You need to have a valid headless BinaryNinja license to build and run the image.** The `license.dat` file should be placed in a `.binaryninja` directory, under the user's home directory. For more details, see the [Docker commands that are run](https://github.com/redballoonsecurity/ofrak/blob/master/disassemblers/ofrak_binary_ninja/Dockerstub).
 
 To build the image, the license should be placed in the project's root directory and named `license.dat`. The serial number needs to be extracted from that file into a file named `serial.txt`. This can be done with the following command:
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -128,11 +128,11 @@ docker exec \
 - To manually stop it, run `python -m ofrak_ghidra.server stop`. 
 - Ghidra logs can be found here: `/root/.ghidra/.ghidra_10.1.2_PUBLIC/application.log`.
 
-See [the Ghidra user guide](https://ofrak.com/docs/user-guide/ghidra.html) for more information about using Ghidra with OFRAK.
+See [the Ghidra user guide](./user-guide/ghidra.md) for more information about using Ghidra with OFRAK.
 
 ### Binary Ninja
 
-Note that Binary Ninja is not distributed with OFRAK. Instead, if a license is present, the Docker build step will run the official headless installer using the provided license. **You need to have a valid BinaryNinja license to build and run the image.** For more details, [read the script that is run](https://github.com/redballoonsecurity/ofrak/blob/master/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh).
+Note that Binary Ninja is not distributed with OFRAK. **You need to have a valid headless BinaryNinja license to build and run the image.** For more details, see the [Docker commands that are run](https://github.com/redballoonsecurity/ofrak/blob/master/disassemblers/ofrak_binary_ninja/Dockerstub).
 
 To build the image, the license should be placed in the project's root directory and named `license.dat`. The serial number needs to be extracted from that file into a file named `serial.txt`. This can be done with the following command:
 
@@ -145,7 +145,7 @@ python3 \
 
 The command `python3 build_image.py --config ofrak-binary-ninja.yml --base --finish` will build an image using Docker BuildKit secrets so that neither the license nor serial number are exposed in the built Docker image. (If [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) is not enabled in your environment, precede the `python3 build_image.py` command with `DOCKER_BUILDKIT=1`.)
 
-See [the Binary Ninja user guide](https://ofrak.com/docs/user-guide/binary_ninja.html) for more information about using Binary Ninja wiht OFRAK.
+See the [Binary Ninja user guide](./user-guide/binary_ninja.md) for more information about using Binary Ninja with OFRAK.
 
 ### Useful Docker Commands
 

--- a/docs/user-guide/binary_ninja.md
+++ b/docs/user-guide/binary_ninja.md
@@ -2,7 +2,9 @@
 
 ## Install
 
-Binary Ninja is not distributed with OFRAK. Instead, if a license is present, the Docker build step will run the official headless installer using the provided license. **You need to have a valid BinaryNinja license to build and run the image.** For more details, [read about the environment setup](https://ofrak.com/docs/environment-setup.html).
+Binary Ninja is not distributed with OFRAK. **You need to have a valid headless BinaryNinja license to build and run the image.** For more details, [read about the environment setup](../environment-setup.md#binary-ninja).
+
+The recommended BinaryNinja version to use with OFRAK is 3.2.3814. If you are running OFRAK outside of the Docker image, you can switch to this version of BinaryNinja using the [BinaryNinja version switcher](https://github.com/Vector35/binaryninja-api/blob/dev/python/examples/version_switcher.py).
 
 To make this backend available to OFRAK, the Docker container should be run with the same license file from the installation step. The license can then be mounted into the Docker container at location `/root/.binaryninja/license.dat` by adding the following arguments to the `docker run` command:
 

--- a/docs/user-guide/patch-maker/user-guide.md
+++ b/docs/user-guide/patch-maker/user-guide.md
@@ -256,7 +256,7 @@ dataclass ToolchainConfig:
 Check out the [ToolchainConfig][ofrak_patch_maker.toolchain.model.ToolchainConfig] for the full suite
 of tunables (they are likely to get updated frequently while OFRAK is developed).
 
-Together, [ArchInfo][ofrak_type.architecture.ArchInfo] and [ToolchainConfig][ofrak_patch_maker.toolchain.model.ToolchainConfig] can be used to instantiate a [Toolchain][ofrak_patch_maker.abstract.Toolchain].
+Together, [ArchInfo][ofrak_type.architecture.ArchInfo] and [ToolchainConfig][ofrak_patch_maker.toolchain.model.ToolchainConfig] can be used to instantiate a [Toolchain][ofrak_patch_maker.toolchain.abstract.Toolchain].
 
 
 #### PatchMaker Instantiation

--- a/ofrak-binary-ninja.yml
+++ b/ofrak-binary-ninja.yml
@@ -12,6 +12,9 @@ packages_paths:
     frontend,
   ]
 extra_build_args:
-  ["--secret",
-   "id=serial,src=serial.txt"
+  [
+    "--secret",
+    "id=serial,src=serial.txt",
+    "--secret",
+    "id=license.dat,src=license.dat"
   ]


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Pin BinaryNinja version to 3.2.3814 in Docker build.

**Please describe the changes in your request.**
Pin BinaryNinja version to 3.2.3814. This is currently the recommended BinaryNinja version for compatibility with OFRAK.
