### PR TITLE
Enable running ofrak_ghidra with local Ghidra installation with steps

### DIFF
--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/config/__main__.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/config/__main__.py
@@ -34,7 +34,9 @@ import_parser = command_parser.add_parser(
     "import",
     description="Loads a complete OFRAK Ghidra config from a path to a yaml file and saves it as the current Ghidra config.",
 )
-import_parser.add_argument("config-path", type=str, help="Path to config file to import")
+import_parser.add_argument(
+    "config_path", type=str, help="Path to config file to import", metavar="config-path"
+)
 import_parser.set_defaults(func=_import_config)
 restore_parser = command_parser.add_parser(
     "restore", description="Restore the default OFRAK Ghidra settings."

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
@@ -11,7 +11,7 @@ from ofrak_ghidra.constants import (
 
 
 def _run_ghidra_server(args):
-    if sys.platform == "linux":
+    if sys.platform == "linux" or sys.platform == "darwin":
         subprocess.call(["chmod", "+x", GHIDRA_START_SERVER_SCRIPT])
         subprocess.call([GHIDRA_START_SERVER_SCRIPT, GHIDRA_PATH, CORE_OFRAK_GHIDRA_SCRIPTS])
     else:

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
@@ -19,7 +19,7 @@ def _run_ghidra_server(args):
 
 
 def _stop_ghidra_server(args):
-    if sys.platform == "linux":
+    if sys.platform == "linux" or sys.platform == "darwin":
         subprocess.call([os.path.join(GHIDRA_PATH, "server", "ghidraSvr"), "stop"])
     else:
         raise NotImplementedError(f"Native OFRAK Ghidra server not supported for {sys.platform}!")

--- a/docs/user-guide/disassembler-backends/ghidra.md
+++ b/docs/user-guide/disassembler-backends/ghidra.md
@@ -2,30 +2,38 @@
 
 ## Install
 
-### Docker
-If building an OFRAK Docker image, Ghidra will be automatically installed if the `disassemblers/ofrak_ghidra` package is included in the Docker build's config file.
-For example, `ofrak-ghidra.yml`:
+=== "Docker"
 
-```yaml
-registry: "redballoonsecurity/ofrak"
-base_image_name: "ghidra-base"
-image_name: "ghidra"
-packages_paths:
-  [
-    "ofrak_type",
-    "ofrak_io",
-    "ofrak_patch_maker",
-    "ofrak_core",
-    "disassemblers/ofrak_ghidra",
-    "frontend",
-  ]
-entrypoint: |
-    nginx \
-      & python3 -m ofrak_ghidra.server start \
-      & python3 -m ofrak gui -H 0.0.0.0 -p 8877
+    If building an OFRAK Docker image, Ghidra will be automatically installed if the `disassemblers/ofrak_ghidra` package is included in the Docker build's config file.
+    For example, `ofrak-ghidra.yml`:
 
+    ```yaml
+    registry: "redballoonsecurity/ofrak"
+    base_image_name: "ghidra-base"
+    image_name: "ghidra"
+    packages_paths:
+      [
+        "ofrak_type",
+        "ofrak_io",
+        "ofrak_patch_maker",
+        "ofrak_core",
+        "disassemblers/ofrak_ghidra",
+        "frontend",
+      ]
+    entrypoint: |
+        nginx \
+          & python3 -m ofrak_ghidra.server start \
+          & python3 -m ofrak gui -H 0.0.0.0 -p 8877
+    ```
+=== "Native"
 
-```
+    If you are running OFRAK natively, you can use your existing Ghidra installation by following these steps:
+
+    1. Copy `ofrak/disassemblers/ofrak_ghidra/server.conf` to the `server/` directory of your local Ghidra installation.
+    1. Run `python -m ofrak_ghidra.config dump > ofrak_ghidra.yml` to create the default YAML file.
+    1. Modify `ofrak_ghidra.yml` according to your local Ghidra environment.
+    1. Run `python -m ofrak_ghidra.config import ofrak_ghidra.yml`.
+    1. Run `sudo python -m ofrak_ghidra.server start`.
 
 ## Start/Stop the Ghidra Server
 

--- a/docs/user-guide/disassembler-backends/ghidra.md
+++ b/docs/user-guide/disassembler-backends/ghidra.md
@@ -1,6 +1,6 @@
 # Ghidra Backend
 
-## Installation Type
+## Install
 
 === "Docker"
 
@@ -27,13 +27,14 @@
     ```
 === "Native"
 
-    If you are running OFRAK natively, you can use your existing Ghidra installation by following these steps:
+    If you would like to run OFRAK natively with a local Ghidra installation, follow these steps:
 
-    1. Copy `ofrak/disassemblers/ofrak_ghidra/server.conf` to the `server/` directory of your local Ghidra installation.
-    1. Run `python -m ofrak_ghidra.config dump > ofrak_ghidra.yml` to create the default YAML file.
-    1. Modify `ofrak_ghidra.yml` according to your local Ghidra environment.
-    1. Run `python -m ofrak_ghidra.config import ofrak_ghidra.yml`.
-    1. Run `sudo python -m ofrak_ghidra.server start`.
+    1. [Follow the directions to install Ghidra](https://github.com/NationalSecurityAgency/ghidra#install), or use your existing Ghidra installation
+    1. Copy `ofrak/disassemblers/ofrak_ghidra/server.conf` to the `server/` directory of your local Ghidra installation
+    1. Run `python -m ofrak_ghidra.config dump > ofrak_ghidra.yml` to create the default YAML file
+    1. Modify `ofrak_ghidra.yml` according to your local Ghidra environment
+    1. Run `python -m ofrak_ghidra.config import ofrak_ghidra.yml`
+    1. Run `sudo python -m ofrak_ghidra.server start`
 
 ## Start/Stop the Ghidra Server
 

--- a/docs/user-guide/disassembler-backends/ghidra.md
+++ b/docs/user-guide/disassembler-backends/ghidra.md
@@ -1,6 +1,6 @@
 # Ghidra Backend
 
-## Install
+## Installation Type
 
 === "Docker"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.tabbed:
       alternate_style: true
-  - admonition
 
 nav:
   - Home: "index.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,8 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.superfences
   - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
   - admonition
 
 nav:


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix for running `ofrak_ghidra.config`, enable `ofrak_ghidra.server` on Mac, and add steps to docs on how to run `ofrak_ghidra` with a local Ghidra install.

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
`metavar` is necessary for storing positional command-line arguments in differently named variables (underscore vs dash). Ghidra is runnable on Mac as well as Linux. Initial pass at directions on how to run `ofrak_ghidra` with local Ghidra.

**Anyone you think should look at this, specifically?**
@whyitfor 
