### PR TITLE
Adding necessary compiler flags for non-relocatable arm64 patches

### DIFF
--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `ofrak-patch-maker` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Added
+- `-fno-pic` flag added to the GNU_10_Toolchain to support non-relocatable ARM64 patches (see [#245](https://github.com/redballoonsecurity/ofrak/pull/245))
 
 ## [3.0.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-patch-maker-v.2.0.0...ofrak-patch-maker-v.3.0.0) - 2023-01-20
 ### Added

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -374,3 +374,4 @@ class GNU_10_Toolchain(Abstract_GNU_Toolchain):
             self._linker_flags.append("--pic-executable")
         else:
             self._compiler_flags.append("-fno-plt")
+            self._compiler_flags.append("-fno-pic")


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Adding the -fno-pic compiler flag to the GNU Toolchain allows non-relocatable arm64 patches to succeed

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
This pull request adds the -fno-pic compiler flag to the GNU Toolchain

**Anyone you think should look at this, specifically?**
@whyitfor 
