### PR TITLE
Fix a dev container build failure

### DIFF
--- a/ofrak-dev.yml
+++ b/ofrak-dev.yml
@@ -15,7 +15,9 @@ packages_paths:
   ]
 extra_build_args:
   ["--secret",
-   "id=serial,src=serial.txt"
+   "id=serial,src=serial.txt",
+   "--secret",
+   "id=license.dat,src=license.dat"
   ]
 entrypoint: |
     nginx \


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Trivial bugfix - `ofrak-dev.yml` container build was failing otherwise, so I copied the `license.dat` lines from `ofrak-binary-ninja.yml`, and now it works.

**Anyone you think should look at this, specifically?**
@EdwardLarson maybe?
