### PR TITLE
Remove music files

### DIFF
--- a/frontend/public/sounds/Bush+Week.mp3
+++ b/frontend/public/sounds/Bush+Week.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9003182e4c1de679ff57b77de6da52bc1333dbb3a640f120feee3aa6fc5f95a
-size 14310108

--- a/frontend/public/sounds/Dream+Sunlight.mp3
+++ b/frontend/public/sounds/Dream+Sunlight.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1db46330bc61cef2ce9fb4acd2bb2dc78d33bc9d02d806779f897171c4c6850b
-size 13050128

--- a/frontend/public/sounds/Glimmer.mp3
+++ b/frontend/public/sounds/Glimmer.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7298e94aade9dd53dfe1ef922a15ee07ed9ca3483020c86d928be2057a5f3c24
-size 9809424

--- a/frontend/public/sounds/Motion+Blur.mp3
+++ b/frontend/public/sounds/Motion+Blur.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a79f4ffcf3be961d4dbf41d85c76433063d149f2264aad98d440255ff6ba5896
-size 9464904

--- a/frontend/public/sounds/Panthalassa.mp3
+++ b/frontend/public/sounds/Panthalassa.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d820b64892df9359224ceaa698448e70828939a402c51c0aedb995739cbd0a8f
-size 15302952

--- a/frontend/scripts/download-music.sh
+++ b/frontend/scripts/download-music.sh
@@ -1,31 +1,19 @@
 #!/bin/bash
 
-pushd public/sounds || exit;
-
-curl \
-    --silent \
-    --location "http://www.nihilore.com/synthwave" \
-  | grep \
-    --only-matching \
-    "http.*mp3" \
-  | head -n 5 \
-  | xargs \
-    -L 1 \
-    -P 0 \
-    wget \
-      --no-verbose \
-      --no-clobber;
-
-popd || exit;
-
 TEMP_FILE="$(mktemp)";
 
 tr '\n' '\r' \
   < src/AudioPlayer.svelte \
   | sed "s:const sources = \[[^]]*\]:const sources = [$( \
-    find public/sounds/ -type f -print0 \
-      | xargs -0 -L 1 basename \
-      | sed -E -e 's:^(.*)$:"/sounds/\1", :g'  \
+    curl \
+        --silent \
+        --location "http://www.nihilore.com/synthwave" \
+      | grep \
+        --only-matching \
+        "http.*mp3" \
+      | head -n 5 \
+      | sed -E -e 's:^(.*)$:"\1", :g' \
+      | sed 's/:/\\:/g' \
       | tr '\n' ' ' \
     )]:g" \
   | tr '\r' '\n' \

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -93,6 +93,11 @@
       $selected = window.location.hash.slice(1);
     }
   }
+
+  function isAprilFirst() {
+    const date = new Date();
+    return date.getMonth() + 1 === 4 && date.getDate() === 1;
+  }
 </script>
 
 <svelte:window on:popstate="{backButton}" />
@@ -162,9 +167,11 @@
     </Split>
   {/await}
 
-  <div class="bottomleft">
-    <AudioPlayer />
-  </div>
+  {#if isAprilFirst()}
+    <div class="bottomleft">
+      <AudioPlayer />
+    </div>
+  {/if}
 {:else}
   <StartView
     bind:rootResourceLoadPromise="{rootResourceLoadPromise}"

--- a/frontend/src/AudioPlayer.svelte
+++ b/frontend/src/AudioPlayer.svelte
@@ -19,11 +19,11 @@
     http://www.nihilore.com/license
   */
   const sources = [
-    "/sounds/Bush+Week.mp3",
-    "/sounds/Glimmer.mp3",
-    "/sounds/Motion+Blur.mp3",
-    "/sounds/Panthalassa.mp3",
-    "/sounds/Dream+Sunlight.mp3",
+    "https://static1.squarespace.com/static/57e83f709de4bbd550a2fdba/58e6e631579fb3bb25ed2822/606d59d50726d2518e6c8725/1617779204095/Dream+Sunlight.mp3",
+    "https://static1.squarespace.com/static/57e83f709de4bbd550a2fdba/58e6e631579fb3bb25ed2822/5b9332214d7a9cece566be20/1536373390381/Glimmer.mp3",
+    "https://static1.squarespace.com/static/57e83f709de4bbd550a2fdba/58e6e631579fb3bb25ed2822/6323fd85ebe8f81bc36cd975/1663303114116/Eternal+Light.mp3",
+    "https://static1.squarespace.com/static/57e83f709de4bbd550a2fdba/58e6e631579fb3bb25ed2822/5a7e6ee1ec212d8118ae4857/1518235615625/Panthalassa.mp3",
+    "https://static1.squarespace.com/static/57e83f709de4bbd550a2fdba/58e6e631579fb3bb25ed2822/5ab591b7562fa77d176c3f72/1521848881258/Motion+Blur.mp3",
   ];
   let currentSound = Math.floor(Math.random() * sources.length);
 


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

Remove music files and player.

**Please describe the changes in your request.**

The music files were huge, and took up the majority of space in the `pip` package. Also auto-playing music is obnoxious. 

This PR removes the music files from the repo (and thereby from the built frontend, and thus from `pip`), and only opens the audio player as an easter egg, once per year. Hopefully this strikes a good balance between maintaining fun energy and not being bothersome.

**Anyone you think should look at this, specifically?**

@EdwardLarson 