### PR TITLE
Fix `ofrak-minimal` build, make `make -C ofrak_core develop` more robust

### DIFF
--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -24,9 +24,9 @@ dependencies:
 ofrak/gui/public:
 	if [ -d /ofrak_gui ] ; then \
 		cp -r /ofrak_gui ofrak/gui/public ; \
-	else \
-		pushd ../frontend ; \
-		npm run build ; \
-		popd ; \
+	elif [ -d ../frontend ]; then \
+		cd ../frontend && \
+		npm run build && \
+		cd ../ofrak_core && \
 		cp -r ../frontend/public ofrak/gui/public ; \
 	fi


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**

**Please describe the changes in your request.**
Make `make -C ofrak_core develop` more robust:
- Make it work when `/bin/sh` is `dash` and does not have `pushd`/`popd`
- Make it work when there is no `frontend` (such as in the `ofrak-minimal` container)

**Anyone you think should look at this, specifically?**
@jstrieb 