### PR TITLE
Normalize GUI script strings before testing

### DIFF
--- a/ofrak_core/test_ofrak/unit/test_ofrak_server.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_server.py
@@ -64,7 +64,7 @@ def dicts_are_similar(d1, d2, attributes_to_skip=None):
     return True
 
 
-def normalize(list_of_strs: List[str]) -> str:
+def join_and_normalize(list_of_strs: List[str]) -> str:
     in_str = "\n".join(list_of_strs)
     return re.sub(r"RuntimeError\(\s*.*\s*\)", "RuntimeError(err)", in_str, flags=re.M)
 
@@ -475,8 +475,8 @@ async def test_update_script(ofrak_client: TestClient, hello_world_elf):
         "",
     ]
 
-    expected_str = normalize(expected_list)
-    actual_str = normalize(resp_body)
+    expected_str = join_and_normalize(expected_list)
+    actual_str = join_and_normalize(resp_body)
     assert actual_str == expected_str
 
 
@@ -606,8 +606,8 @@ async def test_selectable_attr_err(ofrak_client: TestClient, hello_world_elf):
         "",
     ]
 
-    expected_str = normalize(expected_list)
-    actual_str = normalize(resp_body)
+    expected_str = join_and_normalize(expected_list)
+    actual_str = join_and_normalize(resp_body)
     assert actual_str == expected_str
 
 
@@ -679,6 +679,6 @@ async def test_clear_action_queue(ofrak_client: TestClient, hello_world_elf):
         "",
     ]
 
-    expected_str = normalize(expected_list)
-    actual_str = normalize(resp_body)
+    expected_str = join_and_normalize(expected_list)
+    actual_str = join_and_normalize(resp_body)
     assert actual_str == expected_str

--- a/ofrak_core/test_ofrak/unit/test_ofrak_server.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_server.py
@@ -718,7 +718,7 @@ async def test_add_flush_to_disk_to_script(ofrak_client: TestClient, firmware_zi
         f"/{root_id}/get_script",
     )
     resp_body = await resp.json()
-    assert resp_body == [
+    expected_list = [
         "from ofrak import *",
         "from ofrak.core import *",
         "",
@@ -782,3 +782,7 @@ async def test_add_flush_to_disk_to_script(ofrak_client: TestClient, firmware_zi
         "    ofrak.run(main)",
         "",
     ]
+
+    expected_str = join_and_normalize(expected_list)
+    actual_str = join_and_normalize(resp_body)
+    assert actual_str == expected_str


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Compare scripts as strings rather than lists, and remove parts of the strings which may change frequently or be inconsistent across runs (error messages, including the resource IDs within those messages).

**Link to Related Issue(s)**
#279 

**Please describe the changes in your request.**
Add a function that joins scripts as lists into one string and then replace the error messages with a constant value.

**Anyone you think should look at this, specifically?**
@rbs-jacob @whyitfor 