### PR TITLE
Add cmake to ofrak_core Dockerstub file

### DIFF
--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -3,6 +3,7 @@ ARG TARGETARCH
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
       build-essential \
+      cmake \
       cpio \
       git \
       liblz4-dev \


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add `cmake` to `ofrak_core/Dockerstub`.

**Link to Related Issue(s)**
`cmake` is needed for some Python packages that need to be built. For example, keystone on M1 (see https://github.com/redballoonsecurity/ofrak/issues/76#issuecomment-1416160037).

**Please describe the changes in your request.**
Add `cmake` to `ofrak_core/Dockerstub`.
