### PR TITLE
Remove linux-setup.sh step from BinaryNinja headless install

### DIFF
--- a/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh
+++ b/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh
@@ -14,4 +14,3 @@ python download_headless.py --serial $SERIAL
 unzip BinaryNinja-headless.zip
 rm download_headless.py BinaryNinja-headless.zip
 python binaryninja/scripts/install_api.py
-./binaryninja/scripts/linux-setup.sh


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Remove linux-setup.sh from BinaryNinja headless install steps.

**Please describe the changes in your request.**
The linux-setup.sh step was not working; it is not actually needed for a headless install of BinaryNinja in Docker.
It was therefore removed.

I've tested the change and validated the OFRAK BinaryNinja tests pass in the built Docker image.

**Anyone you think should look at this, specifically?**
@EdwardLarson 