### PR TITLE
Add flush_to_disk() call in script when user downloads resource in GUI

### DIFF
--- a/frontend/src/ResourceTreeToolbar.svelte
+++ b/frontend/src/ResourceTreeToolbar.svelte
@@ -129,6 +129,7 @@
             a.click();
 
             URL.revokeObjectURL(blobUrl);
+            await $selectedResource.flush_to_disk(a.download);
           }
         },
       },

--- a/frontend/src/ofrak/remote_resource.js
+++ b/frontend/src/ofrak/remote_resource.js
@@ -486,6 +486,21 @@ export class RemoteResource extends Resource {
       script.set(await r.json());
     });
   }
+
+  async flush_to_disk(output_file_name) {
+    await fetch(`${this.uri}/flush_to_disk`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(output_file_name),
+    }).then(async (r) => {
+      if (!r.ok) {
+        throw Error(JSON.stringify(await r.json(), undefined, 2));
+      }
+      await this.update_script();
+    });
+  }
 }
 
 export function remote_models_to_resources(remote_models, resources) {

--- a/frontend/src/ofrak/resource.js
+++ b/frontend/src/ofrak/resource.js
@@ -386,6 +386,10 @@ export class Resource {
     throw new NotImplementedError("update_script");
   }
 
+  async flush_to_disk() {
+    throw new NotImplementedError("flush_to_disk");
+  }
+
   /***
    * Return the string representation of a comment, which includes its range as prefix if it
    * has one.

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -657,6 +657,7 @@ class AiohttpOFRAKServer:
     async def flush_to_disk(self, request: Request) -> Response:
         resource = await self._get_resource_for_request(request)
         output_file_name = self._serializer.from_pjson(await request.json(), str)
+        # Use FilesystemEntry name as filename if available, otherwise generate random filename
         if not output_file_name:
             output_file_name = str(uuid.uuid4())
         script_str = (

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -664,7 +664,7 @@ class AiohttpOFRAKServer:
         await {resource}"""
             f""".flush_to_disk("{output_file_name}")"""
         )
-        await self.script_builder.add_action(resource, script_str, ActionType.PACK)
+        await self.script_builder.add_action(resource, script_str, ActionType.UNDEF)
         await self.script_builder.commit_to_script(resource)
         return json_response(self._serialize_resource(resource))
 

--- a/ofrak_core/test_ofrak/unit/test_ofrak_server.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_server.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+import os
 import pytest
 import sys
 
@@ -19,6 +20,16 @@ from test_ofrak.components.hello_world_elf import hello_elf
 @pytest.fixture(scope="session")
 def hello_world_elf() -> bytes:
     return hello_elf()
+
+
+@pytest.fixture(scope="session")
+def firmware_zip() -> bytes:
+    assets_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../components/assets/binwalk_assets")
+    )
+    asset_path = os.path.join(assets_dir, "firmware.zip")
+    with open(asset_path, "rb") as f:
+        return f.read()
 
 
 # Create test server that will be spun up for each test
@@ -638,6 +649,98 @@ async def test_clear_action_queue(ofrak_client: TestClient, hello_world_elf):
         "    )",
         "",
         "    await root_resource.unpack()",
+        "",
+        "",
+        'if __name__ == "__main__":',
+        "    ofrak = OFRAK()",
+        "    if False:",
+        "        import ofrak_angr",
+        "        import ofrak_capstone",
+        "",
+        "        ofrak.discover(ofrak_capstone)",
+        "        ofrak.discover(ofrak_angr)",
+        "",
+        "    if False:",
+        "        import ofrak_binary_ninja",
+        "        import ofrak_capstone",
+        "",
+        "        ofrak.discover(ofrak_capstone)",
+        "        ofrak.discover(ofrak_binary_ninja)",
+        "",
+        "    if False:",
+        "        import ofrak_ghidra",
+        "",
+        "        ofrak.discover(ofrak_ghidra)",
+        "",
+        "    ofrak.run(main)",
+        "",
+    ]
+
+
+i = 0
+
+
+async def test_flush_to_disk(ofrak_client: TestClient, firmware_zip):
+    create_resp = await ofrak_client.post(
+        "/create_root_resource", params={"name": "firmware_zip"}, data=firmware_zip
+    )
+    root = await create_resp.json()
+    root_id = root["id"]
+
+    await ofrak_client.post(f"/{root_id}/unpack")
+    child_resp = await ofrak_client.post(f"/batch/get_children", json=[root_id])
+    child_body = await child_resp.json()
+    only_child_id = child_body[root_id][0]["id"]
+    await ofrak_client.post(f"/{only_child_id}/unpack")
+    grandchildren_resp = await ofrak_client.post(f"/batch/get_children", json=[only_child_id])
+    grandchildren_body = await grandchildren_resp.json()
+    eldest_grandchild_id = grandchildren_body[only_child_id][0]["id"]
+    await ofrak_client.post(
+        f"/{eldest_grandchild_id}/flush_to_disk", json="DIR655B1_FW203NAB02.bin"
+    )
+
+    resp = await ofrak_client.get(
+        f"/{root_id}/get_script",
+    )
+    resp_body = await resp.json()
+    assert resp_body == [
+        "from ofrak import *",
+        "from ofrak.core import *",
+        "",
+        "",
+        "async def main(ofrak_context: OFRAKContext):",
+        "",
+        '    root_resource = await ofrak_context.create_root_resource_from_file("firmware_zip")',
+        "",
+        "    await root_resource.unpack()",
+        "",
+        "    folder_dir655_revB_FW_203NA = await root_resource.get_only_child(",
+        "        r_filter=ResourceFilter(",
+        "            tags={Folder},",
+        "            attribute_filters=[",
+        "                ResourceAttributeValueFilter(",
+        "                    attribute=AttributesType[FilesystemEntry].Name,",
+        '                    value="dir655_revB_FW_203NA",',
+        "                )",
+        "            ],",
+        "        )",
+        "    )",
+        "",
+        "    await folder_dir655_revB_FW_203NA.unpack()",
+        "",
+        "    file_DIR655B1_FW203NAB02_bin = await folder_dir655_revB_FW_203NA.get_only_child(",
+        "        r_filter=ResourceFilter(",
+        "            tags={File},",
+        "            attribute_filters=[",
+        "                ResourceAttributeValueFilter(",
+        "                    attribute=AttributesType[FilesystemEntry].Name,",
+        '                    value="DIR655B1_FW203NAB02.bin",',
+        "                )",
+        "            ],",
+        "        )",
+        "    )",
+        "",
+        '    await file_DIR655B1_FW203NAB02_bin.flush_to_disk("DIR655B1_FW203NAB02.bin")',
         "",
         "",
         'if __name__ == "__main__":',

--- a/ofrak_core/test_ofrak/unit/test_ofrak_server.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_server.py
@@ -677,9 +677,6 @@ async def test_clear_action_queue(ofrak_client: TestClient, hello_world_elf):
     ]
 
 
-i = 0
-
-
 async def test_flush_to_disk(ofrak_client: TestClient, firmware_zip):
     create_resp = await ofrak_client.post(
         "/create_root_resource", params={"name": "firmware_zip"}, data=firmware_zip


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add call to flush a resource to disk in the script whenever a user downloads a resource from the GUI.

**Link to Related Issue(s)**
#274 

**Please describe the changes in your request.**
Add a server end point that adds an action to flush the currently selected resource to disk in the script. 
Call the endpoint when the user clicks the Download button in the resource tree toolbar.

**Anyone you think should look at this, specifically?**
@rbs-jacob 