### PR TITLE
Fix bug when jumping to a multiple of 0x10

### DIFF
--- a/frontend/src/JumpToOffset.svelte
+++ b/frontend/src/JumpToOffset.svelte
@@ -55,7 +55,7 @@
     if (e.key === 'Enter') {
       input.blur();
       try {
-        let result = calculator.calculate(input.value);
+        let result = calculator.calculate(input.value) + 1;
         $scrollY.top = result / dataLength;
       } catch (_) {
         input.value = `0x${startOffset.toString(16)}`;

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))
 
+### Fixed
+- Fix bug where jumping to a multiple of `0x10` in the GUI went to the previous line ([#254](https://github.com/redballoonsecurity/ofrak/pull/254))
+
 ## [2.2.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.0...ofrak-v2.2.1) - 2023-03-08
 ### Added
 - Add GUI features


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix bug where jumping to a multiple of `0x10` in the GUI went to the previous line.

The changes introduced in #243 caused a different bug where jumping to an exact multiple of `0x10` rounded down the address to jump to and went to the previous line in the hex view of the GUI. This change fixes that issue.

**Anyone you think should look at this, specifically?**

@whyitfor 