### PR TITLE
Revert "Update CPIO unpacker to use 7z utility instead of cpio utility issue …"

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add `-i`/`--import` option to the CLI to import and discover additional OFRAK Python packages when starting OFRAK. [#269](https://github.com/redballoonsecurity/ofrak/pull/269)
 
 ### Changed
-- Changed the `CpioUnpacker` to use `7zz` instead of the `cpio` utility due to `cpio` failing when extracting absolute paths. [#276](https://github.com/redballoonsecurity/ofrak/pull/276)
 - Remove need to create Resources to pass source code and headers to `PatchFromSourceModifier` and `FunctionReplaceModifier` ([#249](https://github.com/redballoonsecurity/ofrak/pull/249))
 - Choose Analyzer components which output the entirety of a view, rather than piece by piece, which would choose the wrong Analyzer sometimes. [#264](https://github.com/redballoonsecurity/ofrak/pull/264)
 - Generate LinkableBinary stubs as strong symbols, so linker use them to override weak symbols in patch

--- a/ofrak_core/ofrak/core/cpio.py
+++ b/ofrak_core/ofrak/core/cpio.py
@@ -15,8 +15,6 @@ from ofrak.model.component_model import ComponentExternalTool
 from ofrak.resource import Resource
 from ofrak_type.range import Range
 
-from ofrak.core.seven_zip import SEVEN_ZIP
-
 LOGGER = logging.getLogger(__name__)
 
 CPIO_TOOL = ComponentExternalTool(
@@ -84,32 +82,26 @@ class CpioUnpacker(Unpacker[None]):
 
     targets = (CpioFilesystem,)
     children = (File, Folder, SpecialFileType)
-    external_dependencies = (SEVEN_ZIP,)
+    external_dependencies = (CPIO_TOOL,)
 
     async def unpack(self, resource: Resource, config=None):
-        with tempfile.TemporaryDirectory() as temp_flush_dir, tempfile.NamedTemporaryFile(
-            suffix=".cpio"
-        ) as temp_cpio:
-            temp_cpio.write(await resource.get_data())
-            temp_cpio.flush()
-
-            # use 7z utility to unpack CPIO temp file to temp_flush_dir
+        cpio_v = await resource.view_as(CpioFilesystem)
+        resource_data = await cpio_v.resource.get_data()
+        with tempfile.TemporaryDirectory() as temp_flush_dir:
             cmd = [
-                "7zz",
-                "x",
-                f"-o{temp_flush_dir}",
-                temp_cpio.name,
+                "cpio",
+                "-id",
             ]
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=temp_flush_dir,
             )
-            await proc.wait()
-            # Raise when a specific or non-fatal error occurs
-            # https://sourceforge.net/p/sevenzip/discussion/45797/thread/c374fd35/
-            if proc.returncode and proc.returncode != 2:
+            await proc.communicate(input=resource_data)
+            if proc.returncode:
                 raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
-
-            cpio_v = await resource.view_as(CpioFilesystem)
             await cpio_v.initialize_from_disk(temp_flush_dir)
 
 

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -352,21 +352,13 @@ class FilesystemRoot(ResourceView):
                         ),
                     )
                 elif os.path.isfile(absolute_path):
-                    try:
-                        with open(absolute_path, "rb") as fh:
-                            file_data = fh.read()
-                    except (PermissionError, OSError) as e:
-                        os.chmod(absolute_path, stat.S_IRUSR)
-                        with open(absolute_path, "rb") as fh:
-                            file_data = fh.read()
-
-                    await self.add_file(
-                        relative_path,
-                        file_data,
-                        file_attributes_stat,
-                        file_attributes_xattr,
-                    )
-
+                    with open(absolute_path, "rb") as fh:
+                        await self.add_file(
+                            relative_path,
+                            fh.read(),
+                            file_attributes_stat,
+                            file_attributes_xattr,
+                        )
                 elif stat.S_ISFIFO(mode):
                     await self.add_special_file_entry(
                         relative_path,
@@ -663,14 +655,7 @@ class FilesystemRoot(ResourceView):
 
     @classmethod
     def _get_xattr_map(cls, path):
-        try:
-            xattr_dict = {}
-            for attr in xattr.listxattr(path, symlink=True):  # Don't follow links
-                xattr_dict[attr] = xattr.getxattr(path, attr)
-        except (PermissionError, OSError) as e:
-            os.chmod(path, stat.S_IRUSR)
-            xattr_dict = {}
-            for attr in xattr.listxattr(path, symlink=True):  # Don't follow links
-                xattr_dict[attr] = xattr.getxattr(path, attr)
-
+        xattr_dict = {}
+        for attr in xattr.listxattr(path, symlink=True):  # Don't follow links
+            xattr_dict[attr] = xattr.getxattr(path, attr)
         return xattr_dict

--- a/ofrak_core/test_ofrak/components/assets/filesystem.cpio
+++ b/ofrak_core/test_ofrak/components/assets/filesystem.cpio
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:294c61f34c23d3d8411f84319ee2b0feb955d537af6f2781d86fd6868154de5d
-size 11982848

--- a/ofrak_core/test_ofrak/components/test_cpio_component.py
+++ b/ofrak_core/test_ofrak/components/test_cpio_component.py
@@ -2,21 +2,16 @@ import os
 import subprocess
 import tempfile
 
-
 from ofrak import OFRAKContext
 from ofrak.resource import Resource
-from ofrak.core import FilesystemRoot
 from ofrak.core.cpio import CpioFilesystem
 from ofrak.core.strings import StringPatchingConfig, StringPatchingModifier
-from pytest_ofrak.patterns.unpack_modify_pack import UnpackModifyPackPattern, UnpackPackPattern
-import test_ofrak.components
+from pytest_ofrak.patterns.unpack_modify_pack import UnpackModifyPackPattern
 
 INITIAL_DATA = b"hello world"
 EXPECTED_DATA = b"hello ofrak"
 TARGET_CPIO_FILE = "test.cpio"
 CPIO_ENTRY_NAME = "hello_cpio_file"
-
-CPIO_FILESYSTEM = os.path.join(test_ofrak.components.ASSETS_DIR, "filesystem.cpio")
 
 
 class TestCpioUnpackModifyPack(UnpackModifyPackPattern):
@@ -58,32 +53,3 @@ class TestCpioUnpackModifyPack(UnpackModifyPackPattern):
                 with open(os.path.join(temp_flush_dir, CPIO_ENTRY_NAME), "rb") as f:
                     patched_data = f.read()
                 assert patched_data == EXPECTED_DATA
-
-
-class TestCpioWithAbsolutePathsUnpackPack(UnpackPackPattern):
-    async def create_root_resource(self, ofrak_context: OFRAKContext) -> Resource:
-        resource = await ofrak_context.create_root_resource_from_file(CPIO_FILESYSTEM)
-        return resource
-
-    async def unpack(self, cpio_resource: Resource) -> None:
-        """
-        Tests that absolute path '/dev/console' exists after unpacking to ensure that files in
-        filesystems with absolute paths unpack successfully without overwriting system files.
-        """
-        await cpio_resource.unpack()
-        filesystem_view = await cpio_resource.view_as(FilesystemRoot)
-        dev_console = await filesystem_view.get_entry("dev/console")
-        assert dev_console is not None
-
-    async def repack(self, cpio_resource: Resource) -> None:
-        await cpio_resource.pack_recursively()
-
-    async def verify(self, repacked_cpio_resource: Resource) -> None:
-        """
-        Tests that absolute path '/dev/console' exists after repacking to ensure that the cpiotool
-        can repack files that it cannot unpack.
-        """
-        await repacked_cpio_resource.unpack()
-        filesystem_view = await repacked_cpio_resource.view_as(FilesystemRoot)
-        dev_console = await filesystem_view.get_entry("dev/console")
-        assert dev_console is not None


### PR DESCRIPTION
Reverts redballoonsecurity/ofrak#276

Found a significant behavior divergence in the 7zz unpacker: Symbolic links are no longer unpacked.