### PR TITLE
Use `asyncio.create_subprocess` instead of `subprocess.run`

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Tweak how errors are raised when auto-running components, so the actual root cause is not buried [#219](https://github.com/redballoonsecurity/ofrak/pull/219)
 - Show mapped resource captions on hover in the hex view [#221](https://github.com/redballoonsecurity/ofrak/pull/221)
 - Change how resources are stored to making deleting (and thus packing) much faster [#201](https://github.com/redballoonsecurity/ofrak/pull/201)
+- Use non-blocking asyncio subprocess calls in packers/unpackers 
 
 ## [2.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.1...ofrak-v2.2.0))
 ### Fixed

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Tweak how errors are raised when auto-running components, so the actual root cause is not buried [#219](https://github.com/redballoonsecurity/ofrak/pull/219)
 - Show mapped resource captions on hover in the hex view [#221](https://github.com/redballoonsecurity/ofrak/pull/221)
 - Change how resources are stored to making deleting (and thus packing) much faster [#201](https://github.com/redballoonsecurity/ofrak/pull/201)
-- Use non-blocking asyncio subprocess calls in packers/unpackers 
+- Use non-blocking `asyncio.create_subprocess_exec` calls in components [#53](https://github.com/redballoonsecurity/ofrak/issues/53)
 
 ## [2.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.1...ofrak-v2.2.0))
 ### Fixed

--- a/ofrak_core/ofrak/cli/command/deps.py
+++ b/ofrak_core/ofrak/cli/command/deps.py
@@ -1,3 +1,4 @@
+import asyncio
 from argparse import RawDescriptionHelpFormatter, Namespace
 from types import ModuleType
 from typing import Iterable, Set, Dict
@@ -96,7 +97,7 @@ class DepsCommand(OfrakCommand):
 
         for dep in dependencies:
             if check_deps:
-                is_installed = dep.is_tool_installed()
+                is_installed = asyncio.run(dep.is_tool_installed())
             else:
                 is_installed = None
 

--- a/ofrak_core/ofrak/core/apk.py
+++ b/ofrak_core/ofrak/core/apk.py
@@ -57,7 +57,7 @@ class _UberApkSignerTool(ComponentExternalTool):
         except FileNotFoundError:
             return False
 
-        return 0 == returncode
+        return True
 
 
 UBER_APK_SIGNER = _UberApkSignerTool()

--- a/ofrak_core/ofrak/core/binwalk.py
+++ b/ofrak_core/ofrak/core/binwalk.py
@@ -33,7 +33,7 @@ class _BinwalkExternalTool(ComponentExternalTool):
             install_check_arg="",
         )
 
-    def is_tool_installed(self) -> bool:
+    async def is_tool_installed(self) -> bool:
         return BINWALK_INSTALLED
 
 

--- a/ofrak_core/ofrak/core/cpio.py
+++ b/ofrak_core/ofrak/core/cpio.py
@@ -1,5 +1,5 @@
+import asyncio
 import logging
-import subprocess
 import tempfile
 from dataclasses import dataclass
 from enum import Enum
@@ -87,14 +87,17 @@ class CpioUnpacker(Unpacker[None]):
         cpio_v = await resource.view_as(CpioFilesystem)
         resource_data = await cpio_v.resource.get_data()
         with tempfile.TemporaryDirectory() as temp_flush_dir:
-            command = ["cpio", "-id"]
-            subprocess.run(
-                command,
-                check=True,
-                capture_output=True,
+            proc = await asyncio.create_subprocess_exec(
+                "cpio",
+                "-id",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
                 cwd=temp_flush_dir,
-                input=resource_data,
             )
+            stdout, stderr = await proc.communicate(input=resource_data)
+            if proc.returncode and proc.returncode < 0:
+                raise Exception(stderr.decode())
             await cpio_v.initialize_from_disk(temp_flush_dir)
 
 
@@ -110,22 +113,31 @@ class CpioPacker(Packer[None]):
         cpio_v: CpioFilesystem = await resource.view_as(CpioFilesystem)
         temp_flush_dir = await cpio_v.flush_to_disk()
         cpio_format = cpio_v.archive_type.value
-        list_files_output = subprocess.run(
-            ["find", ".", "-print"],
-            check=True,
-            capture_output=True,
+        list_files_proc = await asyncio.create_subprocess_exec(
+            "find",
+            "-print",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             cwd=temp_flush_dir,
         )
-        cpio_pack_output = subprocess.run(
-            ["cpio", "-o", f"--format={cpio_format}"],
-            check=True,
-            capture_output=True,
+        list_files_list, stderr = await list_files_proc.communicate()
+        if list_files_proc.returncode and list_files_proc.returncode < 0:
+            raise Exception(stderr.decode())
+
+        cpio_pack_proc = await asyncio.create_subprocess_exec(
+            "cpio",
+            "-o",
+            f"--format={cpio_format}",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             cwd=temp_flush_dir,
-            input=list_files_output.stdout,
         )
-        new_data = cpio_pack_output.stdout
+        cpio_pack_output, stderr = await cpio_pack_proc.communicate(input=list_files_list)
+        if cpio_pack_proc.returncode and cpio_pack_proc.returncode < 0:
+            raise Exception(stderr.decode())
         # Passing in the original range effectively replaces the original data with the new data
-        resource.queue_patch(Range(0, await resource.get_data_length()), new_data)
+        resource.queue_patch(Range(0, await resource.get_data_length()), cpio_pack_output)
 
 
 MagicMimeIdentifier.register(CpioFilesystem, "application/x-cpio")

--- a/ofrak_core/ofrak/core/cpio.py
+++ b/ofrak_core/ofrak/core/cpio.py
@@ -3,6 +3,7 @@ import logging
 import tempfile
 from dataclasses import dataclass
 from enum import Enum
+from subprocess import CalledProcessError
 
 from ofrak.component.analyzer import Analyzer
 from ofrak.component.packer import Packer
@@ -87,17 +88,20 @@ class CpioUnpacker(Unpacker[None]):
         cpio_v = await resource.view_as(CpioFilesystem)
         resource_data = await cpio_v.resource.get_data()
         with tempfile.TemporaryDirectory() as temp_flush_dir:
-            proc = await asyncio.create_subprocess_exec(
+            cmd = [
                 "cpio",
                 "-id",
+            ]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=temp_flush_dir,
             )
-            stdout, stderr = await proc.communicate(input=resource_data)
-            if proc.returncode and proc.returncode < 0:
-                raise Exception(stderr.decode())
+            await proc.communicate(input=resource_data)
+            if proc.returncode:
+                raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
             await cpio_v.initialize_from_disk(temp_flush_dir)
 
 
@@ -113,29 +117,35 @@ class CpioPacker(Packer[None]):
         cpio_v: CpioFilesystem = await resource.view_as(CpioFilesystem)
         temp_flush_dir = await cpio_v.flush_to_disk()
         cpio_format = cpio_v.archive_type.value
-        list_files_proc = await asyncio.create_subprocess_exec(
+        list_files_cmd = [
             "find",
             "-print",
+        ]
+        list_files_proc = await asyncio.create_subprocess_exec(
+            *list_files_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=temp_flush_dir,
         )
         list_files_list, stderr = await list_files_proc.communicate()
-        if list_files_proc.returncode and list_files_proc.returncode < 0:
-            raise Exception(stderr.decode())
+        if list_files_proc.returncode:
+            raise CalledProcessError(returncode=list_files_proc.returncode, cmd=list_files_cmd)
 
-        cpio_pack_proc = await asyncio.create_subprocess_exec(
+        cpio_pack_cmd = [
             "cpio",
             "-o",
             f"--format={cpio_format}",
+        ]
+        cpio_pack_proc = await asyncio.create_subprocess_exec(
+            *cpio_pack_cmd,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=temp_flush_dir,
         )
         cpio_pack_output, stderr = await cpio_pack_proc.communicate(input=list_files_list)
-        if cpio_pack_proc.returncode and cpio_pack_proc.returncode < 0:
-            raise Exception(stderr.decode())
+        if cpio_pack_proc.returncode:
+            raise CalledProcessError(returncode=cpio_pack_proc.returncode, cmd=cpio_pack_cmd)
         # Passing in the original range effectively replaces the original data with the new data
         resource.queue_patch(Range(0, await resource.get_data_length()), cpio_pack_output)
 

--- a/ofrak_core/ofrak/core/squashfs.py
+++ b/ofrak_core/ofrak/core/squashfs.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
-import subprocess
 import tempfile
 from dataclasses import dataclass
+from subprocess import CalledProcessError
 
 from ofrak.component.packer import Packer
 from ofrak.component.unpacker import Unpacker
@@ -26,20 +26,24 @@ class _UnsquashfsV45Tool(ComponentExternalTool):
     def __init__(self):
         super().__init__("unsquashfs", "https://github.com/plougher/squashfs-tools.git", "")
 
-    def is_tool_installed(self) -> bool:
+    async def is_tool_installed(self) -> bool:
         try:
-            result = subprocess.run(
-                ["unsquashfs", "-help"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
+            cmd = ["unsquashfs", "-help"]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
             )
+            stdout, stderr = await proc.communicate()
+            if proc.returncode:
+                raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
         except FileNotFoundError:
             return False
 
-        if 0 != result.returncode:
+        if 0 != proc.returncode:
             return False
 
-        if b"-no-exit" not in result.stdout:
+        if b"-no-exit" not in stdout:
             # Version 4.5+ has the required -no-exit option
             return False
 
@@ -70,18 +74,20 @@ class SquashfsUnpacker(Unpacker[None]):
             temp_file.flush()
 
             with tempfile.TemporaryDirectory() as temp_flush_dir:
-                proc = await asyncio.create_subprocess_exec(
+                cmd = [
                     "unsquashfs",
                     "-no-exit-code",
                     "-force",
                     "-dest",
                     temp_flush_dir,
                     temp_file.name,
-                    stderr=asyncio.subprocess.PIPE,
+                ]
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
                 )
-                stdout, stderr = await proc.communicate()
-                if proc.returncode and proc.returncode < 0:
-                    raise Exception(stderr.decode())
+                returncode = await proc.wait()
+                if proc.returncode:
+                    raise CalledProcessError(returncode=returncode, cmd=cmd)
 
                 squashfs_view = await resource.view_as(SquashfsFilesystem)
                 await squashfs_view.initialize_from_disk(temp_flush_dir)
@@ -99,16 +105,18 @@ class SquashfsPacker(Packer[None]):
         squashfs_view: SquashfsFilesystem = await resource.view_as(SquashfsFilesystem)
         temp_flush_dir = await squashfs_view.flush_to_disk()
         with tempfile.NamedTemporaryFile(suffix=".sqsh", mode="rb") as temp:
-            proc = await asyncio.create_subprocess_exec(
+            cmd = [
                 "mksquashfs",
                 temp_flush_dir,
                 temp.name,
                 "-noappend",
-                stderr=asyncio.subprocess.PIPE,
+            ]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
             )
-            stdout, stderr = await proc.communicate()
-            if proc.returncode and proc.returncode < 0:
-                raise Exception(stderr.decode())
+            returncode = await proc.wait()
+            if proc.returncode:
+                raise CalledProcessError(returncode=returncode, cmd=cmd)
             new_data = temp.read()
             # Passing in the original range effectively replaces the original data with the new data
             resource.queue_patch(Range(0, await resource.get_data_length()), new_data)

--- a/ofrak_core/ofrak/model/component_model.py
+++ b/ofrak_core/ofrak/model/component_model.py
@@ -71,7 +71,7 @@ class ComponentExternalTool:
         except FileNotFoundError:
             return False
 
-        return 0 == returncode
+        return True
 
 
 CC = TypeVar("CC", bound=Optional[ComponentConfig])

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -204,7 +204,11 @@ class OFRAK:
         components_missing_deps = []
         audited_components = []
         for component in all_discovered_components:
-            if all(dep.is_tool_installed() for dep in component.external_dependencies):
+            if all(
+                await asyncio.gather(
+                    *[dep.is_tool_installed() for dep in component.external_dependencies]
+                )
+            ):
                 audited_components.append(component)
             else:
                 components_missing_deps.append(component)

--- a/ofrak_core/test_ofrak/unit/component/test_component_external_tool.py
+++ b/ofrak_core/test_ofrak/unit/component/test_component_external_tool.py
@@ -98,7 +98,7 @@ async def test_external_tool_runtime_error_caught(ofrak_context: OFRAKContext, t
 
 
 async def test_tool_install_check(mock_dependency):
-    assert not mock_dependency.is_tool_installed()
+    assert not await mock_dependency.is_tool_installed()
 
     echo_tool = ComponentExternalTool("echo", "", install_check_arg=".")
-    assert echo_tool.is_tool_installed()
+    assert await echo_tool.is_tool_installed()


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Use `asyncio.create_subprocess_exec`instead of blocking subprocess.run calls in packers/unpackers.

**Link to Related Issue(s)**
#53 

**Please describe the changes in your request.**
See above

**Anyone you think should look at this, specifically?**
@rbs-jacob 