### PR TITLE
Change tab title to include the current caption

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -85,6 +85,7 @@
         currentResource.has_tag(tag)
       );
       $hexScrollY.top = 0;
+      document.title = "OFRAK App – " + currentResource.get_caption();
     }
     if ($selected !== window.location.hash.slice(1)) {
       window.history.pushState(null, "", `#${$selected}`);

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add a button to the GUI to add a new tag to a resource [#215](https://github.com/redballoonsecurity/ofrak/pull/215)
 - Add a way to sort and filter by data length or offset [#220](https://github.com/redballoonsecurity/ofrak/pull/220)
 - Add caption to ElfProgramHeader
+- Add current resource caption to GUI browser tab title 
 
 ### Changed
 - Tweak how errors are raised when auto-running components, so the actual root cause is not buried [#219](https://github.com/redballoonsecurity/ofrak/pull/219)


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add current resource caption to GUI browser tab title.

**Please describe the changes in your request.**

This small PR improves the OFRAK GUI user's experience by adding the current resource caption to the tab title. This makes it much more convenient to have different OFRAK GUI windows open simultaneously, since a user no longer has to guess which tab or window has which resource. 

**Anyone you think should look at this, specifically?**

@whyitfor 