### PR TITLE
Enable running the GUI without opening the browser

### DIFF
--- a/ofrak-core-dev.yml
+++ b/ofrak-core-dev.yml
@@ -7,4 +7,5 @@ packages_paths:
     "ofrak_io",
     "ofrak_patch_maker",
     "ofrak_core",
+    "frontend",
   ]

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - GUI is much faster, especially for resources with hundreds of thousands of children [#191](https://github.com/redballoonsecurity/ofrak/pull/191)
 
+### Added
+- GUI command line now has a flag to not automatically open the browser
+
 
 ## [2.1.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.0...ofrak-v2.1.1) - 2023-01-25
 ### Fixed

--- a/ofrak_core/ofrak/cli/command/gui.py
+++ b/ofrak_core/ofrak/cli/command/gui.py
@@ -2,7 +2,7 @@ import logging
 from argparse import ArgumentDefaultsHelpFormatter, Namespace
 
 from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
-from ofrak.gui.server import open_gui, start_server
+from ofrak.gui.server import open_gui
 from ofrak.ofrak_context import OFRAKContext
 
 LOGGER = logging.getLogger(__name__)
@@ -40,8 +40,5 @@ class GUICommand(OfrakCommandRunsScript):
         return gui_parser
 
     async def ofrak_func(self, ofrak_context: OFRAKContext, args: Namespace):  # pragma: no cover
-        if not args.no_browser:
-            server = await open_gui(args.hostname, args.port)
-        else:
-            server = await start_server(ofrak_context, args.hostname, args.port)
+        server = await open_gui(args.hostname, args.port, open_in_browser=(not args.no_browser))
         await server.run_until_cancelled()

--- a/ofrak_core/ofrak/cli/command/gui.py
+++ b/ofrak_core/ofrak/cli/command/gui.py
@@ -2,7 +2,7 @@ import logging
 from argparse import ArgumentDefaultsHelpFormatter, Namespace
 
 from ofrak.cli.ofrak_cli import OfrakCommandRunsScript
-from ofrak.gui.server import open_gui
+from ofrak.gui.server import open_gui, start_server
 from ofrak.ofrak_context import OFRAKContext
 
 LOGGER = logging.getLogger(__name__)
@@ -31,9 +31,17 @@ class GUICommand(OfrakCommandRunsScript):
             help="Set GUI server host port.",
             default=8080,
         )
+        gui_parser.add_argument(
+            "--no-browser",
+            action="store_true",
+            help="Don't open the browser to the OFRAK GUI",
+        )
         self.add_ofrak_arguments(gui_parser)
         return gui_parser
 
     async def ofrak_func(self, ofrak_context: OFRAKContext, args: Namespace):  # pragma: no cover
-        server = await open_gui(args.hostname, args.port)
+        if not args.no_browser:
+            server = await open_gui(args.hostname, args.port)
+        else:
+            server = await start_server(ofrak_context, args.hostname, args.port)
         await server.run_until_cancelled()

--- a/ofrak_core/ofrak/cli/command/identify.py
+++ b/ofrak_core/ofrak/cli/command/identify.py
@@ -40,6 +40,11 @@ class IdentifyCommand(OfrakCommandRunsScript):
             help="Set GUI server host port.",
             default=8080,
         )
+        subparser.add_argument(
+            "--gui-no-browser",
+            action="store_true",
+            help="Don't open the browser to the OFRAK GUI",
+        )
 
         return subparser
 
@@ -51,7 +56,12 @@ class IdentifyCommand(OfrakCommandRunsScript):
         print(await IdentifyCommand.print_info(root_resource))
 
         if args.gui:
-            server = await open_gui(args.gui_hostname, args.gui_port, focus_resource=root_resource)
+            server = await open_gui(
+                args.gui_hostname,
+                args.gui_port,
+                focus_resource=root_resource,
+                open_in_browser=(not args.gui_no_browser),
+            )
             await server.run_until_cancelled()
 
     @staticmethod

--- a/ofrak_core/ofrak/cli/command/unpack.py
+++ b/ofrak_core/ofrak/cli/command/unpack.py
@@ -66,6 +66,11 @@ class UnpackCommand(OfrakCommandRunsScript):
             help="Set GUI server host port.",
             default=8080,
         )
+        subparser.add_argument(
+            "--gui-no-browser",
+            action="store_true",
+            help="Don't open the browser to the OFRAK GUI",
+        )
 
         self.add_ofrak_arguments(subparser)
 
@@ -120,7 +125,12 @@ class UnpackCommand(OfrakCommandRunsScript):
         print(info_dump)
 
         if args.gui:
-            server = await open_gui(args.gui_hostname, args.gui_port, focus_resource=root_resource)
+            server = await open_gui(
+                args.gui_hostname,
+                args.gui_port,
+                focus_resource=root_resource,
+                open_in_browser=(not args.gui_no_browser),
+            )
             await server.run_until_cancelled()
 
     async def resource_tree_to_files(self, resource: Resource, path):

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -536,14 +536,6 @@ class AiohttpOFRAKServer:
         """
         return list(map(self._serialize_resource, resources))
 
-    def open_resource_in_browser(self, resource: Optional[Resource]):  # pragma: no cover
-        if resource is None:
-            url = f"http://{self._host}:{self._port}/"
-        else:
-            url = f"http://{self._host}:{self._port}/#{resource.get_id().hex()}"
-        print(f"GUI is being served on {url}")
-        webbrowser.open(url)
-
 
 async def start_server(
     ofrak_context: OFRAKContext, host: str, port: int
@@ -597,8 +589,16 @@ async def open_gui(
         ofrak_context = get_current_ofrak_context()
 
     server = await start_server(ofrak_context, host, port)
+
+    if focus_resource is None:
+        url = f"http://{server._host}:{server._port}/"
+    else:
+        url = f"http://{server._host}:{server._port}/#{focus_resource.get_id().hex()}"
+    print(f"GUI is being served on {url}")
+
     if open_in_browser:
-        server.open_resource_in_browser(focus_resource)
+        webbrowser.open(url)
+
     return server
 
 

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -495,10 +495,12 @@ async def open_gui(
     port: int,
     focus_resource: Optional[Resource] = None,
     ofrak_context: Optional[OFRAKContext] = None,
+    open_in_browser: bool = True,
 ) -> AiohttpOFRAKServer:  # pragma: no cover
     if ofrak_context is None:
         ofrak_context = get_current_ofrak_context()
 
     server = await start_server(ofrak_context, host, port)
-    server.open_resource_in_browser(focus_resource)
+    if open_in_browser:
+        server.open_resource_in_browser(focus_resource)
     return server


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

Enable running the GUI without opening the browser.

**Please describe the changes in your request.**

Sometimes, a user may not want to open the browser automatically when they start the GUI. This adds a command-line option to enable that feature.

**Anyone you think should look at this, specifically?**

@EdwardLarson 