### PR TITLE
AARCH64/Linux patch maker changes

### DIFF
--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to `ofrak-patch-maker` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+### Changed
+- Discard `.altinstructions` section when linking
+- Use `SUBALIGN(0)` for `.bss` sections
+- Force literal pool at end of function for AARCH64 using `-mpc-relative-literal-loads`
 ### Added
+- `cortex-a72` processor type
 - `-fno-pic` flag added to the GNU_10_Toolchain to omit GOTs in patches (FEMs) against binaries that aren't dynamically linked. (see [#245](https://github.com/redballoonsecurity/ofrak/pull/245))
 
 ### Added

--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Use `SUBALIGN(0)` for `.bss` sections
 - Force literal pool at end of function for AARCH64 using `-mpc-relative-literal-loads`
 ### Added
-- `cortex-a72` processor type
 - `-fno-pic` flag added to the GNU_10_Toolchain to omit GOTs in patches (FEMs) against binaries that aren't dynamically linked. (see [#245](https://github.com/redballoonsecurity/ofrak/pull/245))
 
 ### Added

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
@@ -93,6 +93,7 @@ class Toolchain(ABC):
             ".dynsym",
             ".dynstr",
             ".eh_frame",
+            ".altinstructions",
         ]
 
         self._assembler_target = self._get_assembler_target(processor)

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -196,7 +196,7 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
     ) -> str:
         bss_section_name = ".bss"
         return (
-            f"    {bss_section_name} : {{\n"
+            f"    {bss_section_name} : SUBALIGN(0) {{\n"
             f"        *.o({bss_section_name}, {bss_section_name}.*)\n"
             f"    }} > {memory_region_name}"
         )

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_aarch64.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_aarch64.py
@@ -19,6 +19,8 @@ class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
         super().__init__(processor, toolchain_config, logger=logger)
         # Enable compilation of the GNU atomics intrinsics.
         self._compiler_flags.append("-mno-outline-atomics")
+        # Force literal pools at end of functions, rather than .rodata
+        self._compiler_flags.append("-mpc-relative-literal-loads")
 
     @property
     def name(self) -> str:

--- a/ofrak_type/CHANGELOG.md
+++ b/ofrak_type/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
+- `ProcessorType.CORTEX_A72`
 - LinkableSymbolType enum for generalized representation of symbol types (essentially functions vs. data)
 
 ## [2.1.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-type-v2.0.0...ofrak-type-v2.1.0) - 2023-01-20

--- a/ofrak_type/ofrak_type/architecture.py
+++ b/ofrak_type/ofrak_type/architecture.py
@@ -153,6 +153,7 @@ class ProcessorType(Enum):
     COLDFIRE4E = "cfv4e"
     CORTEX_A53 = "cortex-a53"
     CORTEX_A55 = "cortex-a55"
+    CORTEX_A72 = "cortex-a72"
     AVR = "avr"
 
 


### PR DESCRIPTION
**One sentence summary of this PR (This should go in the CHANGELOG!)**
Patch Maker changes for AARCH64/Linux patches.

**Link to Related Issue(s)**
n/a

**Please describe the changes in your request.**
- Discard `.altinstructions` sections
  - Some macros in the Linux headers generate an `.altinstructions` section. This section is not required so we can discard it.
- Fix `.bss` subalignment
- Force literal pool at end of function using `-mpc-relative-literal-loads`
- Add `cortex-a72` processor type

**Anyone you think should look at this, specifically?**
@whyitfor 
