### PR TITLE
Add support for flash with multiple of the same field type in attribute

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - Updates to Flash components: [#195](https://github.com/redballoonsecurity/ofrak/pull/195)
   - Flash components now support more than one occurrence of the same field type in `FlashAttributes`.
-  - `FlashOobResourceUnpacker` continues to unpack even it blocks do not perfectly align at end of the `FlashOobResource` (this is useful for real-world flash dumps).
+  - `FlashOobResourceUnpacker` continues to unpack even if blocks do not perfectly align at end of the `FlashOobResource` (this is useful for real-world flash dumps).
 
 ### Fixed
 - Fix bug where initially loaded GUI resource has collapsed children

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+### Added
+- Updates to Flash components: [#195](https://github.com/redballoonsecurity/ofrak/pull/195)
+  - Flash components now support more than one occurrence of the same field type in `FlashAttributes`.
+  - `FlashOobResourceUnpacker` continues to unpack even it blocks do not perfectly align at end of the `FlashOobResource` (this is useful for real-world flash dumps).
+
 ### Fixed
 - Fix bug where initially loaded GUI resource has collapsed children
 

--- a/ofrak_core/ofrak/core/flash.py
+++ b/ofrak_core/ofrak/core/flash.py
@@ -444,6 +444,8 @@ class FlashOobResourceUnpacker(Unpacker[None]):
             field_offset = 0
             for field_index, field in enumerate(block):
                 field_range = Range(field_offset, field_offset + field.size)
+
+                # We must check all blocks anyway so deal with ECC here
                 if field.field_type == FlashFieldType.ECC:
                     block_ecc_range = field_range
                     cur_block_ecc = block_data[block_ecc_range.start : block_ecc_range.end]
@@ -451,6 +453,7 @@ class FlashOobResourceUnpacker(Unpacker[None]):
                     # Add hash of everything up to the ECC to our dict for faster packing
                     block_data_hash = md5(block_data[: block_ecc_range.start]).digest()
                     DATA_HASHES[block_data_hash] = cur_block_ecc
+
                 if field.field_type == FlashFieldType.DATA:
                     block_data_range = field_range
                     # Get next ECC range
@@ -463,7 +466,7 @@ class FlashOobResourceUnpacker(Unpacker[None]):
                         future_offset += future_field.size
 
                     if block_ecc_range is not None:
-                        # Try decoding/correcting with ECC, otherwise just add the data anyway
+                        # Try decoding/correcting with ECC, report any error
                         try:
                             # Assumes that data comes before ECC
                             if (ecc_attr is not None) and (ecc_attr.ecc_class is not None):
@@ -477,7 +480,7 @@ class FlashOobResourceUnpacker(Unpacker[None]):
                         except EccError:
                             raise UnpackerError("ECC correction failed")
                     else:
-                        # No ECC, just add the data directly
+                        # No ECC found in block, just add the data directly
                         only_data += block_data[block_data_range.start : block_data_range.end]
                 field_offset += field.size
             offset += block_size

--- a/ofrak_core/ofrak/core/flash.py
+++ b/ofrak_core/ofrak/core/flash.py
@@ -439,11 +439,11 @@ class FlashOobResourceUnpacker(Unpacker[None]):
             block_data = await oob_resource.get_data(range=block_range)
 
             # Iterate through every field in block, dealing with ECC and DATA
+            block_ecc_range = None
+            block_data_range = None
             field_offset = 0
             for field in c:
                 field_range = Range(field_offset, field_offset + field.size)
-                block_ecc_range = None
-                block_data_range = None
                 if field.field_type == FlashFieldType.ECC:
                     block_ecc_range = field_range
                     cur_block_ecc = block_data[block_ecc_range.start : block_ecc_range.end]

--- a/ofrak_core/ofrak/core/flash.py
+++ b/ofrak_core/ofrak/core/flash.py
@@ -458,7 +458,8 @@ class FlashOobResourceUnpacker(Unpacker[None]):
                     block_data_range = field_range
                     # Get next ECC range
                     future_offset = field_offset
-                    for future_field in block[field_index:]:
+                    block_list = list(block)
+                    for future_field in block_list[field_index:]:
                         if future_field.field_type == FlashFieldType.ECC:
                             block_ecc_range = Range(
                                 future_offset, future_offset + future_field.size

--- a/ofrak_core/test_ofrak/components/assets/flash_test_default_unpacked_modified_verify.bin
+++ b/ofrak_core/test_ofrak/components/assets/flash_test_default_unpacked_modified_verify.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3ad98d6fd8c118c1ee6f61ec0b5874ecc17d0293fac6e84145dc3aa40c42345
+size 881

--- a/ofrak_core/test_ofrak/components/assets/flash_test_default_unpacked_verify.bin
+++ b/ofrak_core/test_ofrak/components/assets/flash_test_default_unpacked_verify.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3ad98d6fd8c118c1ee6f61ec0b5874ecc17d0293fac6e84145dc3aa40c42345
+oid sha256:ac9f6c1916c48374e067caff8c393012cd5a22d76c2c103a67fbad7c310e769d
 size 881

--- a/ofrak_core/test_ofrak/components/test_flash_component.py
+++ b/ofrak_core/test_ofrak/components/test_flash_component.py
@@ -24,6 +24,9 @@ DEFAULT_VERIFY_FILE = os.path.join(
 DEFAULT_UNPACKED_VERIFY_FILE = os.path.join(
     test_ofrak.components.ASSETS_DIR, "flash_test_default_unpacked_verify.bin"
 )
+DEFAULT_UNPACKED_MODIFIED_VERIFY_FILE = os.path.join(
+    test_ofrak.components.ASSETS_DIR, "flash_test_default_unpacked_modified_verify.bin"
+)
 DEFAULT_TEST_ATTR = FlashAttributes(
     header_block_format=[
         FlashField(FlashFieldType.MAGIC, 7),
@@ -196,6 +199,12 @@ class TestFlashUnpackModifyPackUnpackVerify(TestFlashUnpackModifyPack):
         root_resource.add_attributes(DEFAULT_TEST_ATTR)
         await root_resource.save()
         await self.unpack(root_resource)
+        logical_data_resource = await root_resource.get_only_descendant(
+            r_filter=ResourceFilter.with_tags(
+                FlashLogicalDataResource,
+            ),
+        )
+        await self.verify(logical_data_resource, DEFAULT_UNPACKED_VERIFY_FILE)
         await self.modify(root_resource)
         await self.repack(root_resource)
         await self.unpack(root_resource)
@@ -204,4 +213,4 @@ class TestFlashUnpackModifyPackUnpackVerify(TestFlashUnpackModifyPack):
                 FlashLogicalDataResource,
             ),
         )
-        await self.verify(logical_data_resource, DEFAULT_UNPACKED_VERIFY_FILE)
+        await self.verify(logical_data_resource, DEFAULT_UNPACKED_MODIFIED_VERIFY_FILE)


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Allows for multiple of the same `FlashField.field_type` within a block format as described by `FlashAttributes`

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Instead of assuming only one of type DATA or ECC, now will parse each field individually and handle accordingly. This should allow a lot more flexibility to customize for different use cases.

**Anyone you think should look at this, specifically?**
@whyitfor 