### PR TITLE
Release/ofrak 2.2.1

### DIFF
--- a/disassemblers/ofrak_ghidra/requirements.txt
+++ b/disassemblers/ofrak_ghidra/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML~=6.0,>=5.4
+PyYAML>=5.4
 aiohttp~=3.8.1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ofrak-app",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The graphical front-end for OFRAK.",
   "homepage": "https://ofrak.com",
   "private": true,

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -233,5 +233,5 @@ Answer by running riddle.answer('your answer here') from the console.`);
 {/if}
 
 <div class="bottomright">
-  <p><a href="https://ofrak.com" target="_blank" rel="noreferrer">v2.2.0</a></p>
+  <p><a href="https://ofrak.com" target="_blank" rel="noreferrer">v2.2.1</a></p>
 </div>

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -5,33 +5,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
-## [2.2.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.0...ofrak-v2.2.1))
-### Fixed
-- Fix bug where initially loaded GUI resource has collapsed children [#209](https://github.com/redballoonsecurity/ofrak/pull/209)
-- Support more OpenWRT TRX files by making fewer assumptions about the partitions [#216](https://github.com/redballoonsecurity/ofrak/pull/216)
-- Fix some OS-specific problems (libmagic install, log file path) preventing OFRAK install on Windows [#239](https://github.com/redballoonsecurity/ofrak/pull/239)
-- Fix bug in GUI where "jump to offset" feature in hex view rounded up instead of down [#243](https://github.com/redballoonsecurity/ofrak/pull/243)
-
+## [2.2.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.0...ofrak-v2.2.1) - 2023-03-08
 ### Added
-- Add keyboard shortcuts to the GUI
-- Updates to Flash components: [#195](https://github.com/redballoonsecurity/ofrak/pull/195)
-  - Flash components now support more than one occurrence of the same field type in `FlashAttributes`.
-  - `FlashOobResourceUnpacker` continues to unpack even if blocks do not perfectly align at end of the `FlashOobResource` (this is useful for real-world flash dumps).
-- Add a button to the GUI to add a new tag to a resource [#215](https://github.com/redballoonsecurity/ofrak/pull/215)
-- Add a way to sort and filter by data length or offset [#220](https://github.com/redballoonsecurity/ofrak/pull/220)
-- Add caption to ElfProgramHeader
-- Add current resource caption to GUI browser tab title 
+- Add GUI features
+  - Keyboard shortcuts ([#210](https://github.com/redballoonsecurity/ofrak/pull/210))
+  - Button to add a tag to a resource ([#215](https://github.com/redballoonsecurity/ofrak/pull/215))
+  - Browser tab title contains current resource caption ([#230](https://github.com/redballoonsecurity/ofrak/pull/230))
+- Add a way to sort and filter by data length or offset ([#220](https://github.com/redballoonsecurity/ofrak/pull/220))
+- Add caption to ElfProgramHeader ([#223](https://github.com/redballoonsecurity/ofrak/pull/223))
+- Add baseline support for running pip-installing ofrak on Windows ([#228](https://github.com/redballoonsecurity/ofrak/pull/228), [#239](https://github.com/redballoonsecurity/ofrak/pull/239), [#242](https://github.com/redballoonsecurity/ofrak/pull/242), [#246]( #246))
 
 ### Changed
-- Tweak how errors are raised when auto-running components, so the actual root cause is not buried [#219](https://github.com/redballoonsecurity/ofrak/pull/219)
-- Show mapped resource captions on hover in the hex view [#221](https://github.com/redballoonsecurity/ofrak/pull/221)
-- Change how resources are stored to making deleting (and thus packing) much faster [#201](https://github.com/redballoonsecurity/ofrak/pull/201)
-- Use non-blocking `asyncio.create_subprocess_exec` calls in components [#53](https://github.com/redballoonsecurity/ofrak/issues/53)
+- Updates to Flash components: ([#195](https://github.com/redballoonsecurity/ofrak/pull/195))
+  - Flash components now support more than one occurrence of the same field type in `FlashAttributes`.
+  - `FlashOobResourceUnpacker` continues to unpack even if blocks do not perfectly align at end of the `FlashOobResource` (this is useful for real-world flash dumps).
+- Tweak how errors are raised when auto-running components, so the actual root cause is not buried ([#219](https://github.com/redballoonsecurity/ofrak/pull/219))
+- Show mapped resource captions on hover in the hex view ([#221](https://github.com/redballoonsecurity/ofrak/pull/221))
+- Change how resources are stored to making deleting (and thus packing) much faster ([#201](https://github.com/redballoonsecurity/ofrak/pull/201))
+- Use non-blocking `asyncio.create_subprocess_exec` calls in components ([#53](https://github.com/redballoonsecurity/ofrak/issues/53))
 
-### Added
-- Add stub `xattr` module to use on platforms without `xattr` support (e.g., Windows) [#228](https://github.com/redballoonsecurity/ofrak/pull/228)
+### Fixed
+- Fix bug where initially loaded GUI resource has collapsed children ([#209](https://github.com/redballoonsecurity/ofrak/pull/209))
+- Fix bug in GUI where "jump to offset" feature in hex view rounded up instead of down ([#243](https://github.com/redballoonsecurity/ofrak/pull/243))
+- Support more OpenWRT TRX files by making fewer assumptions about the partitions ([#216](https://github.com/redballoonsecurity/ofrak/pull/216))
+- Fix some OS-specific problems (libmagic install, log file path) preventing OFRAK install on Windows ([#239](https://github.com/redballoonsecurity/ofrak/pull/239))
 
-## [2.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.1...ofrak-v2.2.0))
+## [2.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.1.1...ofrak-v2.2.0) - 2023-02-01
 ### Fixed
 - Fix bug in data service that can cause mangled internal state [#197](https://github.com/redballoonsecurity/ofrak/pull/197)
 - Fix long-broken `OFRAK.set_id_service` [#198](https://github.com/redballoonsecurity/ofrak/pull/198)

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+## [2.2.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.0...ofrak-v2.2.1))
 ### Fixed
 - Fix bug where initially loaded GUI resource has collapsed children [#209](https://github.com/redballoonsecurity/ofrak/pull/209)
 - Support more OpenWRT TRX files by making fewer assumptions about the partitions [#216](https://github.com/redballoonsecurity/ofrak/pull/216)

--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -30,7 +30,7 @@ RUN wget https://raw.githubusercontent.com/iBotPeaches/Apktool/v2.3.3/scripts/li
 
 # Install official 7-zip
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-  cd tmp && \
+  cd /tmp && \
   wget https://www.7-zip.org/a/7z2201-linux-arm64.tar.xz && \
   tar -xf 7z2201-linux-arm64.tar.xz && \
   mv 7zz /usr/local/bin && \
@@ -38,7 +38,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 fi;
 
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-  cd tmp && \
+  cd /tmp && \
   wget https://www.7-zip.org/a/7z2201-linux-x64.tar.xz && \
   tar -xf 7z2201-linux-x64.tar.xz && \
   mv 7zz /usr/local/bin && \

--- a/ofrak_core/requirements-test.txt
+++ b/ofrak_core/requirements-test.txt
@@ -12,6 +12,5 @@ pytest-asyncio==0.19.0
 pytest-lazy-fixture
 pytest-cov
 pytest-xdist
-beartype~=0.10.2
 requests
 fun-coverage==0.2.0

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -1,12 +1,12 @@
 aiohttp~=3.8.1
-beartype~=0.10.2
-fdt==0.3.2
+beartype~=0.12.0
+fdt==0.3.3
 importlib-metadata>=1.4
 intervaltree==3.1.0
 keystone-engine==0.9.2
-lief==0.12.2
-orjson~=3.6.7
-pefile==2022.5.30
+lief==0.12.3
+orjson~=3.8.7
+pefile==2023.2.7
 pycdlib==1.12.0
 python-magic
 python-magic-bin;platform_system=="Windows"

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -10,7 +10,7 @@ pefile==2022.5.30
 pycdlib==1.12.0
 python-magic
 python-magic-bin;platform_system=="Windows"
-reedsolo==1.5.4
+reedsolo==1.7.0
 sortedcontainers==2.2.2
 synthol~=0.1.1
 typeguard~=2.13.3

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -40,7 +40,7 @@ def read_requirements(requirements_path):
 
 setuptools.setup(
     name="ofrak",
-    version="2.2.0",
+    version="2.2.1",
     description="A binary analysis and modification platform",
     packages=setuptools.find_packages(exclude=["test_ofrak", "test_ofrak.*"]),
     package_data={


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Update OFRAK to 2.2.1

**Link to Related Issue(s)**

**Please describe the changes in your request.**
Bump version numbers, plus minor touch-ups:
* remove pyyaml 6.0 pin in ofrak_ghidra
* handle missing uber-apk-signer properly and os-agnostic
* dockerstub goes to tmp dir with absolute path

**Anyone you think should look at this, specifically?**
