### PR TITLE
add black to core ofrak requirements (required for script generation …

### DIFF
--- a/ofrak_core/requirements-test.txt
+++ b/ofrak_core/requirements-test.txt
@@ -1,5 +1,4 @@
 autoflake==1.4
-black==22.6.0
 pytest
 hypothesis~=6.39.3
 hypothesis-trio

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp~=3.8.1
 aiohttp-cors~=0.7.0
 beartype~=0.12.0
+black==22.6.0
 fdt==0.3.3
 importlib-metadata>=1.4
 intervaltree==3.1.0


### PR DESCRIPTION
…feature)

- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**
Black is now required in core OFRAK, not only for tests, but installing just core ofrak (i.e. `pip install -e .`) would not install the black requirement because it is only listed as a requirement of the tests extra.

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
