### PR TITLE
Fix freezes from undefined image data

### DIFF
--- a/frontend/src/ByteclassView.svelte
+++ b/frontend/src/ByteclassView.svelte
@@ -115,7 +115,7 @@
     context.msImageSmoothingEnabled = false;
   }
 
-  $: if (mounted && canvas !== undefined && canvas !== null) {
+  $: if (mounted && canvas !== undefined && canvas !== null && imageData) {
     const context = canvas.getContext("2d");
     context.putImageData(imageData, 0, 0);
 

--- a/frontend/src/EntropyView.svelte
+++ b/frontend/src/EntropyView.svelte
@@ -93,7 +93,7 @@
     }
   }
 
-  $: if (mounted && canvas !== undefined && canvas !== null) {
+  $: if (mounted && canvas !== undefined && canvas !== null && imageData) {
     const context = canvas.getContext("2d");
     context.putImageData(imageData, 0, 0);
 

--- a/frontend/src/MagnitudeView.svelte
+++ b/frontend/src/MagnitudeView.svelte
@@ -93,7 +93,7 @@
     }
   }
 
-  $: if (mounted && canvas !== undefined && canvas !== null) {
+  $: if (mounted && canvas !== undefined && canvas !== null && imageData) {
     const context = canvas.getContext("2d");
     context.putImageData(imageData, 0, 0);
 

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Fixed 
+- Fixed a bug where clicking "Unpack" or "Identify" (for example) too quickly after loading a large resource causes an error that freezes up the whole GUI ([#297](https://github.com/redballoonsecurity/ofrak/pull/297))
 
 ## [3.0.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.1...ofrak-v3.0.0)
 ### Added


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Sometimes clicking "Unpack" or "Identify" (for example) too quickly after loading a large resource causes an error that freezes up the whole GUI. This fixes that problem.

**Anyone you think should look at this, specifically?**

@EdwardLarson 