### PR TITLE
add argument for `ofrak gui` command to load files as Resources

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
-- Add option to ofrak gui to pre-load some files into OFRAK before opening the GUI, so they can be explore right away ([#266](https://github.com/redballoonsecurity/ofrak/pull/266))
+- Add option to `ofrak gui` command to pre-load some files into OFRAK before opening the GUI, so they can be explored right away ([#266](https://github.com/redballoonsecurity/ofrak/pull/266))
 
 ### Changed
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Added
+- Add option to ofrak gui to pre-load some files into OFRAK before opening the GUI, so they can be explore right away ([#266](https://github.com/redballoonsecurity/ofrak/pull/266))
+
 ### Changed
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))
 

--- a/ofrak_core/ofrak/cli/command/gui.py
+++ b/ofrak_core/ofrak/cli/command/gui.py
@@ -39,7 +39,7 @@ class GUICommand(OfrakCommandRunsScript):
         gui_parser.add_argument(
             "--file",
             "-f",
-            required="False",
+            required=False,
             action="append",
             help="Path to a file to load into OFRAK when starting the GUI (multiple may be "
             "provided)",
@@ -49,13 +49,15 @@ class GUICommand(OfrakCommandRunsScript):
         return gui_parser
 
     async def ofrak_func(self, ofrak_context: OFRAKContext, args: Namespace):  # pragma: no cover
-        if len(args.file):
+        most_recent_root = None
+        if len(args.file) > 0:
             for path in args.file:
-                _ = await ofrak_context.create_root_resource_from_file(path)
+                most_recent_root = await ofrak_context.create_root_resource_from_file(path)
         server = await open_gui(
             args.hostname,
             args.port,
             open_in_browser=(not args.no_browser),
             ofrak_context=ofrak_context,
+            focus_resource=most_recent_root if len(args.file) == 1 else None,
         )
         await server.run_until_cancelled()

--- a/ofrak_core/ofrak/cli/command/gui.py
+++ b/ofrak_core/ofrak/cli/command/gui.py
@@ -36,9 +36,26 @@ class GUICommand(OfrakCommandRunsScript):
             action="store_true",
             help="Don't open the browser to the OFRAK GUI",
         )
+        gui_parser.add_argument(
+            "--file",
+            "-f",
+            required="False",
+            action="append",
+            help="Path to a file to load into OFRAK when starting the GUI (multiple may be "
+            "provided)",
+            default=[],
+        )
         self.add_ofrak_arguments(gui_parser)
         return gui_parser
 
     async def ofrak_func(self, ofrak_context: OFRAKContext, args: Namespace):  # pragma: no cover
-        server = await open_gui(args.hostname, args.port, open_in_browser=(not args.no_browser))
+        if len(args.file):
+            for path in args.file:
+                _ = await ofrak_context.create_root_resource_from_file(path)
+        server = await open_gui(
+            args.hostname,
+            args.port,
+            open_in_browser=(not args.no_browser),
+            ofrak_context=ofrak_context,
+        )
         await server.run_until_cancelled()


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add option to `ofrak gui` to pre-load some files into OFRAK before opening the GUI, so they can be explore right away

**Link to Related Issue(s)**
The `ofrak gui` command didn't have a way to open a file in the GUI. It was easy to work around with `ofrak identify --gui` which will take a file and then open the GUI, but it wasn't obvious. It just made it a bit clumsier to transition from a terminal to using the GUI.

**Please describe the changes in your request.**
Add the "--file" (or "-f") argument to pass paths to files. Multiple files can be passed in this way, and the the user can choose one from the dropdown menu on the home screen.

**Anyone you think should look at this, specifically?**
@whyitfor I believe you were also lamenting the lack of this feature with me the other day