### PR TITLE
swap order that errors are raised when auto-running fails

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,14 +4,16 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Fixed
+- Fix bug where initially loaded GUI resource has collapsed children
 
 ### Added
 - Updates to Flash components: [#195](https://github.com/redballoonsecurity/ofrak/pull/195)
   - Flash components now support more than one occurrence of the same field type in `FlashAttributes`.
   - `FlashOobResourceUnpacker` continues to unpack even if blocks do not perfectly align at end of the `FlashOobResource` (this is useful for real-world flash dumps).
 
-### Fixed
-- Fix bug where initially loaded GUI resource has collapsed children
+### Changed
+- Tweak how errors are raised when auto-running components, so the actual root cause is not buried [#219](https://github.com/redballoonsecurity/ofrak/pull/219)
 
 ## [2.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.1...ofrak-v2.2.0))
 ### Fixed

--- a/ofrak_core/ofrak/service/job_service.py
+++ b/ofrak_core/ofrak/service/job_service.py
@@ -453,11 +453,11 @@ class JobService(JobServiceInterface):
                 else:
                     component_run_error = cast(BaseException, component_run_result)
                     request_causing_run, component_name = component_run_metadata
-                    raise ComponentAutoRunFailure(
+                    raise component_run_error from ComponentAutoRunFailure(
                         request_causing_run.target_resource_id,
                         request_causing_run.component_filter,
                         component_name.encode(),
-                    ) from component_run_error
+                    )
 
             concurrent_run_tasks = list(pending)
             n_tasks_to_add = min(len(completed), len(queue))

--- a/ofrak_core/test_ofrak/components/test_elf_analyzers.py
+++ b/ofrak_core/test_ofrak/components/test_elf_analyzers.py
@@ -14,7 +14,6 @@ from ofrak.core.architecture import ProgramAttributes
 from ofrak.model.viewable_tag_model import ViewableResourceTag, AttributesType
 from ofrak.resource import Resource
 from ofrak.resource_view import ResourceView
-from ofrak.service.job_service_i import ComponentAutoRunFailure
 from ofrak.service.resource_service_i import ResourceFilter
 from ofrak.core.elf.analyzer import (
     ElfRelaAnalyzer,
@@ -460,7 +459,7 @@ ELF_BASIC_HEADER_ANALYZER_TEST_CASES = [
     ElfBasicHeaderTestCase(
         "invalid magic",
         struct.pack("4sBBBBB7s", b"\x7fLOL", 0, 0, 0, 0, 0, b"\x00" * 7),
-        ComponentAutoRunFailure,
+        AssertionError,
     ),
     ElfBasicHeaderTestCase(
         "little endian, 32-bit",
@@ -583,7 +582,7 @@ async def test_elf_program_attributes_analyzer_unknown_isa(ofrak_context: OFRAKC
         e_machine=0xFF,
     )
 
-    with pytest.raises(ComponentAutoRunFailure):
+    with pytest.raises(KeyError):
         _ = await elf_r.analyze(ProgramAttributes)
 
 

--- a/ofrak_core/test_ofrak/components/test_tar_component.py
+++ b/ofrak_core/test_ofrak/components/test_tar_component.py
@@ -5,8 +5,8 @@ import tempfile
 import pytest
 
 from ofrak import OFRAKContext
+from ofrak.component.unpacker import UnpackerError
 from ofrak.resource import Resource
-from ofrak.service.job_service_i import ComponentAutoRunFailure
 from ofrak.core.strings import StringPatchingConfig, StringPatchingModifier
 from ofrak.core.tar import TarArchive
 from pytest_ofrak.patterns.pack_unpack_filesystem import (
@@ -101,7 +101,7 @@ class TestTarUnpackerDirectoryTraversalFailure:
 
             root_resource = await ofrak_context.create_root_resource_from_file(archive_path)
 
-        with pytest.raises(ComponentAutoRunFailure) as err_info:
+        with pytest.raises(UnpackerError):
             await root_resource.unpack_recursively()
 
 

--- a/ofrak_core/test_ofrak/unit/test_resource.py
+++ b/ofrak_core/test_ofrak/unit/test_resource.py
@@ -16,7 +16,6 @@ from ofrak.model.viewable_tag_model import AttributesType
 from ofrak.resource import Resource
 from ofrak.resource_view import ResourceView
 from ofrak.service.resource_service_i import ResourceFilter
-from ofrak.service.job_service_i import ComponentAutoRunFailure
 from ofrak_type.range import Range
 
 from test_ofrak.unit.component import mock_component
@@ -204,17 +203,15 @@ async def test_flush_to_disk_pack(ofrak_context: OFRAKContext):
 
     with BytesIO() as buffer:
         # should fail because write_to runs pack_recursively and MockFailFile will fail on packing
-        with pytest.raises(ComponentAutoRunFailure) as exc_info:
+        with pytest.raises(MockFailException):
             await root_resource.write_to(buffer)
-
-        assert isinstance(exc_info.value.__cause__, MockFailException)
 
         # this should not fail because pack_recursively was suppressed
         await root_resource.write_to(buffer, pack=False)
 
     with tempfile.NamedTemporaryFile() as t:
         # again, should fail because the packer is run automatically
-        with pytest.raises(ComponentAutoRunFailure):
+        with pytest.raises(MockFailException):
             await root_resource.flush_to_disk(t.name)
 
         await root_resource.flush_to_disk(t.name, pack=False)


### PR DESCRIPTION
the component's error is now at the bottom of the stack trace, so the user sees it first

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Tweak how errors are raised when auto-running components, so the actual root cause is not buried

**Link to Related Issue(s)**
If a component is auto-run (which is common, every `analyze` or `unpack` are auto-runs for example) and it raises an error `E`, then the job service also generates it's own error `F` with info about why the component was chosen by the auto-run. Previously the errors were raised as `raise F from E`, which resulted in the stack trace printing error info in the order:

```
E
F
```
So what a user sees most obviously is some junk about the auto-run, and the root cause is buried halfway up. This also translates to the GUI when there is a backend error: Since `F` is the most proximate error, that auto-run info error is the one shown in a pop-up when there is a backend error.

**Please describe the changes in your request.**
Do `raise E from F` instead, so errors are printed in the order:
```
F
E
```
And the most recent stuff printed is about the root cause that the user cares about. The info about why the component was selected is still there, if it will be useful for debugging.

**Anyone you think should look at this, specifically?**
