### PR TITLE
Set initially loaded resource to "uncollapsed"

### DIFF
--- a/frontend/src/ResourceTreeNode.svelte
+++ b/frontend/src/ResourceTreeNode.svelte
@@ -100,7 +100,6 @@
   import LoadingText from "./LoadingText.svelte";
 
   import { selected } from "./stores.js";
-  import { chunkList, sleep } from "./helpers";
 
   export let rootResource,
     resourceNodeDataMap,

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -185,6 +185,10 @@
       return r.json();
     });
     resources[resource.id] = remote_model_to_resource(resource, resources);
+    if (resourceNodeDataMap[resource.id] === undefined) {
+      resourceNodeDataMap[resource.id] = {};
+    }
+    resourceNodeDataMap[resource.id].collapsed = false;
     while (resource.parent_id) {
       resource = await fetch(`/${resource.parent_id}/`).then((r) => {
         if (!r.ok) {
@@ -239,7 +243,9 @@
   >
     {#if !dragging}
       <h1>Drag in a file to analyze</h1>
-      <p style:margin-bottom="0">Click anwyhere to browse your computer</p>
+      <p style:margin-bottom="0">
+        Click anwyhere to browse for a file to analyze
+      </p>
     {:else}
       <h1>Drop the file!</h1>
     {/if}

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Fixed
+- Fix bug where initially loaded GUI resource has collapsed children
 
 ## [2.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.1...ofrak-v2.2.0))
 ### Fixed


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix bug where initially loaded GUI resource has collapsed children.

**Please describe the changes in your request.**

When loading a resource in the GUI via `ofrak unpack` or `ofrak identify` at the command line, the initially-loaded resource would have its children collapsed. This change set fixes that issue.

**Anyone you think should look at this, specifically?**

@EdwardLarson 