### PR TITLE
Better view analysis

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Changed
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))
+- Choose Analyzer components which output the entirety of a view, rather than piece by piece, which would choose the wrong Analyzer sometimes. [#264](https://github.com/redballoonsecurity/ofrak/pull/264)
 
 ### Fixed
 - Fix bug where jumping to a multiple of `0x10` in the GUI went to the previous line ([#254](https://github.com/redballoonsecurity/ofrak/pull/254))

--- a/ofrak_core/ofrak/model/component_filters.py
+++ b/ofrak_core/ofrak/model/component_filters.py
@@ -85,7 +85,7 @@ class AnalyzerOutputFilter(ComponentFilter):
         def component_is_analyzer_with_outputs(c: ComponentInterface):
             if _isinstance(c, Analyzer):
                 analyzer_outputs = set(c.get_outputs_as_attribute_types())  # type: ignore
-                return not analyzer_outputs.isdisjoint(self.outputs)
+                return self.outputs.issubset(analyzer_outputs)
             return False
 
         return {c for c in components if component_is_analyzer_with_outputs(c)}

--- a/ofrak_core/ofrak/model/job_request_model.py
+++ b/ofrak_core/ofrak/model/job_request_model.py
@@ -10,7 +10,7 @@ from ofrak.model.tag_model import ResourceTag
 class JobAnalyzerRequest:
     job_id: bytes
     resource_id: bytes
-    attributes: Type[ResourceAttributes]
+    attributes: Tuple[Type[ResourceAttributes], ...]
     target_tags: Tuple[ResourceTag, ...]
 
 

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -421,7 +421,7 @@ class Resource:
         """
         attributes = self._check_attributes(resource_attributes)
         if attributes is None:
-            await self._analyze_attributes(resource_attributes)
+            await self._analyze_attributes((resource_attributes,))
             return self.get_attributes(resource_attributes)
         else:
             return attributes
@@ -533,13 +533,13 @@ class Resource:
 
         destination.write(await self.get_data())
 
-    async def _analyze_attributes(self, attribute_type: Type[ResourceAttributes]):
+    async def _analyze_attributes(self, attribute_types: Tuple[Type[ResourceAttributes], ...]):
         job_context = self._job_context
         components_result = await self._job_service.run_analyzer_by_attribute(
             JobAnalyzerRequest(
                 self._job_id,
                 self._resource.id,
-                attribute_type,
+                attribute_types,
                 tuple(self._resource.tags),
             ),
             job_context,
@@ -747,15 +747,17 @@ class Resource:
             self._resource_view_context.add_view(self.get_id(), view)
             return cast(RV, view)
 
-        analysis_tasks = [
-            self._analyze_attributes(attrs_t)
-            for attrs_t, existing in zip(composed_attrs_types, existing_attributes)
-            if not existing
-        ]
+        analysis_task = self._analyze_attributes(
+            tuple(
+                attrs_t
+                for attrs_t, existing in zip(composed_attrs_types, existing_attributes)
+                if not existing
+            )
+        )
 
         # Only if analysis is absolutely necessary is an awaitable created and returned
         async def finish_view_creation() -> RV:
-            await asyncio.gather(*analysis_tasks)
+            await asyncio.gather(analysis_task)
             view = viewable_tag.create(self.get_model())
             view.resource = self  # type: ignore
             self._resource_view_context.add_view(self.get_id(), view)

--- a/ofrak_core/ofrak/service/job_service.py
+++ b/ofrak_core/ofrak/service/job_service.py
@@ -248,7 +248,7 @@ class JobService(JobServiceInterface):
         else:
             raise NotFoundError(
                 f"Unable to find any analyzer for attributes "
-                f"{','.join(attr_t.__name__ for attr_t in request.attributes)}"
+                f"{', '.join(attr_t.__name__ for attr_t in request.attributes)}"
                 f"\nFilter: {component_filter}"
             )
 

--- a/ofrak_core/test_ofrak/service/component_locator/test_component_locator.py
+++ b/ofrak_core/test_ofrak/service/component_locator/test_component_locator.py
@@ -325,6 +325,15 @@ GET_COMPONENTS_TEST_CASES = [
             AbstractionRRUnpacker,
         ),
     ),
+    GetComponentMatchingFiltersTestCase(
+        "match only the analyzer outputting ALL the requested attributes",
+        (
+            AnalyzerOutputFilter(
+                AbstractionAttributesA, AbstractionAttributesB, AbstractionAttributesC
+            ),
+        ),
+        (TargetsQOutputsABC,),
+    ),
 ]
 
 


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Choose Analyzer components which output the entirety of a view, rather than piece by piece, which would choose the wrong Analyzer sometimes.

**Link to Related Issue(s)**
ResourceViews are composed of multiple attributes types, and when running something like `view_as` OFRAK would previously make a request for each of those attributes types. With limited visibility into what the user actually wants, the job service would sometimes end up choosing Analyzers which do output one or more of the requested attributes but actually require the analysis of the other attributes, resulting in a deadlock.

**Please describe the changes in your request.**
* Auto-analyze attributes requests now can take multiple attributes types at once (and `view_as` uses this)
* The component filter for analyzer output looks for analyzers which output all of the requested attributes (and possibly other attributes as well), instead of any analyzers which output one or more of the requested attributes
* When auto-analyzing attributes, the job service first looks for an Analyzer outputting all of the requested attributes, and if such an Analyzer is not found, falls back to looking for Analyzers for each requested attribute individually (the previous behavior)

**Anyone you think should look at this, specifically?**
@rbs-jacob 