### PR TITLE
Maintenance: Windows pip install

### DIFF
--- a/disassemblers/ofrak_angr/MANIFEST.in
+++ b/disassemblers/ofrak_angr/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements*.txt

--- a/disassemblers/ofrak_capstone/MANIFEST.in
+++ b/disassemblers/ofrak_capstone/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements*.txt

--- a/disassemblers/ofrak_ghidra/MANIFEST.in
+++ b/disassemblers/ofrak_ghidra/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include ofrak_ghidra/ghidra_scripts *
 include ofrak_ghidra/run_ghidra_server.sh
 include ofrak_ghidra/config/ofrak_ghidra.conf.yml.default
+include requirements*.txt

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Fix bug where initially loaded GUI resource has collapsed children [#209](https://github.com/redballoonsecurity/ofrak/pull/209)
 - Support more OpenWRT TRX files by making fewer assumptions about the partitions [#216](https://github.com/redballoonsecurity/ofrak/pull/216)
+- Fixed some OS-specific problems (libmagic install, log file path) preventing OFRAK install on Windows [#239](https://github.com/redballoonsecurity/ofrak/pull/239)
 
 ### Added
 - Add keyboard shortcuts to the GUI

--- a/ofrak_core/MANIFEST.in
+++ b/ofrak_core/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-exclude test_ofrak *
 recursive-include ofrak/core/entropy/ *
 recursive-include ofrak/gui/public *
+include requirements*.txt

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import tempfile
 import time
 from types import ModuleType
 from typing import Type, Any, Awaitable, Callable, List, Iterable, Optional
@@ -24,6 +25,7 @@ from ofrak.service.job_service_i import JobServiceInterface
 from ofrak.service.resource_service_i import ResourceServiceInterface
 
 LOGGER = logging.getLogger("ofrak")
+DEFAULT_OFRAK_LOG_FILE = os.path.join(tempfile.gettempdir(), "ofrak.log")
 
 
 class OFRAKContext:
@@ -120,7 +122,7 @@ class OFRAK:
         not use any components missing some dependencies
         """
         logging.basicConfig(level=logging_level, format="[%(filename)15s:%(lineno)5s] %(message)s")
-        logging.getLogger().addHandler(logging.FileHandler("/tmp/ofrak.log"))
+        logging.getLogger().addHandler(logging.FileHandler(DEFAULT_OFRAK_LOG_FILE))
         logging.getLogger().setLevel(logging_level)
         logging.captureWarnings(True)
         self.injector = DependencyInjector()

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -15,3 +15,4 @@ synthol~=0.1.1
 typeguard~=2.13.3
 ubi-reader==0.8.5
 xattr==0.10.1;platform_system!="Windows"
+python-magic-bin;platform_system=="Windows"

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -9,10 +9,10 @@ orjson~=3.6.7
 pefile==2022.5.30
 pycdlib==1.12.0
 python-magic
+python-magic-bin;platform_system=="Windows"
 reedsolo==1.5.4
 sortedcontainers==2.2.2
 synthol~=0.1.1
 typeguard~=2.13.3
 ubi-reader==0.8.5
 xattr==0.10.1;platform_system!="Windows"
-python-magic-bin;platform_system=="Windows"

--- a/ofrak_patch_maker/MANIFEST.in
+++ b/ofrak_patch_maker/MANIFEST.in
@@ -1,1 +1,2 @@
 include ofrak_patch_maker/toolchain.conf
+include requirements*.txt

--- a/ofrak_tutorial/MANIFEST.in
+++ b/ofrak_tutorial/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements*.txt


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
N/A

**Link to Related Issue(s)**
* Libmagic was missing on windows, so not even importing `python-magic` worked
* requirements.txt files were not part of pip packages, so setup.py could not find and parse them
* /tmp/ofrak.log is not a valid path on Windows

**Please describe the changes in your request.**
*  install libmagic binaries on windows
* include requirements files in packages
* get log file in OS-agnostic way

**Anyone you think should look at this, specifically?**
