### PR TITLE
Draft PR contributor guide link language

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
+
 **One sentence summary of this PR (This should go in the CHANGELOG!)**
 
 **Link to Related Issue(s)**


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add language to the PR template about the OFRAK contributor guide.

Happy to change the language to whatever people think is best, but having a link to the contributor guide front-and-center would be helpful.

**Anyone you think should look at this, specifically?**
@whyitfor 