### PR TITLE
Force resource caption refresh in the GUI tree

### DIFF
--- a/frontend/src/ResourceTreeNode.svelte
+++ b/frontend/src/ResourceTreeNode.svelte
@@ -108,7 +108,7 @@
     selectPreviousSibling = () => {},
     collapsed = true,
     childrenCollapsed = true;
-  let self,
+  let caption,
     firstChild,
     childrenPromise,
     commentsPromise,
@@ -134,6 +134,13 @@
     commentsPromise = resourceNodeDataMap[self_id].commentsPromise;
     collapsed = resourceNodeDataMap[self_id].collapsed;
   }
+
+  function updateCaption() {
+    rootResource.get_latest_model().then(() => {
+      caption = rootResource.get_caption();
+    });
+  }
+  $: updateCaption(childrenPromise);
 
   $: childrenPromise?.then((children) => {
     if (children?.length > 0) {
@@ -210,11 +217,10 @@
     </button>{/if}{/await}<button
   on:click="{onClick}"
   on:dblclick="{onDoubleClick}"
-  bind:this="{self}"
   class:selected="{$selected === self_id}"
   id="{self_id}"
 >
-  {rootResource.get_caption()}
+  {caption}
 </button>
 {#await commentsPromise then comments}
   {#each comments as comment}

--- a/frontend/src/ofrak/remote_resource.js
+++ b/frontend/src/ofrak/remote_resource.js
@@ -108,6 +108,17 @@ export class RemoteResource extends Resource {
     this.attributes = newer.attributes;
   }
 
+  async get_latest_model() {
+    const result = await fetch(`${this.uri}/`).then(async (r) => {
+      if (!r.ok) {
+        throw Error(JSON.stringify(await r.json(), undefined, 2));
+      }
+      return r.json();
+    });
+    remote_model_to_resource(result, this.resource_list);
+    this.update();
+  }
+
   async get_children(r_filter, r_sort) {
     if (this.cache["get_children"]) {
       return this.cache["get_children"];


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

Force resource caption refresh in the GUI tree.

**Please describe the changes in your request.**

Previously, running components in the GUI might update a resource's caption, but this change would not be reflected in the tree. This PR fixes that bug by forcing the caption to refresh when a resource's children refresh, which happens every time the resource changes.

**Anyone you think should look at this, specifically?**

@EdwardLarson 