### PR TITLE
Fix UF2 file identification so that it works

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Fix bug where jumping to a multiple of `0x10` in the GUI went to the previous line ([#254](https://github.com/redballoonsecurity/ofrak/pull/254))
 - Fix installing on Windows, as well as small GUI style fixes for Windows ([#261](https://github.com/redballoonsecurity/ofrak/pull/261))
+- Fixed `Uf2File` identifier so that it correctly tags UF2 files with `Uf2File`
 
 ## [2.2.1](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.0...ofrak-v2.2.1) - 2023-03-08
 ### Added

--- a/ofrak_core/ofrak/core/uf2.py
+++ b/ofrak_core/ofrak/core/uf2.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ofrak.core import MagicDescriptionIdentifier
+from ofrak import Identifier
 from ofrak.core.code_region import CodeRegion
 
 from ofrak.resource import Resource
@@ -244,4 +244,14 @@ class Uf2FilePacker(Packer[None]):
         resource.queue_patch(Range(0, await resource.get_data_length()), repacked_data)
 
 
-MagicDescriptionIdentifier.register(Uf2File, lambda s: s.startswith("UF2"))
+class Uf2FileIdentifier(Identifier[None]):
+    targets = (GenericBinary,)
+
+    async def identify(self, resource: Resource, config=None) -> None:
+        if await resource.get_data_length() < 8:
+            pass
+        else:
+            data = await resource.get_data(Range(0, 8))
+            magic_one, magic_two = struct.unpack("<II", data)
+            if magic_one == UF2_MAGIC_START_ONE and magic_two == UF2_MAGIC_START_TWO:
+                resource.add_tag(Uf2File)

--- a/ofrak_core/ofrak/core/uf2.py
+++ b/ofrak_core/ofrak/core/uf2.py
@@ -3,13 +3,14 @@ import struct
 from enum import IntEnum
 from dataclasses import dataclass
 from typing import List, Tuple
+
+from ofrak.core import MagicDescriptionIdentifier
 from ofrak.core.code_region import CodeRegion
 
 from ofrak.resource import Resource
 from ofrak.model.resource_model import ResourceAttributes
 from ofrak.component.unpacker import Unpacker
 from ofrak.component.packer import Packer
-from ofrak.component.identifier import Identifier
 from ofrak.core.binary import GenericBinary
 from ofrak_type.range import Range
 from ofrak.service.resource_service_i import ResourceFilter
@@ -243,11 +244,4 @@ class Uf2FilePacker(Packer[None]):
         resource.queue_patch(Range(0, await resource.get_data_length()), repacked_data)
 
 
-class Uf2FileIdentifier(Identifier):
-    id = b"Uf2FileIdentifier"
-    targets = (GenericBinary,)
-
-    async def identify(self, resource: Resource, config=None):
-        resource_data = await resource.get_data(Range(0, 8))
-        if resource_data[:4] == UF2_MAGIC_START_ONE and resource_data[4:8] == UF2_MAGIC_START_TWO:
-            resource.add_tag(Uf2File)
+MagicDescriptionIdentifier.register(Uf2File, lambda s: s.startswith("UF2"))

--- a/ofrak_core/test_ofrak/components/test_uf2_component.py
+++ b/ofrak_core/test_ofrak/components/test_uf2_component.py
@@ -18,11 +18,17 @@ FILENAME = "rp2-pico-20220618-v1.19.1.uf2"
 EXPECTED_DATA = b"Raspberry Pi Pico with RP1337"
 
 
+async def test_uf2_identify(ofrak_context: OFRAKContext) -> None:
+    asset_path = Path(test_ofrak.components.ASSETS_DIR, FILENAME)
+    root_resource = await ofrak_context.create_root_resource_from_file(str(asset_path))
+    await root_resource.identify()
+    assert root_resource.has_tag(Uf2File), "Expected resource to have tag Uf2File"
+
+
 class TestUf2UnpackModifyPack(UnpackModifyPackPattern):
     async def create_root_resource(self, ofrak_context: OFRAKContext) -> Resource:
         asset_path = Path(test_ofrak.components.ASSETS_DIR, FILENAME)
         root_resource = await ofrak_context.create_root_resource_from_file(str(asset_path))
-        root_resource.add_tag(Uf2File)
         await root_resource.save()
         return root_resource
 
@@ -53,4 +59,3 @@ class TestUf2UnpackModifyPack(UnpackModifyPackPattern):
         resource_data = await repacked_uf2_resource.get_data()
         unpacked_data = resource_data[0x78EB5:0x78ED2]
         assert unpacked_data == EXPECTED_DATA
-        assert repacked_uf2_resource.has_tag(Uf2File)


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
UF2 file identification was not working. This PR fixes this, and updates the tests to specifically test that identifcation works.

**Please describe the changes in your request.**
- Add a Magic Mime identifier for UF2 files
- Deletes custom Uf2FileIdentifier which was not working
- Updates UF2 tests with a test to assert that identification works
- Update UF2 unpack test to remove adding Uf2File tag (this was making the test pass even though the identifier wasn't working)

**Anyone you think should look at this, specifically?**
@sjossi