### PR TITLE
General support for separate_data_sections, and new flag for keeping more sections

### DIFF
--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -6,11 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
 - `-fno-pic` flag added to the GNU_10_Toolchain to omit GOTs in patches (FEMs) against binaries that aren't dynamically linked. (see [#245](https://github.com/redballoonsecurity/ofrak/pull/245))
-
-### Added
 - Add methods to parse relocation symbols from object files.
 - Extend parsed symbol dictionary to include LinkableSymbolType.
 - Extend AssembledObject and BOM types to include relocation and unresolved symbols.
+- Add separate data sections support to LLVM toolchain, and add general flag for including subsections
 
 ## [3.0.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-patch-maker-v.2.0.0...ofrak-patch-maker-v.3.0.0) - 2023-01-20
 ### Added

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
@@ -82,7 +82,7 @@ class Toolchain(ABC):
         # The keep_list should only contain FUNCTIONALLY important sections
         # (not empty .got.plt, for instance).
         # TODO: Come up with a better system to handle this...
-        self._linker_keep_list = [".data", ".rodata", ".text"]
+        self._linker_keep_list = [".data", ".rodata", ".text", ".rel"]
         self._linker_discard_list = [
             ".gnu.hash",
             ".comment",
@@ -357,11 +357,16 @@ class Toolchain(ABC):
     def linker_include_filter(symbol_name: str) -> bool:
         return "." in symbol_name or "_DYNAMIC" in symbol_name
 
-    def keep_section(self, section_name: str) -> bool:
-        if self._config.separate_data_sections:
-            raise NotImplementedError("you must override keep_section() in your Toolchain sublass")
+    def keep_section(self, section_name: str):
+        if section_name in self._linker_keep_list:
+            return True
+        if self._config.separate_data_sections or self._config.include_subsections:
+            for keep_section in self._linker_keep_list:
+                if section_name.startswith(keep_section):
+                    return True
+            return False
         else:
-            return section_name in self._linker_keep_list
+            return False
 
     @abstractmethod
     def generate_linker_include_file(self, symbols: Mapping[str, int], out_path: str) -> str:

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -113,17 +113,6 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
     def _get_linker_map_flag(exec_path: str) -> Iterable[str]:
         return "-Map", f"{exec_path}.map"
 
-    def keep_section(self, section_name: str):
-        if section_name in self._linker_keep_list:
-            return True
-        if self._config.separate_data_sections:
-            for keep_section in self._linker_keep_list:
-                if section_name.startswith(keep_section):
-                    return True
-            return False
-        else:
-            return False
-
     def add_linker_include_values(self, symbols: Mapping[str, int], path: str):
         with open(path, "a") as f:
             for name, addr in symbols.items():

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/llvm_12.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/llvm_12.py
@@ -55,7 +55,7 @@ class LLVM_12_0_1_Toolchain(Toolchain):
         )
 
         if self._config.separate_data_sections:
-            raise NotImplementedError("separate sections not supported by LLVM Toolchain yet")
+            self._compiler_flags.append("-fdata-sections")
         if self._config.compiler_cpu:
             self._compiler_flags.append(f"-mcpu={self._config.compiler_cpu}")
 
@@ -234,7 +234,7 @@ class LLVM_12_0_1_Toolchain(Toolchain):
         abs_path = os.path.abspath(object_path)
         return (
             f"    .rbs_{stripped_obj_name}_{stripped_seg_name} : {{\n"
-            f"        {abs_path}({segment_name})\n"
+            f"        {abs_path}({segment_name}*)\n"
             f"    }} > {memory_region_name}"
         )
 

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/model.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/model.py
@@ -97,6 +97,8 @@ class ToolchainConfig:
     :var isysroot: Specifies the root directory for header files
     :var c_standard: Specifies the version of C to use, e.g. C89, C99, etc
     :var separate_data_sections: Whether to put each data object in a separate section in .o file
+    :var include_subsections: In addition to normal keep sections, keep "sub"-sections sharing name
+    prefix e.g. .text.foo (this flag is treated as True if separate_data_sections is True)
     :var hard_float: Compile with support for hardware floating point operations (Default: `False`)
     """
 
@@ -117,5 +119,6 @@ class ToolchainConfig:
     userspace_dynamic_linker: Optional[str] = None
     isysroot: Optional[str] = None
     c_standard: Optional[CStandardVersion] = CStandardVersion.C99
-    separate_data_sections: Optional[bool] = False
+    separate_data_sections: bool = False
+    include_subsections: bool = False
     hard_float: Optional[bool] = False


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
- Add separate data sections support to LLVM toolchain, and add general flag for including subsections

**Link to Related Issue(s)**
Extends and replaces https://github.com/redballoonsecurity/ofrak/pull/203

**Please describe the changes in your request.**
The addition of the `separate_data_sections` functionality to the LLVM toolchain aligns it with the GNU toolchain. In both toolchains, enabling `separate_data_sections` requires broadening the pattern for the sections we keep from the BOM to the FEM. Per the discussion in #203, I added a separate flag that just enables that broader keep list without actually making data sections.

**Anyone you think should look at this, specifically?**
