### PR TITLE
Fix path to GUI keybindings in OFRAK documentation

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -30,7 +30,7 @@ ofrak list
 
 However, not all of OFRAK's dependencies can be installed via `pip install`. 
 These dependencies are, however, optional, and the OFRAK code that requires them can be disabled in order avoid runtime errors.
-OFRAK has a system for inspecting and installing such dependencies. See [the section on external dependencies](handling-non-python-dependencies) for more info on that.
+OFRAK has a system for inspecting and installing such dependencies. See [the section on external dependencies](#handling-non-python-dependencies) for more info on that.
 
 
 ## From Source Code
@@ -65,7 +65,7 @@ However, this will result in a somewhat confusing environment where some of the 
 
 Installing OFRAK from source code will not install all of OFRAK's non-Python dependencies (for same reason as when installing OFRAK from PyPI - not all of its dependencies are pip-installable).
 These dependencies are, however, optional, and the OFRAK code that requires them can be disabled in order avoid runtime errors.
-OFRAK has a system for inspecting and installing dependencies. See [the section on external dependencies](handling-non-python-dependencies) for more info on that.
+OFRAK has a system for inspecting and installing dependencies. See [the section on external dependencies](#handling-non-python-dependencies) for more info on that.
 
 
 ### Modifying OFRAK Source Code

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ nav:
           - Packer: "user-guide/key-concepts/component/packer.md"
         - GUI:
           - Minimap View: "user-guide/key-concepts/gui/minimap.md"
-          - Keybindings: "user-guide/gui/keybindings.md"
+          - Keybindings: "user-guide/key-concepts/gui/keybindings.md"
       - Disassembler Backends:
         - Ghidra Backend: "user-guide/disassembler-backends/ghidra.md"
         - Binary Ninja Backend: "user-guide/disassembler-backends/binary_ninja.md"


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix path to GUI keybindings in OFRAK docs, and another broken link in the docs.
