### PR TITLE
Bugfix: more selective criteria for resources to delete when injecting

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Fixed
 - Fix long-broken `OFRAK.set_id_service` [#198](https://github.com/redballoonsecurity/ofrak/pull/198)
-- Delete narrower list of resources when using `SegmentInjectorModifier` [#200](https://github.com/redballoonsecurity/ofrak/pull/200)
+- Fix bug in `SegmentInjectorModifier` that resulted in deleting more resources than necessary [#200](https://github.com/redballoonsecurity/ofrak/pull/200)
 
 ### Changed
 - GUI is much faster, especially for resources with hundreds of thousands of children [#191](https://github.com/redballoonsecurity/ofrak/pull/191)

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 - GUI is much faster, especially for resources with hundreds of thousands of children [#191](https://github.com/redballoonsecurity/ofrak/pull/191)
+- Resources whose data gets modified are now listed in the `resource_modified` field of component results [#200](https://github.com/redballoonsecurity/ofrak/pull/200)
 
 
 ## [2.1.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.0...ofrak-v2.1.1) - 2023-01-25

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Fixed
 - Fix long-broken `OFRAK.set_id_service` [#198](https://github.com/redballoonsecurity/ofrak/pull/198)
+- Delete narrower list of resources when using `SegmentInjectorModifier` [#200](https://github.com/redballoonsecurity/ofrak/pull/200)
 
 ### Changed
 - GUI is much faster, especially for resources with hundreds of thousands of children [#191](https://github.com/redballoonsecurity/ofrak/pull/191)

--- a/ofrak_core/ofrak/component/abstract.py
+++ b/ofrak_core/ofrak/component/abstract.py
@@ -149,13 +149,15 @@ class AbstractComponent(ComponentInterface[CC], ABC):
                     f"the resource context"
                 )
 
-        # Get resources modified by data patches
+        # Include resources modified by data patches in `modified_resource_ids`
         data_ids_to_models = await dependency_handler.map_data_ids_to_resources(
             patch_result.data_id for patch_result in patch_results
         )
         for m in data_ids_to_models.values():
             modified_resource_ids.add(m.id)
 
+        # Exclude deleted resources from `modified_resource_ids`
+        # (deleting and modifying are handled separately)
         modified_resource_ids.difference_update(component_context.resources_deleted)
 
         # Save modified resources

--- a/ofrak_core/ofrak/component/abstract.py
+++ b/ofrak_core/ofrak/component/abstract.py
@@ -149,6 +149,15 @@ class AbstractComponent(ComponentInterface[CC], ABC):
                     f"the resource context"
                 )
 
+        # Get resources modified by data patches
+        data_ids_to_models = await dependency_handler.map_data_ids_to_resources(
+            patch_result.data_id for patch_result in patch_results
+        )
+        for m in data_ids_to_models.values():
+            modified_resource_ids.add(m.id)
+
+        modified_resource_ids.difference_update(component_context.resources_deleted)
+
         # Save modified resources
         await self._save_resources(
             job_id,

--- a/ofrak_core/ofrak/core/patch_maker/modifiers.py
+++ b/ofrak_core/ofrak/core/patch_maker/modifiers.py
@@ -209,15 +209,14 @@ class SegmentInjectorModifier(Modifier[SegmentInjectorModifierConfig]):
 
             injection_tasks.append((region.resource, BinaryInjectorModifierConfig(patches)))
 
-        all_decendants = await resource.get_descendants()
         for injected_resource, injection_config in injection_tasks:
             result = await injected_resource.run(BinaryInjectorModifier, injection_config)
-            parents_to_delete = list(
-                filter(lambda r: r.get_id() in result.resources_modified, all_decendants)
-            )
-            to_delete = []
-            for parent in parents_to_delete:
-                to_delete.extend(list(await parent.get_descendants()))
+            to_delete = [
+                r
+                for r in await resource.get_descendants()
+                if r.get_id() in result.resources_modified
+                and r.get_id() != injected_resource.get_id()
+            ]
             await asyncio.gather(*(r.delete() for r in to_delete))
 
 

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -16,6 +16,7 @@ from typing import (
     Awaitable,
     Sequence,
     Callable,
+    Set,
 )
 
 from ofrak.component.interface import ComponentInterface
@@ -292,7 +293,8 @@ class Resource:
         try:
             fetched_resource = await self._resource_service.get_by_id(resource.id)
         except NotFoundError:
-            del self._resource_context.resource_models[resource.id]
+            if resource.id in self._component_context.modification_trackers:
+                del self._resource_context.resource_models[resource.id]
             return
 
         resource.reset(fetched_resource)
@@ -305,10 +307,12 @@ class Resource:
                 tasks.append(self._fetch(context_resource))
         await asyncio.gather(*tasks)
 
-    async def _update_views(self, modified: Iterable[bytes], deleted: Iterable[bytes]):
+    async def _update_views(self, modified: Set[bytes], deleted: Set[bytes]):
         for resource_id in modified:
             views_in_context = self._resource_view_context.views_by_resource[resource_id]
             for view in views_in_context.values():
+                if resource_id not in self._resource_context.resource_models:
+                    await self._fetch(view.resource.get_model())  # type: ignore
                 updated_model = self._resource_context.resource_models[resource_id]
                 fresh_view = view.create(updated_model)
                 for field in dataclasses.fields(fresh_view):
@@ -344,6 +348,9 @@ class Resource:
             ),
             job_context,
         )
+        for deleted_id in component_result.resources_deleted:
+            if deleted_id in self._component_context.modification_trackers:
+                del self._component_context.modification_trackers[deleted_id]
         await self._fetch_resources(component_result.resources_modified)
         await self._update_views(
             component_result.resources_modified, component_result.resources_deleted
@@ -386,6 +393,9 @@ class Resource:
                 all_packers=all_packers,
             )
         )
+        for deleted_id in components_result.resources_deleted:
+            if deleted_id in self._component_context.modification_trackers:
+                del self._component_context.modification_trackers[deleted_id]
         await self._fetch_resources(components_result.resources_modified)
         await self._update_views(
             components_result.resources_modified, components_result.resources_deleted

--- a/ofrak_core/ofrak/service/dependency_handler.py
+++ b/ofrak_core/ofrak/service/dependency_handler.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 from typing import Set, List, Iterable, Dict, cast
 
@@ -33,7 +34,8 @@ class DependencyHandler:
         self._component_context = component_context
         self._resource_context = resource_context
 
-    async def _map_data_ids_to_resources(
+    @functools.lru_cache(None)
+    async def map_data_ids_to_resources(
         self, data_ids: Iterable[bytes]
     ) -> Dict[bytes, MutableResourceModel]:
         resources_by_data_id = dict()
@@ -59,7 +61,7 @@ class DependencyHandler:
 
     async def handle_post_patch_dependencies(self, patch_results: List[DataPatchesResult]):
         # Create look up maps for resources and dependencies
-        resources_by_data_id = await self._map_data_ids_to_resources(
+        resources_by_data_id = await self.map_data_ids_to_resources(
             patch_result.data_id for patch_result in patch_results
         )
 

--- a/ofrak_core/ofrak/service/resource_service.py
+++ b/ofrak_core/ofrak/service/resource_service.py
@@ -966,6 +966,7 @@ class ResourceService(ResourceServiceInterface):
             former_parent_resource_node.remove_child(resource_node)
 
         deleted_models = self._delete_resource_helper(resource_node)
+        LOGGER.debug(f"Deleted {resource_id.hex()}")
         return deleted_models
 
     async def delete_resources(self, resource_ids: Iterable[bytes]):
@@ -981,6 +982,8 @@ class ResourceService(ResourceServiceInterface):
                 former_parent_resource_node.remove_child(resource_node)
 
             deleted_models.extend(self._delete_resource_helper(resource_node))
+        if resource_ids:
+            LOGGER.debug(f"Deleted {', '.join(resource_id.hex() for resource_id in resource_ids)}")
         return deleted_models
 
     def _delete_resource_helper(self, _resource_node: ResourceNode):


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Delete narrower list of resources when injecting.

**Link to Related Issue(s)**
All descendants of the injected resource itself would be deleted when injecting segments, not just the descendants affected. The injected resource itself was of course modified, and all descendants of modified resources were marked to be deleted.

**Please describe the changes in your request.**
Only delete resources which are descendants, modified, AND not the injected resource.

**Anyone you think should look at this, specifically?**
@whyitfor @rbs-afflitto 
