### PR TITLE
Fix bulleted list in PatchMaker docs

### DIFF
--- a/docs/user-guide/advanced/patch-maker/user-guide.md
+++ b/docs/user-guide/advanced/patch-maker/user-guide.md
@@ -218,6 +218,7 @@ Compile the patch source using OFRAK PatchMaker, after defining the arch info, t
 re-link to the target-under-analysis.
 
 This is composed of a few steps in itself, which are:
+
 - Define the `ArchInfo` dataclass, which specifies the target CPU, ISA, etc.;
 - Define the `ToolchainConfig` dataclass, which specifies toolchain configuration parameters, such as optimization flags, reloc flags, etc.;
 - Initialize a `Toolchain` with the arch info and toolchain config;


### PR DESCRIPTION
**Please describe the changes in your request.**

Alas, PyCharm is a more forgiving renderer of Markdown than MkDocs :(

This minor fix improves the rendering of a bulleted list in the PatchMaker docs. Specifically, it turns [this](https://ofrak.com/docs/user-guide/advanced/patch-maker/user-guide.html#patchmaker-steps):

<img width="812" alt="image" src="https://user-images.githubusercontent.com/99368685/220510458-62740088-95fa-4cf6-a23f-f8b0d2ec8990.png">

into this:

<img width="806" alt="image" src="https://user-images.githubusercontent.com/99368685/220510561-8a3845a3-2d28-4bce-ae8f-faba2565dc6b.png">

**Anyone you think should look at this, specifically?**

@andresito00 