### PR TITLE
Fix bug in GUI where "jump to offset" 

### DIFF
--- a/frontend/src/HexView.svelte
+++ b/frontend/src/HexView.svelte
@@ -87,11 +87,11 @@
     end = 64;
   $: if (scrollY !== undefined && $scrollY !== undefined) {
     start = Math.max(
-      Math.ceil((data.byteLength * $scrollY.top) / alignment) * alignment,
+      Math.floor((data.byteLength * $scrollY.top) / alignment) * alignment,
       0
     );
     end = Math.min(
-      start + Math.ceil($scrollY.viewHeightPixels / lineHeight) * alignment,
+      start + Math.floor($scrollY.viewHeightPixels / lineHeight) * alignment,
       data.byteLength
     );
     chunks = chunkList(new Uint8Array(data.slice(start, end)), alignment).map(

--- a/frontend/src/JumpToOffset.svelte
+++ b/frontend/src/JumpToOffset.svelte
@@ -42,7 +42,7 @@
 
   $: if (mounted) {
     startOffset = Math.max(
-      Math.ceil((dataLength * $scrollY.top) / alignment) * alignment,
+      Math.floor((dataLength * $scrollY.top) / alignment) * alignment,
       0
     );
     input.value = `0x${startOffset.toString(16)}`;

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Fix bug where initially loaded GUI resource has collapsed children [#209](https://github.com/redballoonsecurity/ofrak/pull/209)
 - Support more OpenWRT TRX files by making fewer assumptions about the partitions [#216](https://github.com/redballoonsecurity/ofrak/pull/216)
-- Fixed some OS-specific problems (libmagic install, log file path) preventing OFRAK install on Windows [#239](https://github.com/redballoonsecurity/ofrak/pull/239)
+- Fix some OS-specific problems (libmagic install, log file path) preventing OFRAK install on Windows [#239](https://github.com/redballoonsecurity/ofrak/pull/239)
+- Fix bug in GUI where "jump to offset" feature in hex view rounded up instead of down [#243](https://github.com/redballoonsecurity/ofrak/pull/243)
 
 ### Added
 - Add keyboard shortcuts to the GUI


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
The GUI "jump to offset" feature would round up to nearest 16-byte-aligned address. This fixes this behavior to correctly round down.

**Please describe the changes in your request.**
See above.
