### PR TITLE
Adding necessary compiler flags to the GNU toolchain for non-relocata…

### DIFF
--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -374,3 +374,4 @@ class GNU_10_Toolchain(Abstract_GNU_Toolchain):
             self._linker_flags.append("--pic-executable")
         else:
             self._compiler_flags.append("-fno-plt")
+	    self._compiler_flags.append("-fno-pic")


### PR DESCRIPTION
…ble patches

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Adding -fno-pic to the GNU toolchain for non-relocatable patches facilitates valid arm64 patching 

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
This pull request adds "-fno-pic" for non-relocatable patches in the GNU toochain

**Anyone you think should look at this, specifically?**
@whyitfor 