### PR TITLE
Update CPIO unpacker to use 7z utility instead of cpio utility issue …

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add `-i`/`--import` option to the CLI to import and discover additional OFRAK Python packages when starting OFRAK. [#269](https://github.com/redballoonsecurity/ofrak/pull/269)
 
 ### Changed
+- Changed the `CpioUnpacker` to use `7zz` instead of the `cpio` utility due to `cpio` failing when extracting absolute paths. [#276](https://github.com/redballoonsecurity/ofrak/pull/276)
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))
 - Choose Analyzer components which output the entirety of a view, rather than piece by piece, which would choose the wrong Analyzer sometimes. [#264](https://github.com/redballoonsecurity/ofrak/pull/264)
 - Generate LinkableBinary stubs as strong symbols, so linker use them to override weak symbols in patch

--- a/ofrak_core/ofrak/core/cpio.py
+++ b/ofrak_core/ofrak/core/cpio.py
@@ -104,6 +104,7 @@ class CpioUnpacker(Unpacker[None]):
                 *cmd,
             )
             await proc.wait()
+            # Raise when a specific or non-fatal error occurs
             if proc.returncode and proc.returncode != 2:
                 raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
 

--- a/ofrak_core/ofrak/core/cpio.py
+++ b/ofrak_core/ofrak/core/cpio.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import logging
 import tempfile
 from dataclasses import dataclass
@@ -100,7 +101,7 @@ class CpioUnpacker(Unpacker[None]):
 
             # use 7z utility to unpack cpio temp file to temp_flush_dir
             cmd = [
-                "7z",
+                "7zz",
                 "x",
                 f"-o{temp_flush_dir}",
                 temp_file_path,
@@ -112,7 +113,7 @@ class CpioUnpacker(Unpacker[None]):
 
             await proc.communicate()
             await proc.wait()
-            if proc.returncode:
+            if proc.returncode and proc.returncode != 2:
                 raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
 
             # before initializing cpio resource, remove the temp cpio file

--- a/ofrak_core/ofrak/core/cpio.py
+++ b/ofrak_core/ofrak/core/cpio.py
@@ -105,6 +105,7 @@ class CpioUnpacker(Unpacker[None]):
             )
             await proc.wait()
             # Raise when a specific or non-fatal error occurs
+            # https://sourceforge.net/p/sevenzip/discussion/45797/thread/c374fd35/
             if proc.returncode and proc.returncode != 2:
                 raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
 

--- a/ofrak_core/ofrak/core/cpio.py
+++ b/ofrak_core/ofrak/core/cpio.py
@@ -15,7 +15,7 @@ from ofrak.model.component_model import ComponentExternalTool
 from ofrak.resource import Resource
 from ofrak_type.range import Range
 
-from ofrak_core.ofrak.core.seven_zip import SEVEN_ZIP
+from ofrak.core.seven_zip import SEVEN_ZIP
 
 LOGGER = logging.getLogger(__name__)
 

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -352,13 +352,22 @@ class FilesystemRoot(ResourceView):
                         ),
                     )
                 elif os.path.isfile(absolute_path):
-                    with open(absolute_path, "rb") as fh:
-                        await self.add_file(
-                            relative_path,
-                            fh.read(),
-                            file_attributes_stat,
-                            file_attributes_xattr,
-                        )
+                    try:
+                        with open(absolute_path, "rb") as fh:
+                            file_data = fh.read()
+
+                    except Exception as e:
+                        os.chmod(absolute_path, stat.S_IRUSR)
+                        with open(absolute_path, "rb") as fh:
+                            file_data = fh.read()
+
+                    await self.add_file(
+                        relative_path,
+                        file_data,
+                        file_attributes_stat,
+                        file_attributes_xattr,
+                    )
+
                 elif stat.S_ISFIFO(mode):
                     await self.add_special_file_entry(
                         relative_path,

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -355,8 +355,7 @@ class FilesystemRoot(ResourceView):
                     try:
                         with open(absolute_path, "rb") as fh:
                             file_data = fh.read()
-
-                    except Exception as e:
+                    except PermissionError as e:
                         os.chmod(absolute_path, stat.S_IRUSR)
                         with open(absolute_path, "rb") as fh:
                             file_data = fh.read()

--- a/ofrak_core/test_ofrak/components/assets/filesystem.cpio
+++ b/ofrak_core/test_ofrak/components/assets/filesystem.cpio
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:294c61f34c23d3d8411f84319ee2b0feb955d537af6f2781d86fd6868154de5d
+size 11982848

--- a/ofrak_core/test_ofrak/components/test_cpio_component.py
+++ b/ofrak_core/test_ofrak/components/test_cpio_component.py
@@ -2,16 +2,21 @@ import os
 import subprocess
 import tempfile
 
+
 from ofrak import OFRAKContext
 from ofrak.resource import Resource
+from ofrak.core import FilesystemRoot
 from ofrak.core.cpio import CpioFilesystem
 from ofrak.core.strings import StringPatchingConfig, StringPatchingModifier
-from pytest_ofrak.patterns.unpack_modify_pack import UnpackModifyPackPattern
+from pytest_ofrak.patterns.unpack_modify_pack import UnpackModifyPackPattern, UnpackPackPattern
+import test_ofrak.components
 
 INITIAL_DATA = b"hello world"
 EXPECTED_DATA = b"hello ofrak"
 TARGET_CPIO_FILE = "test.cpio"
 CPIO_ENTRY_NAME = "hello_cpio_file"
+
+CPIO_FILESYSTEM = os.path.join(test_ofrak.components.ASSETS_DIR, "filesystem.cpio")
 
 
 class TestCpioUnpackModifyPack(UnpackModifyPackPattern):
@@ -53,3 +58,32 @@ class TestCpioUnpackModifyPack(UnpackModifyPackPattern):
                 with open(os.path.join(temp_flush_dir, CPIO_ENTRY_NAME), "rb") as f:
                     patched_data = f.read()
                 assert patched_data == EXPECTED_DATA
+
+
+class TestCpioWithAbsolutePathsUnpackPack(UnpackPackPattern):
+    async def create_root_resource(self, ofrak_context: OFRAKContext) -> Resource:
+        resource = await ofrak_context.create_root_resource_from_file(CPIO_FILESYSTEM)
+        return resource
+
+    async def unpack(self, cpio_resource: Resource) -> None:
+        """
+        Tests that absolute path '/dev/console' exists after unpacking to ensure that files in
+        filesystems with absolute paths unpack successfully without overwriting system files.
+        """
+        await cpio_resource.unpack()
+        filesystem_view = await cpio_resource.view_as(FilesystemRoot)
+        dev_console = await filesystem_view.get_entry("dev/console")
+        assert dev_console is not None
+
+    async def repack(self, cpio_resource: Resource) -> None:
+        await cpio_resource.pack_recursively()
+
+    async def verify(self, repacked_cpio_resource: Resource) -> None:
+        """
+        Tests that absolute path '/dev/console' exists after repacking to ensure that the cpiotool
+        can repack files that it cannot unpack.
+        """
+        await repacked_cpio_resource.unpack()
+        filesystem_view = await repacked_cpio_resource.view_as(FilesystemRoot)
+        dev_console = await filesystem_view.get_entry("dev/console")
+        assert dev_console is not None

--- a/ofrak_core/test_ofrak/components/test_filesystem_component.py
+++ b/ofrak_core/test_ofrak/components/test_filesystem_component.py
@@ -14,9 +14,7 @@ from ofrak.core.filesystem import (
     Folder,
 )
 from ofrak.resource import Resource
-from ofrak.service.resource_service_i import ResourceFilter, ResourceAttributeValueFilter
 from pytest_ofrak.patterns.pack_unpack_filesystem import FilesystemPackUnpackVerifyPattern
-import test_ofrak.components
 
 CHILD_TEXT = "Hello World\n"
 SUBCHILD_TEXT = "Goodbye World\n"
@@ -28,8 +26,6 @@ SUBCHILD_FOLDER = "test_subfolder"
 
 FIFO_PIPE_NAME = "fifo"
 DEVICE_NAME = "device"
-
-CPIO_FILESYSTEM = os.path.join(test_ofrak.components.ASSETS_DIR, "filesystem.cpio")
 
 
 class FilesystemRootDirectory(tempfile.TemporaryDirectory):
@@ -73,12 +69,6 @@ async def filesystem_root(ofrak_context: OFRAKContext) -> Resource:
         filesystem_root = await resource.view_as(FilesystemRoot)
         await filesystem_root.initialize_from_disk(temp_dir)
         yield filesystem_root
-
-
-@pytest.fixture
-async def cpio_filesystem_root(ofrak_context: OFRAKContext) -> Resource:
-    resource = await ofrak_context.create_root_resource_from_file(CPIO_FILESYSTEM)
-    return resource
 
 
 class TestFilesystemRoot:
@@ -407,25 +397,3 @@ def diff_directories(dir_1, dir_2, extra_diff_flags):
             second_type = " ".join(second.split(" ")[4:])
 
             assert first_type == second_type
-
-
-class TestCPIOFilesystem:
-    async def test_unpack(self, cpio_filesystem_root):
-        await cpio_filesystem_root.unpack()
-
-    async def test_absolute_paths(self, cpio_filesystem_root):
-        await cpio_filesystem_root.unpack()
-        # Check that absolute path '/dev/console' exists after unpacking to
-        # ensure that files in filesystems with absolute paths unpack
-        # successfully without overwriting system files
-        children = list(await cpio_filesystem_root.get_children_as_view(FilesystemEntry))
-        children_names = [child.get_name() for child in children]
-        assert "dev" in children_names
-        dev = await cpio_filesystem_root.get_only_child(
-            r_filter=ResourceFilter(
-                attribute_filters=(ResourceAttributeValueFilter(FilesystemEntry.Name, "dev"),)
-            )
-        )
-        grandchildren = list(await dev.get_children_as_view(FilesystemEntry))
-        grandkid_names = [grandkid.get_name() for grandkid in grandchildren]
-        assert "console" in grandkid_names

--- a/ofrak_core/test_ofrak/components/test_filesystem_component.py
+++ b/ofrak_core/test_ofrak/components/test_filesystem_component.py
@@ -415,7 +415,9 @@ class TestCPIOFilesystem:
 
     async def test_absolute_paths(self, cpio_filesystem_root):
         await cpio_filesystem_root.unpack()
-        # Check that absolute path '/dev/console' exists after unpacking
+        # Check that absolute path '/dev/console' exists after unpacking to
+        # ensure that files in filesystems with absolute paths unpack
+        # successfully without overwriting system files
         children = list(await cpio_filesystem_root.get_children_as_view(FilesystemEntry))
         children_names = [child.get_name() for child in children]
         assert "dev" in children_names


### PR DESCRIPTION
…#275 in public repo

- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Reference to issue #275 in master repository.



This change modifies `CpioUnpacker` to instead use the `7z` utility (which is a utility used by other OFRAK components) to extract the CPIO filesystem. 

**Link to Related Issue(s)**

https://github.com/redballoonsecurity/ofrak/issues/275

**Please describe the changes in your request.**

CPIO unpacker fails on native Linux due to how OFRAK handles process error codes in the `ofrak_core/ofrak/core/cpio.py`

Specifically, during unpacking, when `cpio` utility tries to extract files with absolute paths, the OS will (correctly) raise an error for that file, which is reflected in the return code. 

One potential fix was to add the `--no-absolute-flags` to the `cpio` command invoked by the unpacker - this however means you will lose certain files when you go to repack. 

Instead, by using `7z`, we can unpack CPIO filesystems without a) putting the OS in a position where it will try to overwrite system files, b) work cleanly with root, and c) handle subprocess return codes more cleanly.

**Anyone you think should look at this, specifically?**
