### PR TITLE
Add GUI file dialog component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ofrak-app",
-  "version": "0.6.0",
+  "version": "2.1.2",
   "description": "The graphical front-end for OFRAK.",
   "homepage": "https://ofrak.com",
   "private": true,

--- a/frontend/src/FileBrowser.svelte
+++ b/frontend/src/FileBrowser.svelte
@@ -60,7 +60,10 @@
 <div
   on:dragover|preventDefault="{() => (dragging = true)}"
   on:dragleave|preventDefault="{() => (dragging = false)}"
-  on:drop|preventDefault="{(e) => (files = e.dataTransfer.files)}"
+  on:drop|preventDefault="{(e) => {
+    files = e.dataTransfer.files;
+    dragging = false;
+  }}"
 >
   {#if !dragging}
     <label class="filelabel">

--- a/frontend/src/FileBrowser.svelte
+++ b/frontend/src/FileBrowser.svelte
@@ -54,19 +54,30 @@
 
 <script>
   export let files, input;
+  let dragging = false;
 </script>
 
-<label class="filelabel">
-  <slot />
-  <input type="file" bind:this="{input}" bind:files="{files}" />
-  <span>
-    <button on:click="{() => input.click()}"> Browse... </button>
-    {#if files}
-      {Array.from(files)
-        .map((f) => f?.name)
-        .join(", ")}
-    {:else}
-      No file selected.
-    {/if}
-  </span>
-</label>
+<div
+  on:dragover|preventDefault="{() => (dragging = true)}"
+  on:dragleave|preventDefault="{() => (dragging = false)}"
+  on:drop|preventDefault="{(e) => (files = e.dataTransfer.files)}"
+>
+  {#if !dragging}
+    <label class="filelabel">
+      <slot />
+      <input type="file" bind:this="{input}" bind:files="{files}" />
+      <span>
+        <button on:click="{() => input.click()}"> Browse... </button>
+        {#if files}
+          {Array.from(files)
+            .map((f) => f?.name)
+            .join(", ")}
+        {:else}
+          No file selected.
+        {/if}
+      </span>
+    </label>
+  {:else}
+    Drop the files to upload.
+  {/if}
+</div>

--- a/frontend/src/FileBrowser.svelte
+++ b/frontend/src/FileBrowser.svelte
@@ -1,0 +1,72 @@
+<style>
+  button {
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    padding-left: 1em;
+    padding-right: 1em;
+    margin-right: 2ch;
+  }
+
+  button:hover,
+  button:focus {
+    outline: none;
+    box-shadow: inset 1px 1px 0 currentColor, inset -1px -1px 0 currentColor;
+  }
+
+  button:active {
+    box-shadow: inset 2px 2px 0 currentColor, inset -2px -2px 0 currentColor;
+  }
+
+  .filelabel {
+    cursor: pointer;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    background: inherit;
+    border-color: inherit;
+    box-shadow: none;
+    user-select: none;
+    line-height: inherit;
+  }
+
+  .filelabel span {
+    width: 100%;
+    margin-left: 2ch;
+    background: inherit;
+    color: inherit;
+    /* border-bottom: 1px solid var(--main-fg-color); */
+  }
+
+  input[type="file"] {
+    display: none;
+  }
+
+  label {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-evenly;
+    align-items: baseline;
+    align-content: center;
+    white-space: nowrap;
+  }
+</style>
+
+<script>
+  export let files, input;
+</script>
+
+<label class="filelabel">
+  <slot />
+  <input type="file" bind:this="{input}" bind:files="{files}" />
+  <span>
+    <button on:click="{() => input.click()}"> Browse... </button>
+    {#if files}
+      {Array.from(files)
+        .map((f) => f?.name)
+        .join(", ")}
+    {:else}
+      No file selected.
+    {/if}
+  </span>
+</label>

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -93,11 +93,14 @@
     preExistingRootsPromise = new Promise(() => {}),
     tryHash = !!window.location.hash;
   let mouseX, selectedAnimal;
+  const warnFileSizeMb = 250;
 
   async function createRootResource(f) {
     if (
-      f.size > 1024 * 1024 * 250 &&
-      !window.confirm("Loading a large file may be slow. Are you sure?")
+      f.size > 1024 * 1024 * warnFileSizeMb &&
+      !window.confirm(
+        `Loading a large file (>${warnFileSizeMb}MB) may be slow. Are you sure?`
+      )
     ) {
       showRootResource = false;
       return;

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -248,7 +248,10 @@
     {:then preExistingRootResources}
       {#if preExistingRootsPromise && preExistingRootsPromise.length > 0}
         <form on:submit|preventDefault="{choosePreExistingRoot}">
-          <select bind:value="{selectedPreExistingRoot}">
+          <select
+            on:click|stopPropagation="{() => undefined}"
+            bind:value="{selectedPreExistingRoot}"
+          >
             <option value="{null}">Open existing resource</option>
             {#each preExistingRootResources as preExistingRoot}
               <option value="{preExistingRoot}">
@@ -262,8 +265,10 @@
             {/each}
           </select>
 
-          <button disabled="{!selectedPreExistingRoot}" type="submit"
-            >Go!</button
+          <button
+            on:click|stopPropagation="{() => undefined}"
+            disabled="{!selectedPreExistingRoot}"
+            type="submit">Go!</button
           >
         </form>
       {:else}

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -86,7 +86,8 @@
     showRootResource,
     resources,
     rootResource,
-    resourceNodeDataMap;
+    resourceNodeDataMap,
+    browsedFiles;
   let dragging = false,
     selectedPreExistingRoot = null,
     preExistingRootsPromise = new Promise(() => {}),
@@ -94,6 +95,14 @@
   let mouseX, selectedAnimal;
 
   async function createRootResource(f) {
+    if (
+      f.size > 1024 * 1024 * 250 &&
+      !window.confirm("Loading a large file may be slow. Are you sure?")
+    ) {
+      showRootResource = false;
+      return;
+    }
+
     const rootModel = await fetch(`/create_root_resource?name=${f.name}`, {
       method: "POST",
       body: await f.arrayBuffer(),
@@ -126,6 +135,12 @@
       rootResourceLoadPromise = createRootResource(f);
       await rootResourceLoadPromise;
     }
+  }
+
+  $: if (browsedFiles && browsedFiles.length > 0) {
+    showRootResource = true;
+    const f = browsedFiles[0];
+    createRootResource(f);
   }
 
   async function getResourcesFromHash(resourceId) {
@@ -211,7 +226,7 @@
     </div>
 
     <div class="maxwidth">
-      <FileBrowser />
+      <FileBrowser bind:files="{browsedFiles}" />
     </div>
 
     <div class="maxwidth">

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -213,7 +213,7 @@
 
 {#if !tryHash}
   <div
-    class="center {dragging ? 'dragging' : ''}"
+    class="center clickable {dragging ? 'dragging' : ''}"
     on:dragover|preventDefault="{(e) => {
       dragging = true;
       mouseX = e.clientX;
@@ -222,14 +222,13 @@
     on:drop|preventDefault="{handleDrop}"
     on:mousemove="{(e) => (mouseX = e.clientX)}"
     on:mouseleave="{() => (mouseX = undefined)}"
+    on:click="{() => fileinput.click()}"
     style:border-color="{animals[selectedAnimal]?.color ||
       "var(--main-fg-color)"}"
     style:color="{animals[selectedAnimal]?.color || "var(--main-fg-color)"}"
   >
     {#if !dragging}
-      <h1 class="clickable" on:click="{() => fileinput.click()}">
-        Drag in a file to analyze
-      </h1>
+      <h1>Drag in a file to analyze</h1>
     {:else}
       <h1>Drop the file!</h1>
     {/if}

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -58,6 +58,10 @@
     height: calc(100% - 6em);
   }
 
+  input[type="file"] {
+    display: none;
+  }
+
   .maxwidth {
     max-width: 50%;
     width: 50%;
@@ -66,6 +70,10 @@
     flex-direction: row;
     justify-content: center;
     align-items: center;
+  }
+
+  .clickable {
+    cursor: pointer;
   }
 </style>
 
@@ -88,7 +96,8 @@
     resources,
     rootResource,
     resourceNodeDataMap,
-    browsedFiles;
+    browsedFiles,
+    fileinput;
   let dragging = false,
     selectedPreExistingRoot = null,
     preExistingRootsPromise = new Promise(() => {}),
@@ -218,22 +227,14 @@
     style:color="{animals[selectedAnimal]?.color || "var(--main-fg-color)"}"
   >
     {#if !dragging}
-      <h1>Drag in a file to analyze</h1>
+      <h1 class="clickable" on:click="{() => fileinput.click()}">
+        Drag in a file to analyze
+      </h1>
     {:else}
       <h1>Drop the file!</h1>
     {/if}
 
-    <div class="maxwidth">
-      <TextDivider
-        color="{animals[selectedAnimal]?.color || 'var(--main-fg-color)'}"
-      >
-        OR
-      </TextDivider>
-    </div>
-
-    <div class="maxwidth">
-      <FileBrowser bind:files="{browsedFiles}" />
-    </div>
+    <input type="file" bind:this="{fileinput}" bind:files="{browsedFiles}" />
 
     <div class="maxwidth">
       <TextDivider

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -4,6 +4,8 @@
     font-weight: bold;
     color: inherit;
     font-size: xxx-large;
+    line-height: 1;
+    margin: 0;
   }
 
   .center {
@@ -55,6 +57,12 @@
     width: calc(100% - 6em);
     height: calc(100% - 6em);
   }
+
+  .maxwidth {
+    max-width: 50%;
+    width: 50%;
+    margin: 1em 0;
+  }
 </style>
 
 <script>
@@ -67,6 +75,7 @@
   import { remote_model_to_resource } from "./ofrak/remote_resource";
 
   import { onMount } from "svelte";
+  import TextDivider from "./TextDivider.svelte";
 
   export let rootResourceLoadPromise,
     showRootResource,
@@ -187,6 +196,26 @@
     {:else}
       <h1>Drop the file!</h1>
     {/if}
+
+    <div class="maxwidth">
+      <TextDivider
+        color="{animals[selectedAnimal]?.color || 'var(--main-fg-color)'}"
+      >
+        OR
+      </TextDivider>
+    </div>
+
+    <div class="maxwidth">
+      <p>TODO: File browser</p>
+    </div>
+
+    <div class="maxwidth">
+      <TextDivider
+        color="{animals[selectedAnimal]?.color || 'var(--main-fg-color)'}"
+      >
+        OR
+      </TextDivider>
+    </div>
 
     {#await preExistingRootsPromise}
       <LoadingText />

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -81,6 +81,7 @@
   import { onMount } from "svelte";
   import TextDivider from "./TextDivider.svelte";
   import FileBrowser from "./FileBrowser.svelte";
+  import { numBytesToQuantity } from "./helpers";
 
   export let rootResourceLoadPromise,
     showRootResource,
@@ -93,13 +94,15 @@
     preExistingRootsPromise = new Promise(() => {}),
     tryHash = !!window.location.hash;
   let mouseX, selectedAnimal;
-  const warnFileSizeMb = 250;
+  const warnFileSize = 250 * 1024 * 1024;
 
   async function createRootResource(f) {
     if (
-      f.size > 1024 * 1024 * warnFileSizeMb &&
+      f.size > warnFileSize &&
       !window.confirm(
-        `Loading a large file (>${warnFileSizeMb}MB) may be slow. Are you sure?`
+        `Loading a large file (${numBytesToQuantity(
+          f.size
+        )} > ${numBytesToQuantity(warnFileSize)}) may be slow. Are you sure?`
       )
     ) {
       showRootResource = false;

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -239,7 +239,7 @@
   >
     {#if !dragging}
       <h1>Drag in a file to analyze</h1>
-      <p>Click anwyhere to browse your computer</p>
+      <p style:margin-bottom="0">Click anwyhere to browse your computer</p>
     {:else}
       <h1>Drop the file!</h1>
     {/if}

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -140,7 +140,7 @@
   $: if (browsedFiles && browsedFiles.length > 0) {
     showRootResource = true;
     const f = browsedFiles[0];
-    createRootResource(f);
+    rootResourceLoadPromise = createRootResource(f);
   }
 
   async function getResourcesFromHash(resourceId) {

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -6,6 +6,12 @@
     font-size: xxx-large;
     line-height: 1;
     margin: 0;
+    max-width: 50%;
+    text-align: center;
+  }
+
+  form {
+    max-width: 50%;
   }
 
   .center {
@@ -75,20 +81,23 @@
   .clickable {
     cursor: pointer;
   }
+
+  .underline {
+    text-decoration: underline;
+  }
 </style>
 
 <script>
   import Animals from "./Animals.svelte";
   import LoadingAnimation from "./LoadingAnimation.svelte";
   import LoadingText from "./LoadingText.svelte";
+  import TextDivider from "./TextDivider.svelte";
 
   import { animals } from "./animals.js";
   import { selected } from "./stores.js";
   import { remote_model_to_resource } from "./ofrak/remote_resource";
 
   import { onMount } from "svelte";
-  import TextDivider from "./TextDivider.svelte";
-  import FileBrowser from "./FileBrowser.svelte";
   import { numBytesToQuantity } from "./helpers";
 
   export let rootResourceLoadPromise,
@@ -212,6 +221,7 @@
 </script>
 
 {#if !tryHash}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div
     class="center clickable {dragging ? 'dragging' : ''}"
     on:dragover|preventDefault="{(e) => {
@@ -229,6 +239,7 @@
   >
     {#if !dragging}
       <h1>Drag in a file to analyze</h1>
+      <p>Click anwyhere to browse your computer</p>
     {:else}
       <h1>Drop the file!</h1>
     {/if}

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -62,6 +62,10 @@
     max-width: 50%;
     width: 50%;
     margin: 1em 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
   }
 </style>
 
@@ -76,6 +80,7 @@
 
   import { onMount } from "svelte";
   import TextDivider from "./TextDivider.svelte";
+  import FileBrowser from "./FileBrowser.svelte";
 
   export let rootResourceLoadPromise,
     showRootResource,
@@ -206,7 +211,7 @@
     </div>
 
     <div class="maxwidth">
-      <p>TODO: File browser</p>
+      <FileBrowser />
     </div>
 
     <div class="maxwidth">
@@ -220,23 +225,29 @@
     {#await preExistingRootsPromise}
       <LoadingText />
     {:then preExistingRootResources}
-      <form on:submit|preventDefault="{choosePreExistingRoot}">
-        <select bind:value="{selectedPreExistingRoot}">
-          <option value="{null}">None</option>
-          {#each preExistingRootResources as preExistingRoot}
-            <option value="{preExistingRoot}">
-              {preExistingRoot.id} &ndash;
-              {#if preExistingRoot.caption}
-                {preExistingRoot.caption}
-              {:else}
-                Untagged
-              {/if}
-            </option>
-          {/each}
-        </select>
+      {#if preExistingRootsPromise && preExistingRootsPromise.length > 0}
+        <form on:submit|preventDefault="{choosePreExistingRoot}">
+          <select bind:value="{selectedPreExistingRoot}">
+            <option value="{null}">Open existing resource</option>
+            {#each preExistingRootResources as preExistingRoot}
+              <option value="{preExistingRoot}">
+                {preExistingRoot.id} &ndash;
+                {#if preExistingRoot.caption}
+                  {preExistingRoot.caption}
+                {:else}
+                  Untagged
+                {/if}
+              </option>
+            {/each}
+          </select>
 
-        <button disabled="{!selectedPreExistingRoot}" type="submit">Go!</button>
-      </form>
+          <button disabled="{!selectedPreExistingRoot}" type="submit"
+            >Go!</button
+          >
+        </form>
+      {:else}
+        No resources loaded yet.
+      {/if}
     {:catch}
       <p>Failed to get any pre-existing root resources!</p>
       <p>The back end server may be down.</p>

--- a/frontend/src/TextDivider.svelte
+++ b/frontend/src/TextDivider.svelte
@@ -1,0 +1,32 @@
+<style>
+  div {
+    width: 100%;
+    margin: 2em 0;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: center;
+  }
+
+  hr {
+    flex-grow: 1;
+    border: none;
+    color: inherit;
+    border-bottom: 1px solid currentColor;
+  }
+
+  span {
+    padding: 0 2ch;
+  }
+</style>
+
+<script>
+  export let color;
+</script>
+
+<div>
+  <hr style:color="{color}" />
+  <span><slot /></span>
+  <hr style:color="{color}" />
+</div>

--- a/frontend/src/helpers.js
+++ b/frontend/src/helpers.js
@@ -52,11 +52,29 @@ export function buf2hex(buffer, joinchar) {
     .join(joinchar ? joinchar : "");
 }
 
-/**
+/***
  * Asynchronously sleep for a certain number of milliseconds.
  */
 export async function sleep(ms) {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Turn a number of bytes into a text-based file size
+ */
+export function numBytesToQuantity(bytes) {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  } else if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(2)}KB`;
+  } else if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(2)}MB`;
+  } else if (bytes < 1024 * 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GB`;
+  } else {
+    // TODO if necessary
+    return `${bytes}B`;
+  }
 }
 
 /***

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 - Replace unofficial p7zip with official 7zip package. 
+- File browser dialog in the GUI
 
 ### Changed
 - GUI is much faster, especially for resources with hundreds of thousands of children [#191](https://github.com/redballoonsecurity/ofrak/pull/191)


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

This adds a "file browser" dialog component to the GUI.

**Please describe the changes in your request.**

This PR adds a "file browser" to the GUI and places it on the first screen when the GUI loads. This PR also includes a few small changes such as a warning for large files and a new default message when there are no previously-loaded resources for the start page dropdown.

The new start page looks like this:

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/99368685/216183560-c641d003-41fc-4f6c-bb77-13bd84cb9484.png">

**Anyone you think should look at this, specifically?**

@whyitfor 