### PR TITLE
Sort by data {length, offset}

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 - Add a button to the GUI to add a new tag to a resource [#215](https://github.com/redballoonsecurity/ofrak/pull/215)
+- Add a way to sort and filter by data length or offset [#220](https://github.com/redballoonsecurity/ofrak/pull/220)
 
 ### Added
 - Add keyboard shortcuts to the GUI

--- a/ofrak_core/ofrak/__init__.py
+++ b/ofrak_core/ofrak/__init__.py
@@ -3,7 +3,7 @@ from ofrak.component.identifier import Identifier
 from ofrak.component.modifier import Modifier
 from ofrak.component.packer import Packer
 from ofrak.component.unpacker import Unpacker
-from ofrak.model.resource_model import ResourceAttributes, ResourceModel, DataBytes
+from ofrak.model.resource_model import ResourceAttributes, ResourceModel, Data
 from ofrak.model.tag_model import ResourceTag
 from ofrak.ofrak_context import OFRAK, OFRAKContext
 from ofrak.resource import Resource, ResourceFactory

--- a/ofrak_core/ofrak/__init__.py
+++ b/ofrak_core/ofrak/__init__.py
@@ -3,8 +3,7 @@ from ofrak.component.identifier import Identifier
 from ofrak.component.modifier import Modifier
 from ofrak.component.packer import Packer
 from ofrak.component.unpacker import Unpacker
-from ofrak.model.resource_model import ResourceAttributes
-from ofrak.model.resource_model import ResourceModel
+from ofrak.model.resource_model import ResourceAttributes, ResourceModel, DataBytes
 from ofrak.model.tag_model import ResourceTag
 from ofrak.ofrak_context import OFRAK, OFRAKContext
 from ofrak.resource import Resource, ResourceFactory

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -60,7 +60,7 @@ from ofrak.model.resource_model import (
     ResourceModel,
     ResourceAttributes,
     MutableResourceModel,
-    RootOffset,
+    DataBytes,
 )
 from ofrak.model.viewable_tag_model import ResourceViewContext
 from ofrak.resource import Resource
@@ -371,7 +371,7 @@ class AiohttpOFRAKServer:
             child_models = await resource._resource_service.get_descendants_by_id(
                 resource._resource.id,
                 max_depth=1,
-                r_sort=ResourceSort(RootOffset),
+                r_sort=ResourceSort(DataBytes.Offset),
             )
             return resource_id, list(map(self._serialize_resource_model, child_models))
 

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -60,7 +60,7 @@ from ofrak.model.resource_model import (
     ResourceModel,
     ResourceAttributes,
     MutableResourceModel,
-    DataBytes,
+    Data,
 )
 from ofrak.model.viewable_tag_model import ResourceViewContext
 from ofrak.resource import Resource
@@ -371,7 +371,7 @@ class AiohttpOFRAKServer:
             child_models = await resource._resource_service.get_descendants_by_id(
                 resource._resource.id,
                 max_depth=1,
-                r_sort=ResourceSort(DataBytes.Offset),
+                r_sort=ResourceSort(Data.Offset),
             )
             return resource_id, list(map(self._serialize_resource_model, child_models))
 

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -60,6 +60,7 @@ from ofrak.model.resource_model import (
     ResourceModel,
     ResourceAttributes,
     MutableResourceModel,
+    RootOffset,
 )
 from ofrak.model.viewable_tag_model import ResourceViewContext
 from ofrak.resource import Resource
@@ -370,6 +371,7 @@ class AiohttpOFRAKServer:
             child_models = await resource._resource_service.get_descendants_by_id(
                 resource._resource.id,
                 max_depth=1,
+                r_sort=ResourceSort(RootOffset),
             )
             return resource_id, list(map(self._serialize_resource_model, child_models))
 

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -897,7 +897,7 @@ def _validate_indexed_type(getter_func: Callable[[Any], X]):
 
 
 @dataclasses.dataclass(**ResourceAttributes.DATACLASS_PARAMS)
-class DataBytes(ResourceAttributes):
+class Data(ResourceAttributes):
     """
     Special attributes class for accessing info about a resource's binary data.
     Users should never access or modify this directly! Changing the fields of this data structure

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -897,23 +897,19 @@ def _validate_indexed_type(getter_func: Callable[[Any], X]):
 
 
 @dataclasses.dataclass(**ResourceAttributes.DATACLASS_PARAMS)
-class _DataAttributes(ResourceAttributes):
+class DataBytes(ResourceAttributes):
     """
     Special attributes class for accessing info about a resource's binary data.
     SHOULD NEVER BE USED OUTSIDE OF INTERNAL OFRAK MECHANISMS.
     """
 
-    root_offset: int
-    length: int
+    _offset: int
+    _length: int
 
     @index
-    def RootOffset(self) -> int:
-        return self.root_offset
+    def Offset(self) -> int:
+        return self._offset
 
     @index
     def Length(self) -> int:
-        return self.length
-
-
-RootOffset = _DataAttributes.RootOffset
-Length = _DataAttributes.Length
+        return self._length

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -900,7 +900,9 @@ def _validate_indexed_type(getter_func: Callable[[Any], X]):
 class DataBytes(ResourceAttributes):
     """
     Special attributes class for accessing info about a resource's binary data.
-    SHOULD NEVER BE USED OUTSIDE OF INTERNAL OFRAK MECHANISMS.
+    Users should never access or modify this directly! Changing the fields of this data structure
+    will not change any about the resource's data! At best, it will do nothing, and at worst it
+    will screw up sorting/filtering.
     """
 
     _offset: int

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -894,3 +894,26 @@ def _validate_indexed_type(getter_func: Callable[[Any], X]):
             f"Type of index {getter_func.__name__} is {index_type}, which is not "
             f"one of {_INDEXABLE_TYPES.values()}; cannot index by this value!"
         )
+
+
+@dataclasses.dataclass(**ResourceAttributes.DATACLASS_PARAMS)
+class _DataAttributes(ResourceAttributes):
+    """
+    Special attributes class for accessing info about a resource's binary data.
+    SHOULD NEVER BE USED OUTSIDE OF INTERNAL OFRAK MECHANISMS.
+    """
+
+    root_offset: int
+    length: int
+
+    @index
+    def RootOffset(self) -> int:
+        return self.root_offset
+
+    @index
+    def Length(self) -> int:
+        return self.length
+
+
+RootOffset = _DataAttributes.RootOffset
+Length = _DataAttributes.Length

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -35,6 +35,7 @@ from ofrak.model.resource_model import (
     ResourceModel,
     MutableResourceModel,
     ResourceContext,
+    _DataAttributes,
 )
 from ofrak.model.tag_model import ResourceTag
 from ofrak.model.viewable_tag_model import (
@@ -634,6 +635,8 @@ class Resource:
                 self._resource.data_id,
                 data_range,
             )
+            data_attrs = _DataAttributes(data_range.start, data_range.length())
+            attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         elif data is not None:
             if self._resource.data_id is None:
                 raise ValueError(
@@ -641,6 +644,8 @@ class Resource:
                 )
             data_model_id = resource_id
             await self._data_service.create_root(data_model_id, data)
+            data_attrs = _DataAttributes(0, len(data))
+            attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         else:
             data_model_id = None
         resource_model = ResourceModel.create(

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -35,7 +35,7 @@ from ofrak.model.resource_model import (
     ResourceModel,
     MutableResourceModel,
     ResourceContext,
-    DataBytes,
+    Data,
 )
 from ofrak.model.tag_model import ResourceTag
 from ofrak.model.viewable_tag_model import (
@@ -635,7 +635,7 @@ class Resource:
                 self._resource.data_id,
                 data_range,
             )
-            data_attrs = DataBytes(data_range.start, data_range.length())
+            data_attrs = Data(data_range.start, data_range.length())
             attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         elif data is not None:
             if self._resource.data_id is None:
@@ -644,7 +644,7 @@ class Resource:
                 )
             data_model_id = resource_id
             await self._data_service.create_root(data_model_id, data)
-            data_attrs = DataBytes(0, len(data))
+            data_attrs = Data(0, len(data))
             attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         else:
             data_model_id = None

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -35,7 +35,7 @@ from ofrak.model.resource_model import (
     ResourceModel,
     MutableResourceModel,
     ResourceContext,
-    _DataAttributes,
+    DataBytes,
 )
 from ofrak.model.tag_model import ResourceTag
 from ofrak.model.viewable_tag_model import (
@@ -635,7 +635,7 @@ class Resource:
                 self._resource.data_id,
                 data_range,
             )
-            data_attrs = _DataAttributes(data_range.start, data_range.length())
+            data_attrs = DataBytes(data_range.start, data_range.length())
             attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         elif data is not None:
             if self._resource.data_id is None:
@@ -644,7 +644,7 @@ class Resource:
                 )
             data_model_id = resource_id
             await self._data_service.create_root(data_model_id, data)
-            data_attrs = _DataAttributes(0, len(data))
+            data_attrs = DataBytes(0, len(data))
             attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         else:
             data_model_id = None

--- a/ofrak_core/ofrak/service/dependency_handler.py
+++ b/ofrak_core/ofrak/service/dependency_handler.py
@@ -8,7 +8,7 @@ from ofrak.model.resource_model import (
     ResourceContext,
     ResourceAttributeDependency,
     MutableResourceModel,
-    _DataAttributes,
+    DataBytes,
 )
 from ofrak.service.data_service_i import DataServiceInterface
 from ofrak.service.resource_service_i import ResourceServiceInterface
@@ -73,11 +73,11 @@ class DependencyHandler:
                 all_data_ids, await self._data_service.get_by_ids(all_data_ids)
             )
         }
-        # First go through and update all models' DataAttributes
+        # First go through and update all models' DataBytes
         for data_patch_result in patch_results:
             resource_m = resources_by_data_id[data_patch_result.data_id]
             data_m = models_by_data_id[data_patch_result.data_id]
-            resource_m.add_attributes(_DataAttributes(data_m.range.start, data_m.range.length()))
+            resource_m.add_attributes(DataBytes(data_m.range.start, data_m.range.length()))
 
         unhandled_dependencies: Set[ResourceAttributeDependency] = set()
         # Figure out which components results must be invalidated based on data changes

--- a/ofrak_core/ofrak/service/dependency_handler.py
+++ b/ofrak_core/ofrak/service/dependency_handler.py
@@ -73,7 +73,7 @@ class DependencyHandler:
                 all_data_ids, await self._data_service.get_by_ids(all_data_ids)
             )
         }
-        # First go through and update all models' Data
+        # Go through and update all models' Data
         for data_patch_result in patch_results:
             resource_m = resources_by_data_id[data_patch_result.data_id]
             data_m = models_by_data_id[data_patch_result.data_id]

--- a/ofrak_core/ofrak/service/dependency_handler.py
+++ b/ofrak_core/ofrak/service/dependency_handler.py
@@ -8,7 +8,7 @@ from ofrak.model.resource_model import (
     ResourceContext,
     ResourceAttributeDependency,
     MutableResourceModel,
-    DataBytes,
+    Data,
 )
 from ofrak.service.data_service_i import DataServiceInterface
 from ofrak.service.resource_service_i import ResourceServiceInterface
@@ -73,11 +73,11 @@ class DependencyHandler:
                 all_data_ids, await self._data_service.get_by_ids(all_data_ids)
             )
         }
-        # First go through and update all models' DataBytes
+        # First go through and update all models' Data
         for data_patch_result in patch_results:
             resource_m = resources_by_data_id[data_patch_result.data_id]
             data_m = models_by_data_id[data_patch_result.data_id]
-            resource_m.add_attributes(DataBytes(data_m.range.start, data_m.range.length()))
+            resource_m.add_attributes(Data(data_m.range.start, data_m.range.length()))
 
         unhandled_dependencies: Set[ResourceAttributeDependency] = set()
         # Figure out which components results must be invalidated based on data changes

--- a/ofrak_core/ofrak/service/dependency_handler.py
+++ b/ofrak_core/ofrak/service/dependency_handler.py
@@ -3,11 +3,12 @@ import logging
 from typing import Set, List, Iterable, Dict, cast
 
 from ofrak.model.component_model import ComponentContext
-from ofrak.model.data_model import DataPatchesResult
+from ofrak.model.data_model import DataPatchesResult, DataModel
 from ofrak.model.resource_model import (
     ResourceContext,
     ResourceAttributeDependency,
     MutableResourceModel,
+    _DataAttributes,
 )
 from ofrak.service.data_service_i import DataServiceInterface
 from ofrak.service.resource_service_i import ResourceServiceInterface
@@ -64,6 +65,19 @@ class DependencyHandler:
         resources_by_data_id = await self.map_data_ids_to_resources(
             patch_result.data_id for patch_result in patch_results
         )
+
+        all_data_ids = [patch_result.data_id for patch_result in patch_results]
+        models_by_data_id: Dict[bytes, DataModel] = {
+            data_id: model
+            for data_id, model in zip(
+                all_data_ids, await self._data_service.get_by_ids(all_data_ids)
+            )
+        }
+        # First go through and update all models' DataAttributes
+        for data_patch_result in patch_results:
+            resource_m = resources_by_data_id[data_patch_result.data_id]
+            data_m = models_by_data_id[data_patch_result.data_id]
+            resource_m.add_attributes(_DataAttributes(data_m.range.start, data_m.range.length()))
 
         unhandled_dependencies: Set[ResourceAttributeDependency] = set()
         # Figure out which components results must be invalidated based on data changes

--- a/ofrak_core/test_ofrak/unit/test_data_attributes.py
+++ b/ofrak_core/test_ofrak/unit/test_data_attributes.py
@@ -1,0 +1,52 @@
+from ofrak import OFRAKContext, ResourceSort
+from ofrak.model.resource_model import RootOffset, _DataAttributes, Length
+from ofrak_type import Range
+
+
+async def test_data_attributes(ofrak_context: OFRAKContext, elf_object_file):
+    root = await ofrak_context.create_root_resource_from_file(elf_object_file)
+    await root.unpack()
+
+    unordered_children = list(await root.get_children())
+    ordered_children = list(await root.get_children(r_sort=ResourceSort(RootOffset)))
+
+    print(ordered_children)
+
+    assert unordered_children != ordered_children
+
+
+async def test_data_attributes_update(ofrak_context: OFRAKContext, elf_object_file):
+    root = await ofrak_context.create_root_resource_from_file(elf_object_file)
+    await root.unpack()
+
+    # Get two arbitrary children, which both have some data
+    unordered_children = list(await root.get_children())
+    arbitrary_child1 = unordered_children[18]
+    arbitrary_child2 = unordered_children[16]
+
+    l1 = await arbitrary_child1.get_data_length()
+    l2 = await arbitrary_child2.get_data_length()
+    assert l1 > 0
+    assert l2 > 0
+
+    # patch away of the arbitrary children's data
+    original_data_attrs = arbitrary_child1.get_attributes(_DataAttributes)
+    assert original_data_attrs.length == l1
+
+    arbitrary_child1.queue_patch(Range(0, l1), b"")
+    await arbitrary_child1.save()
+
+    # manually check the data attributes are updated
+    data_attrs = arbitrary_child1.get_attributes(_DataAttributes)
+    assert data_attrs.length == 0
+    assert data_attrs.root_offset == original_data_attrs.root_offset
+
+    # check that sorting by length works
+    # the child whose data was patched should definitely be before the one which wasn't patched
+    arbitrary_child1_found = False
+    for child in await root.get_children(r_sort=ResourceSort(Length)):
+        if child == arbitrary_child1:
+            arbitrary_child1_found = True
+        elif child == arbitrary_child2:
+            assert arbitrary_child1_found
+            break

--- a/ofrak_core/test_ofrak/unit/test_data_attributes.py
+++ b/ofrak_core/test_ofrak/unit/test_data_attributes.py
@@ -8,7 +8,7 @@ async def test_data_attributes(ofrak_context: OFRAKContext, elf_object_file):
     await root.unpack()
 
     unordered_children = list(await root.get_children())
-    ordered_children = list(await root.get_children(r_sort=ResourceSort(RootOffset)))
+    ordered_children = list(await root.get_children(r_sort=ResourceSort(DataBytes.Offset)))
 
     print(ordered_children)
 

--- a/ofrak_core/test_ofrak/unit/test_data_attributes.py
+++ b/ofrak_core/test_ofrak/unit/test_data_attributes.py
@@ -1,5 +1,5 @@
 from ofrak import OFRAKContext, ResourceSort
-from ofrak.model.resource_model import DataBytes
+from ofrak.model.resource_model import Data
 from ofrak_type import Range
 
 
@@ -8,7 +8,7 @@ async def test_data_attributes(ofrak_context: OFRAKContext, elf_object_file):
     await root.unpack()
 
     unordered_children = list(await root.get_children())
-    ordered_children = list(await root.get_children(r_sort=ResourceSort(DataBytes.Offset)))
+    ordered_children = list(await root.get_children(r_sort=ResourceSort(Data.Offset)))
 
     print(ordered_children)
 
@@ -30,21 +30,21 @@ async def test_data_attributes_update(ofrak_context: OFRAKContext, elf_object_fi
     assert l2 > 0
 
     # patch away of the arbitrary children's data
-    original_data_attrs = arbitrary_child1.get_attributes(DataBytes)
+    original_data_attrs = arbitrary_child1.get_attributes(Data)
     assert original_data_attrs._length == l1
 
     arbitrary_child1.queue_patch(Range(0, l1), b"")
     await arbitrary_child1.save()
 
     # manually check the data attributes are updated
-    data_attrs = arbitrary_child1.get_attributes(DataBytes)
+    data_attrs = arbitrary_child1.get_attributes(Data)
     assert data_attrs._length == 0
     assert data_attrs._offset == original_data_attrs._offset
 
     # check that sorting by length works
     # the child whose data was patched should definitely be before the one which wasn't patched
     arbitrary_child1_found = False
-    for child in await root.get_children(r_sort=ResourceSort(DataBytes.Length)):
+    for child in await root.get_children(r_sort=ResourceSort(Data.Length)):
         if child == arbitrary_child1:
             arbitrary_child1_found = True
         elif child == arbitrary_child2:

--- a/ofrak_core/test_ofrak/unit/test_data_attributes.py
+++ b/ofrak_core/test_ofrak/unit/test_data_attributes.py
@@ -1,5 +1,5 @@
 from ofrak import OFRAKContext, ResourceSort
-from ofrak.model.resource_model import RootOffset, _DataAttributes, Length
+from ofrak.model.resource_model import DataBytes
 from ofrak_type import Range
 
 
@@ -30,21 +30,21 @@ async def test_data_attributes_update(ofrak_context: OFRAKContext, elf_object_fi
     assert l2 > 0
 
     # patch away of the arbitrary children's data
-    original_data_attrs = arbitrary_child1.get_attributes(_DataAttributes)
-    assert original_data_attrs.length == l1
+    original_data_attrs = arbitrary_child1.get_attributes(DataBytes)
+    assert original_data_attrs._length == l1
 
     arbitrary_child1.queue_patch(Range(0, l1), b"")
     await arbitrary_child1.save()
 
     # manually check the data attributes are updated
-    data_attrs = arbitrary_child1.get_attributes(_DataAttributes)
-    assert data_attrs.length == 0
-    assert data_attrs.root_offset == original_data_attrs.root_offset
+    data_attrs = arbitrary_child1.get_attributes(DataBytes)
+    assert data_attrs._length == 0
+    assert data_attrs._offset == original_data_attrs._offset
 
     # check that sorting by length works
     # the child whose data was patched should definitely be before the one which wasn't patched
     arbitrary_child1_found = False
-    for child in await root.get_children(r_sort=ResourceSort(Length)):
+    for child in await root.get_children(r_sort=ResourceSort(DataBytes.Length)):
         if child == arbitrary_child1:
             arbitrary_child1_found = True
         elif child == arbitrary_child2:


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add mechanism to sort & filter by data length or offset like other indexable attributes (e.g. VirtualAddress)

**Link to Related Issue(s)**
There wasn't a way to format a query (like `get_descendants`) so that OFRAK would filter or sort by aspects of the resource's binary data. Users would have to grab that info themselves and implement some filtering or sorting logic locally.

**Please describe the changes in your request.**
* Add `RootOffset` and `Length` indexable attributes that can be used to sort of filter by these aspects of resource's binary data:
`r_sort=ResourceSort(RootOffset),`
* Have the GUI sort resources by data offset by default
* Implement this with a semi-magical special ResourceAttributes known as `DataAttributes` which OFRAK specially handles updating when resources are created with data or get patched

**Anyone you think should look at this, specifically?**
