### PR TITLE
add command line arg to import and discover additional code when star…

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
-- Add option to `ofrak gui` command to pre-load some files into OFRAK before opening the GUI, so they can be explored right away ([#266](https://github.com/redballoonsecurity/ofrak/pull/266))
+- Add `-f`/`--file` option to `ofrak gui` command to pre-load some files into OFRAK before opening the GUI, so they can be explored right away ([#266](https://github.com/redballoonsecurity/ofrak/pull/266))
+- Add `-i`/`--import` option to the CLI to import and discover additional OFRAK Python packages when starting OFRAK. [#269](https://github.com/redballoonsecurity/ofrak/pull/269)
 
 ### Changed
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -21,7 +21,7 @@ BACKEND_PACKAGES = {
     "angr": {"ofrak_angr", "ofrak_capstone"},
     "binary-ninja": {"ofrak_binary_ninja", "ofrak_capstone"},
     "ghidra": {"ofrak_ghidra"},
-    None: {},
+    None: set(),
 }
 
 
@@ -169,7 +169,7 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
         ofrak_pkgs = set(args.imports)
         ofrak_pkgs.update(BACKEND_PACKAGES.get(args.backend))
 
-        if not any(pkgs.issubset(ofrak_pkgs) for pkgs in BACKEND_PACKAGES.values()):
+        if not any(pkgs and pkgs.issubset(ofrak_pkgs) for pkgs in BACKEND_PACKAGES.values()):
             logging.warning("No disassembler backend specified, so no disassembly will be possible")
 
         for ofrak_pkg_name in ofrak_pkgs:

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from argparse import ArgumentParser, _SubParsersAction, Namespace
 from inspect import isabstract
 from types import ModuleType
-from typing import Dict, Iterable, List, Optional, Sequence, Type
+from typing import Dict, Iterable, List, Optional, Sequence, Type, Set
 
 from importlib_metadata import entry_points
 
@@ -16,8 +16,7 @@ from ofrak.model.component_model import ComponentExternalTool
 from ofrak.ofrak_context import OFRAKContext, OFRAK
 from synthol.injector import DependencyInjector
 
-
-BACKEND_PACKAGES = {
+BACKEND_PACKAGES: Dict[Optional[str], Set[str]] = {
     "angr": {"ofrak_angr", "ofrak_capstone"},
     "binary-ninja": {"ofrak_binary_ninja", "ofrak_capstone"},
     "ghidra": {"ofrak_ghidra"},
@@ -167,7 +166,7 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
         )
 
         ofrak_pkgs = set(args.imports)
-        ofrak_pkgs.update(BACKEND_PACKAGES.get(args.backend))
+        ofrak_pkgs.update(BACKEND_PACKAGES[args.backend])
 
         if not any(pkgs and pkgs.issubset(ofrak_pkgs) for pkgs in BACKEND_PACKAGES.values()):
             logging.warning("No disassembler backend specified, so no disassembly will be possible")

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -1,5 +1,7 @@
 import functools
+import importlib
 import logging
+import os.path
 import sys
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser, _SubParsersAction, Namespace
@@ -13,6 +15,14 @@ from ofrak.component.interface import ComponentInterface
 from ofrak.model.component_model import ComponentExternalTool
 from ofrak.ofrak_context import OFRAKContext, OFRAK
 from synthol.injector import DependencyInjector
+
+
+BACKEND_PACKAGES = {
+    "angr": {"ofrak_angr", "ofrak_capstone"},
+    "binary-ninja": {"ofrak_binary_ninja", "ofrak_capstone"},
+    "ghidra": {"ofrak_ghidra"},
+    None: {},
+}
 
 
 class OFRAKEnvironment:
@@ -110,7 +120,6 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
 
     @staticmethod
     def add_ofrak_arguments(command_subparser):
-        # TODO: Add CLI arguments for additional modules to discover (e.g. ofrak_ghidra)
         command_subparser.add_argument(
             "--logging-level",
             "-l",
@@ -129,8 +138,22 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
             "-b",
             "--backend",
             action="store",
-            help="Set GUI server backend.",
+            help="Set GUI server backend by importing additional OFRAK packages. Equivalent to "
+            "importing these packages with `-i`. For example, `-b angr` is: `-i ofrak_angr "
+            "-i ofrak_capstone`",
+            choices=BACKEND_PACKAGES.keys(),
             default=None,
+        )
+        command_subparser.add_argument(
+            "-i",
+            "--import",
+            help="Import additional OFRAK Python packages, where additional Components, Tags, etc. "
+            "may be defined. Can be either the name of an installed module or a local path to "
+            "a Python file or module.",
+            required=False,
+            action="append",
+            default=[],
+            dest="imports",  # object member can't be called "import"
         )
 
     def run(self, ofrak_env: OFRAKEnvironment, args: Namespace):
@@ -143,29 +166,25 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
             exclude_components_missing_dependencies=args.exclude_components_missing_dependencies,
         )
 
-        if args.backend is not None:
-            if args.backend.lower() == "binary-ninja":
-                import ofrak_capstone  # type: ignore
-                import ofrak_binary_ninja  # type: ignore
+        ofrak_pkgs = set(args.imports)
+        ofrak_pkgs.update(BACKEND_PACKAGES.get(args.backend))
 
-                ofrak.discover(ofrak_capstone)
-                ofrak.discover(ofrak_binary_ninja)
+        if not any(pkgs.issubset(ofrak_pkgs) for pkgs in BACKEND_PACKAGES.values()):
+            logging.warning("No disassembler backend specified, so no disassembly will be possible")
 
-            elif args.backend.lower() == "ghidra":
-                import ofrak_ghidra  # type: ignore
+        for ofrak_pkg_name in ofrak_pkgs:
+            if os.path.sep in ofrak_pkg_name or ofrak_pkg_name.endswith(".py"):
+                ofrak_file_path = os.path.abspath(ofrak_pkg_name)
+                ofrak_file_dir = os.path.dirname(ofrak_file_path)
+                ofrak_file_name = os.path.basename(ofrak_file_path)
+                if ofrak_file_name.endswith(".py"):
+                    ofrak_file_name = ofrak_file_name[:-3]
 
-                ofrak.discover(ofrak_ghidra)
-
-            elif args.backend.lower() == "angr":
-                import ofrak_capstone  # type: ignore
-                import ofrak_angr  # type: ignore
-
-                ofrak.discover(ofrak_capstone)
-                ofrak.discover(ofrak_angr)
+                sys.path.append(ofrak_file_dir)
+                ofrak_pkg = importlib.import_module(ofrak_file_name)
             else:
-                logging.warning(
-                    "No disassembler backend specified, so no disassembly will be possible"
-                )
+                ofrak_pkg = importlib.import_module(ofrak_pkg_name)
+            ofrak.discover(ofrak_pkg)
 
         ofrak.run(self.ofrak_func, args)
 

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -183,16 +183,15 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
 
     def _import_via_path(self, path: str):
         ofrak_file_path = os.path.abspath(path)
-        ofrak_module_name = os.path.basename(ofrak_file_path)
-        if ofrak_module_name.endswith(".py"):
-            ofrak_module_name = ofrak_module_name[:-3]
+        ofrak_file_dir = os.path.dirname(ofrak_file_path)
+        ofrak_file_name = os.path.basename(ofrak_file_path)
+        if os.path.isdir(ofrak_file_path) or not ofrak_file_name.endswith(".py"):
+            raise ImportError(f"Cannot import {path} as it does not appear to be a Python file!")
+        ofrak_file_name = ofrak_file_name[:-3]
 
-        spec = importlib.util.spec_from_file_location(ofrak_module_name, ofrak_file_path)
-        if spec is None or spec.loader is None:
-            raise ImportError(f"`{path}` exists but does not appear to be a valid Python file!")
-        ofrak_pkg = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(ofrak_pkg)
-        return ofrak_pkg
+        sys.path.append(ofrak_file_dir)
+        pkg = importlib.import_module(ofrak_file_name)
+        return pkg
 
     @abstractmethod
     async def ofrak_func(self, ofrak_context: OFRAKContext, args: Namespace):

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -188,7 +188,7 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
             ofrak_module_name = ofrak_module_name[:-3]
 
         spec = importlib.util.spec_from_file_location(ofrak_module_name, ofrak_file_path)
-        if spec is None:
+        if spec is None or spec.loader is None:
             raise ImportError(f"`{path}` exists but does not appear to be a valid Python file!")
         ofrak_pkg = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(ofrak_pkg)


### PR DESCRIPTION
…ting OFRAK from cli

**One sentence summary of this PR (This should go in the CHANGELOG!)**
* Add option to the CLI to import and discover additional OFRAK Python packages when starting OFRAK.

**Link to Related Issue(s)**
This is similar to the existing `--backend` option which lets users choose one of a static set of backends, but that option didn't allow users to easily extend OFRAK and load their extensions in the CLI.

**Please describe the changes in your request.**
* Add `-i`/`--import` option to dynamically import and discover additional Python modules
* These don't have to be installed modules; they can be a local file (e.g. `-i ./my_extension.py`), detected with the presence of the OS's path separator (e.g. "/" for Mac or Linux) or the ".py" file extension at the end. Importing these requires adding their directory to the system path.
* Limit the values passed to the "--backend" argument to only the valid disassemblers
* Change how handing the "--backend" argument is handled to use the same mechanism as `-i`/`--import`

**Anyone you think should look at this, specifically?**
@rbs-jacob 
Unfortunately doing these dynamic imports by package name adds a few seconds to the startup time.
