### PR TITLE
Auto-import linux cross-compile headers

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Changed
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))
+- `PatchFromSourceModifier` and `FunctionReplaceModifier` automatically include cross-compile headers for target system
 
 ## [2.2.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.0...ofrak-v2.2.1) - 2023-03-08
 ### Added

--- a/ofrak_core/ofrak/core/patch_maker/modifiers.py
+++ b/ofrak_core/ofrak/core/patch_maker/modifiers.py
@@ -128,6 +128,7 @@ class PatchFromSourceModifier(Modifier):
         patch_maker = PatchMaker(
             toolchain=config.toolchain(program_attributes, config.toolchain_config),
             build_dir=build_tmp_dir,
+            auto_add_linux_headers=True,
         )
 
         patch_bom = patch_maker.make_bom(

--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -6,11 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
 - `-fno-pic` flag added to the GNU_10_Toolchain to omit GOTs in patches (FEMs) against binaries that aren't dynamically linked. (see [#245](https://github.com/redballoonsecurity/ofrak/pull/245))
-
-### Added
 - Add methods to parse relocation symbols from object files.
 - Extend parsed symbol dictionary to include LinkableSymbolType.
 - Extend AssembledObject and BOM types to include relocation and unresolved symbols.
+- Add PatchMaker option to auto-choose a linux cross-compiler header include path
 
 ## [3.0.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-patch-maker-v.2.0.0...ofrak-patch-maker-v.3.0.0) - 2023-01-20
 ### Added

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -75,3 +75,19 @@ RUN apt-get update && apt-get install -y gcc-avr binutils-avr avr-libc
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
     apt-get update && apt-get install -y gcc-10-powerpc-linux-gnu; \
 fi;
+
+
+# General cross-compile headers
+RUN apt-get update && apt-get install -y \
+    linux-libc-dev-amd64-cross \
+    linux-libc-dev-arm64-cross \
+    linux-libc-dev-armel-cross \
+    linux-libc-dev-armhf-cross \
+    linux-libc-dev-i386-cross \
+    linux-libc-dev-m68k-cross \
+    linux-libc-dev-mips-cross \
+    linux-libc-dev-mips64-cross \
+    linux-libc-dev-mips64el-cross \
+    linux-libc-dev-powerpc-cross \
+    linux-libc-dev-ppc64-cross \
+    linux-libc-dev-ppc64el-cross


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
- Add PatchMaker option to auto-choose a linux cross-compiler header include path
- `PatchFromSourceModifier` and `FunctionReplaceModifier` automatically include cross-compile headers for target system

**Link to Related Issue(s)**

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
