### PR TITLE
Add input to jump to offset

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -48,6 +48,7 @@
   import { selected, selectedResource } from "./stores.js";
 
   import { writable } from "svelte/store";
+  import JumpToOffset from "./JumpToOffset.svelte";
 
   printConsoleArt();
 
@@ -149,6 +150,10 @@
           https://github.com/sveltejs/svelte/issues/5604 
         -->
         <svelte:fragment slot="minimap">
+          <JumpToOffset
+            dataPromise="{displayDataPromise}"
+            scrollY="{hexScrollY}"
+          />
           {#if carouselSelection === "Entropy"}
             <EntropyView scrollY="{hexScrollY}" />
           {:else if carouselSelection === "Byteclass"}

--- a/frontend/src/JumpToOffset.svelte
+++ b/frontend/src/JumpToOffset.svelte
@@ -1,0 +1,68 @@
+<style>
+  input {
+    margin-bottom: 1em;
+    max-width: 100%;
+    background: inherit;
+    color: inherit;
+    border: none;
+    text-align: center;
+  }
+
+  input:focus {
+    outline: none;
+    box-shadow: inset 0 -1px 0 var(--main-fg-color);
+  }
+</style>
+
+<script>
+  import { calculator } from "./helpers";
+  import { onMount, tick } from "svelte";
+
+  export let dataPromise, scrollY;
+  let startOffset,
+    input,
+    mounted = false;
+  const alignment = 16;
+
+  let dataLength = 0;
+  dataPromise.then((data) => {
+    dataLength = data.byteLength;
+  });
+
+  onMount(() => {
+    mounted = true;
+  });
+
+  $: if (mounted) {
+    startOffset = Math.max(
+      Math.ceil((dataLength * $scrollY.top) / alignment) * alignment,
+      0
+    );
+    input.value = `0x${startOffset.toString(16)}`;
+  }
+</script>
+
+<input
+  type="text"
+  on:focusout="{() => {
+    try {
+      let result = calculator.calculate(input.value);
+      $scrollY.top = result / dataLength;
+    } catch (_) {
+      input.value = `0x${startOffset.toString(16)}`;
+    }
+  }}"
+  on:keyup="{(e) => {
+    if (e.key === 'Enter') {
+      input.blur();
+    }
+  }}"
+  on:input="{async () => {
+    let { value, selectionStart, selectionEnd } = input;
+    input.value = value.replace(/\n/g, '');
+    await tick();
+    input.selectionStart = selectionStart;
+    input.selectionEnd = selectionEnd;
+  }}"
+  bind:this="{input}"
+/>

--- a/frontend/src/JumpToOffset.svelte
+++ b/frontend/src/JumpToOffset.svelte
@@ -1,7 +1,7 @@
 <style>
   input {
     margin-bottom: 1em;
-    max-width: 100%;
+    width: 125%;
     background: inherit;
     color: inherit;
     border: none;

--- a/frontend/src/JumpToOffset.svelte
+++ b/frontend/src/JumpToOffset.svelte
@@ -44,17 +44,15 @@
 
 <input
   type="text"
-  on:focusout="{() => {
-    try {
-      let result = calculator.calculate(input.value);
-      $scrollY.top = result / dataLength;
-    } catch (_) {
-      input.value = `0x${startOffset.toString(16)}`;
-    }
-  }}"
   on:keyup="{(e) => {
     if (e.key === 'Enter') {
       input.blur();
+      try {
+        let result = calculator.calculate(input.value);
+        $scrollY.top = result / dataLength;
+      } catch (_) {
+        input.value = `0x${startOffset.toString(16)}`;
+      }
     }
   }}"
   on:input="{async () => {

--- a/frontend/src/JumpToOffset.svelte
+++ b/frontend/src/JumpToOffset.svelte
@@ -55,12 +55,5 @@
       }
     }
   }}"
-  on:input="{async () => {
-    let { value, selectionStart, selectionEnd } = input;
-    input.value = value.replace(/\n/g, '');
-    await tick();
-    input.selectionStart = selectionStart;
-    input.selectionEnd = selectionEnd;
-  }}"
   bind:this="{input}"
 />

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 - Replace unofficial p7zip with official 7zip package. 
+- Area in the GUI to jump to a given data offset
 
 ### Changed
 - GUI is much faster, especially for resources with hundreds of thousands of children [#191](https://github.com/redballoonsecurity/ofrak/pull/191)


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add a GUI input to jump to a given data offset.

**Please describe the changes in your request.**

This PR adds a bit of text above the minimap in the hex view that shows the current file offset. Clicking this text will allow the user to edit it and set it arbitrarily. Doing so and either defocusing the input or pressing "Enter" will apply the change and jump within the file. 

Note that the calculator is enabled such that calculations can also be performed in this quick jump box. For example, a user could enter something like `0x10 * 5 + 0xdeadbeef`, and it would work.

The resulting change looks like this:

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/99368685/216488715-34e6692f-6fb9-49ee-b606-e7c41ed2e1f7.png">

**Anyone you think should look at this, specifically?**

@EdwardLarson 