### PR TITLE
re-pin xattr version to version that works with Python 3.9

### DIFF
--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -14,4 +14,4 @@ sortedcontainers==2.2.2
 synthol~=0.1.1
 typeguard~=2.13.3
 ubi-reader==0.8.5
-xattr==0.9.7
+xattr==0.10.1


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
re-pin xattr version to version that works with Python 3.9

**Link to Related Issue(s)**
The xattr version we had pinned it to used a filter for classifiers in its setup.py, and Python 3.9 needs to that be a list, so installing that version of xattr raises an error in Python 3.9.

**Please describe the changes in your request.**
Re-pin to latest version of xattr

**Anyone you think should look at this, specifically?**
@whyitfor 
