### PR TITLE
Remove CalledProcessError from `is_tool_installed`

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Generate LinkableBinary stubs as strong symbols, so linker use them to override weak symbols in patch
 - 
 ### Fixed
+- Fix bug where Component External Tool would raise an error when checking whether a tool was installed returned a non-zero exit value ([#289](https://github.com/redballoonsecurity/ofrak/pull/289))
 - Fix bug where jumping to a multiple of `0x10` in the GUI went to the previous line ([#254](https://github.com/redballoonsecurity/ofrak/pull/254))
 - Fix installing on Windows, as well as small GUI style fixes for Windows ([#261](https://github.com/redballoonsecurity/ofrak/pull/261))
 - Fixed `Uf2File` identifier so that it correctly tags UF2 files with `Uf2File`

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Generate LinkableBinary stubs as strong symbols, so linker use them to override weak symbols in patch
 - 
 ### Fixed
-- Fix bug where Component External Tool would raise an error when checking whether a tool was installed returned a non-zero exit value ([#289](https://github.com/redballoonsecurity/ofrak/pull/289))
+- Fix bug where `ComponentExternalTool` would raise an error when checking whether a tool was installed returned a non-zero exit value ([#289](https://github.com/redballoonsecurity/ofrak/pull/289))
 - Fix bug where jumping to a multiple of `0x10` in the GUI went to the previous line ([#254](https://github.com/redballoonsecurity/ofrak/pull/254))
 - Fix installing on Windows, as well as small GUI style fixes for Windows ([#261](https://github.com/redballoonsecurity/ofrak/pull/261))
 - Fixed `Uf2File` identifier so that it correctly tags UF2 files with `Uf2File`

--- a/ofrak_core/ofrak/core/apk.py
+++ b/ofrak_core/ofrak/core/apk.py
@@ -69,12 +69,10 @@ class _UberApkSignerTool(ComponentExternalTool):
                 stderr=asyncio.subprocess.DEVNULL,
             )
             returncode = await proc.wait()
-            if returncode:
-                raise CalledProcessError(returncode=returncode, cmd=cmd)
         except FileNotFoundError:
             return False
 
-        return True
+        return 0 == returncode
 
 
 UBER_APK_SIGNER = _UberApkSignerTool()

--- a/ofrak_core/ofrak/core/squashfs.py
+++ b/ofrak_core/ofrak/core/squashfs.py
@@ -35,8 +35,6 @@ class _UnsquashfsV45Tool(ComponentExternalTool):
                 stderr=asyncio.subprocess.DEVNULL,
             )
             stdout, stderr = await proc.communicate()
-            if proc.returncode:
-                raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
         except FileNotFoundError:
             return False
 

--- a/ofrak_core/ofrak/model/component_model.py
+++ b/ofrak_core/ofrak/model/component_model.py
@@ -1,7 +1,6 @@
 import asyncio
 from collections import defaultdict
 from dataclasses import dataclass, field
-from subprocess import CalledProcessError
 from typing import Dict, List, Optional, Set, Type, TypeVar
 
 from ofrak.model.data_model import DataPatch
@@ -66,12 +65,10 @@ class ComponentExternalTool:
             )
 
             returncode = await proc.wait()
-            if returncode:
-                raise CalledProcessError(returncode=returncode, cmd=cmd)
         except FileNotFoundError:
             return False
 
-        return True
+        return 0 == returncode
 
 
 CC = TypeVar("CC", bound=Optional[ComponentConfig])

--- a/ofrak_core/test_ofrak/unit/component/test_component_external_tool.py
+++ b/ofrak_core/test_ofrak/unit/component/test_component_external_tool.py
@@ -21,6 +21,11 @@ def mock_dependency(dependency_path):
     return ComponentExternalTool(dependency_path, "", "")
 
 
+@pytest.fixture()
+def bad_dependency():
+    return ComponentExternalTool("ls", "", "-1234")
+
+
 async def test_missing_external_tool_caught(
     ofrak_context: OFRAKContext, dependency_path, mock_dependency
 ):
@@ -102,3 +107,7 @@ async def test_tool_install_check(mock_dependency):
 
     echo_tool = ComponentExternalTool("echo", "", install_check_arg=".")
     assert await echo_tool.is_tool_installed()
+
+
+async def test_bad_tool_install_check(bad_dependency):
+    assert not await bad_dependency.is_tool_installed()

--- a/ofrak_core/test_ofrak/unit/component/test_component_external_tool.py
+++ b/ofrak_core/test_ofrak/unit/component/test_component_external_tool.py
@@ -23,6 +23,7 @@ def mock_dependency(dependency_path):
 
 @pytest.fixture()
 def bad_dependency():
+    # Use known bad flag that will return a non-zero exit code
     return ComponentExternalTool("ls", "", "-1234")
 
 


### PR DESCRIPTION
- [ x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix bug where Component External Tool would raise an error when checking whether a tool was installed returned a non-zero exit value 

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Remove checks against returncode in subprocess calls for `is_tool_installed` methods that would raise a `CalledProcessError`.
Add test case to check return value of `is_tool_installed` when attempting to check for tool with known bad flag that will return non-zero exit code.

**Anyone you think should look at this, specifically?**
@whyitfor 
