### PR TITLE
Specify disassembler backend when starting GUI in container

### DIFF
--- a/ofrak-dev.yml
+++ b/ofrak-dev.yml
@@ -22,4 +22,4 @@ extra_build_args:
 entrypoint: |
     nginx \
       & python3 -m ofrak_ghidra.server start \
-      & python3 -m ofrak gui -H 0.0.0.0 -p 8877
+      & python3 -m ofrak gui -H 0.0.0.0 -p 8877 --backend ghidra

--- a/ofrak-ghidra.yml
+++ b/ofrak-ghidra.yml
@@ -13,4 +13,4 @@ packages_paths:
 entrypoint: |
     nginx \
       & python3 -m ofrak_ghidra.server start \
-      & python3 -m ofrak gui -H 0.0.0.0 -p 8877
+      & python3 -m ofrak gui -H 0.0.0.0 -p 8877 --backend ghidra

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -173,9 +173,9 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
             logging.warning("No disassembler backend specified, so no disassembly will be possible")
 
         for ofrak_pkg_name in ofrak_pkgs:
-            if os.path.exists(ofrak_pkg_name):
+            try:
                 ofrak_pkg = self._import_via_path(ofrak_pkg_name)
-            else:
+            except ImportError:
                 ofrak_pkg = importlib.import_module(ofrak_pkg_name)
             ofrak.discover(ofrak_pkg)
 

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -173,9 +173,9 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
             logging.warning("No disassembler backend specified, so no disassembly will be possible")
 
         for ofrak_pkg_name in ofrak_pkgs:
-            try:
+            if os.path.exists(ofrak_pkg_name) and os.path.isfile(os.path.abspath(ofrak_pkg_name)):
                 ofrak_pkg = self._import_via_path(ofrak_pkg_name)
-            except ImportError:
+            else:
                 ofrak_pkg = importlib.import_module(ofrak_pkg_name)
             ofrak.discover(ofrak_pkg)
 


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Specify disassembler backend for OFRAK GUI in yaml files and modify import logic.

**Link to Related Issue(s)**
#292 

**Please describe the changes in your request.**
Added flag to specify the `ghidra` backend when starting up the OFRAK GUI in the Docker container yaml files. Additionally, adjusted the import logic to fix an issue where name collisions were resulting in an exception being raised when a directory of the same name as the intended package existed in the working directory.

**Anyone you think should look at this, specifically?**
@whyitfor @EdwardLarson @rbs-jacob 