### PR TITLE
Bugfix/set id service

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Fixed
+- Fix long-broken `OFRAK.set_id_service`
 
 ## [2.1.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.0...ofrak-v2.1.1) - 2023-01-25
 ### Fixed

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from types import ModuleType
-from typing import Type, Any, Awaitable, Callable, List, Iterable
+from typing import Type, Any, Awaitable, Callable, List, Iterable, Optional
 
 from ofrak_type import InvalidStateError
 from synthol.injector import DependencyInjector
@@ -122,6 +122,7 @@ class OFRAK:
         self.injector = DependencyInjector()
         self._discovered_modules: List[ModuleType] = []
         self._exclude_components_missing_dependencies = exclude_components_missing_dependencies
+        self._id_service: Optional[IDServiceInterface] = None
 
     def discover(
         self,
@@ -133,7 +134,7 @@ class OFRAK:
         self._discovered_modules.append(module)
 
     def set_id_service(self, service: IDServiceInterface):
-        self.injector.bind_instance(service)
+        self._id_service = service
 
     async def create_ofrak_context(self) -> OFRAKContext:
         """
@@ -184,6 +185,9 @@ class OFRAK:
         import ofrak
 
         self.discover(ofrak)
+
+        if self._id_service:
+            self.injector.bind_instance(self._id_service)
 
     async def _get_discovered_components(self) -> List[ComponentInterface]:
         all_discovered_components = await self.injector.get_instance(List[ComponentInterface])


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix long-broken `OFRAK.set_id_service`

**Link to Related Issue(s)**
`set_id_service` is supposed to be a convenient way to set the ID service (mainly to the sequential ID service, for testing), but has been broken for a long time. The problem is it sets the `synthol` provider for the `IDServiceInterface`, but the discovery of OFRAK classes happens later, which actually overwrite that provider with what it finds in `ofrak`.

**Please describe the changes in your request.**
Save the given ID service for later so that it won't be overwritten.

**Anyone you think should look at this, specifically?**
@rbs-jacob 