### PR TITLE
Remove UnanalyzedElfSection, UnanalyzedElfSegment

### DIFF
--- a/ofrak_core/ofrak/core/elf/analyzer.py
+++ b/ofrak_core/ofrak/core/elf/analyzer.py
@@ -15,13 +15,11 @@ from ofrak.core.elf.model import (
     ElfSegment,
     ElfSectionStructure,
     ElfSection,
-    UnanalyzedElfSection,
     ElfSymbol,
     ElfSymbolStructure,
     ElfRelaEntry,
     ElfDynamicEntry,
     ElfVirtualAddress,
-    UnanalyzedElfSegment,
 )
 from ofrak.core.memory_region import MemoryRegion
 from ofrak.model.component_model import ComponentConfig
@@ -161,8 +159,9 @@ class ElfSegmentAnalyzer(Analyzer[None, ElfSegment]):
     outputs = (ElfSegment,)
 
     async def analyze(self, resource: Resource, config=None) -> ElfSegment:
-        unnamed_segment = await resource.view_as(UnanalyzedElfSegment)
-        segment_header = await unnamed_segment.get_header()
+
+        segment = await resource.view_as(ElfSegmentStructure)
+        segment_header = await segment.get_header()
         return ElfSegment(
             segment_index=segment_header.segment_index,
             virtual_address=segment_header.p_vaddr,
@@ -320,9 +319,9 @@ class ElfSectionNameAnalyzer(Analyzer[None, AttributesType[NamedProgramSection]]
     outputs = (AttributesType[NamedProgramSection],)
 
     async def analyze(self, resource: Resource, config=None) -> AttributesType[NamedProgramSection]:
-        unnamed_section = await resource.view_as(UnanalyzedElfSection)
-        section_header = await unnamed_section.get_header()
-        elf_r = await unnamed_section.get_elf()
+        section = await resource.view_as(ElfSectionStructure)
+        section_header = await section.get_header()
+        elf_r = await section.get_elf()
         string_section = await elf_r.get_section_name_string_section()
         try:
             string_section_data = await string_section.resource.get_data(
@@ -352,8 +351,8 @@ class ElfSectionMemoryRegionAnalyzer(Analyzer[None, MemoryRegion]):
     outputs = (MemoryRegion,)
 
     async def analyze(self, resource: Resource, config=None) -> MemoryRegion:
-        unnamed_section = await resource.view_as(UnanalyzedElfSection)
-        section_header = await unnamed_section.get_header()
+        section = await resource.view_as(ElfSectionStructure)
+        section_header = await section.get_header()
         return MemoryRegion(
             virtual_address=section_header.sh_addr,
             size=section_header.sh_size,

--- a/ofrak_core/ofrak/core/elf/unpacker.py
+++ b/ofrak_core/ofrak/core/elf/unpacker.py
@@ -210,7 +210,7 @@ class ElfDynamicSectionUnpacker(Unpacker[None]):
 
     async def unpack(self, resource: Resource, config=None):
         e_section = await resource.view_as(ElfDynamicSection)
-        elf_r = await e_section.get_parent()
+        elf_r = await e_section.get_elf()
         e_basic_header = await elf_r.get_basic_header()
         dyn_entry_size = 16 if e_basic_header.get_bitwidth() is BitWidth.BIT_64 else 8
         await make_children_helper(resource, ElfDynamicEntry, dyn_entry_size, None)
@@ -223,7 +223,7 @@ class ElfRelaUnpacker(Unpacker[None]):
 
     async def unpack(self, resource: Resource, config=None):
         e_section = await resource.view_as(ElfRelaSection)
-        elf_r = await e_section.get_parent()
+        elf_r = await e_section.get_elf()
         e_basic_header = await elf_r.get_basic_header()
         rela_size = 24 if e_basic_header.get_bitwidth() is BitWidth.BIT_64 else 12
         await make_children_helper(resource, ElfRelaEntry, rela_size, None)
@@ -236,7 +236,7 @@ class ElfSymbolUnpacker(Unpacker[None]):
 
     async def unpack(self, resource: Resource, config=None):
         e_section = await resource.view_as(ElfSymbolSection)
-        elf_r = await e_section.get_parent()
+        elf_r = await e_section.get_elf()
         e_basic_header = await elf_r.get_basic_header()
         symbol_size = 16 if e_basic_header.get_bitwidth() is BitWidth.BIT_32 else 24
         await make_children_helper(

--- a/ofrak_core/test_ofrak/components/test_elf_analyzers.py
+++ b/ofrak_core/test_ofrak/components/test_elf_analyzers.py
@@ -11,10 +11,6 @@ import pytest
 
 from ofrak import OFRAKContext
 from ofrak.core.architecture import ProgramAttributes
-from ofrak.model.viewable_tag_model import ViewableResourceTag, AttributesType
-from ofrak.resource import Resource
-from ofrak.resource_view import ResourceView
-from ofrak.service.resource_service_i import ResourceFilter
 from ofrak.core.elf.analyzer import (
     ElfRelaAnalyzer,
     ElfDynamicSectionAnalyzer,
@@ -27,7 +23,6 @@ from ofrak.core.elf.model import (
     ElfProgramHeader,
     ElfSectionHeader,
     ElfSymbol,
-    UnanalyzedElfSection,
     ElfSectionNameStringSection,
     ElfSection,
     ElfSectionType,
@@ -42,6 +37,10 @@ from ofrak.core.elf.model import (
     ElfDynamicSection,
     ElfPointerArraySection,
 )
+from ofrak.model.viewable_tag_model import ViewableResourceTag, AttributesType
+from ofrak.resource import Resource
+from ofrak.resource_view import ResourceView
+from ofrak.service.resource_service_i import ResourceFilter
 from ofrak_type.architecture import InstructionSet
 from ofrak_type.bit_width import BitWidth
 from ofrak_type.endianness import Endianness
@@ -540,7 +539,7 @@ async def test_elf_section_name_analyzer(ofrak_context: OFRAKContext):
         0,
         0,
     )
-    section_body = UnanalyzedElfSection(test_section_elf_index)
+    section_body = ElfSectionStructure(test_section_elf_index)
     elf_r = await _create_populated_elf(
         ofrak_context,
         ei_class=1,  # 32-bit

--- a/ofrak_tutorial/notebooks_with_outputs/2_ofrak_internals.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/2_ofrak_internals.ipynb
@@ -453,8 +453,7 @@
       "ElfVirtualAddress\n",
       "MemoryRegion\n",
       "NamedProgramSection\n",
-      "ProgramSection\n",
-      "UnanalyzedElfSection\n"
+      "ProgramSection\n"
      ]
     }
    ],
@@ -500,10 +499,10 @@
     {
      "data": {
       "text/plain": [
-       "[Resource(resource_id=565fc63a77494276bafea235ae00344e, tag=[Addressable,CodeRegion,UnanalyzedElfSection,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=565fc63a77494276bafea235ae00344e),\n",
-       " Resource(resource_id=d53f13b1d70c486397c25938311aeeab, tag=[Addressable,CodeRegion,UnanalyzedElfSection,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=d53f13b1d70c486397c25938311aeeab),\n",
-       " Resource(resource_id=9fb3213d0af14510828108089c1d521b, tag=[Addressable,CodeRegion,UnanalyzedElfSection,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=9fb3213d0af14510828108089c1d521b),\n",
-       " Resource(resource_id=1200d9c6b7ba4406bd97d44ef17fea4b, tag=[Addressable,CodeRegion,UnanalyzedElfSection,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=1200d9c6b7ba4406bd97d44ef17fea4b)]"
+       "[Resource(resource_id=565fc63a77494276bafea235ae00344e, tag=[Addressable,CodeRegion,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=565fc63a77494276bafea235ae00344e),\n",
+       " Resource(resource_id=d53f13b1d70c486397c25938311aeeab, tag=[Addressable,CodeRegion,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=d53f13b1d70c486397c25938311aeeab),\n",
+       " Resource(resource_id=9fb3213d0af14510828108089c1d521b, tag=[Addressable,CodeRegion,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=9fb3213d0af14510828108089c1d521b),\n",
+       " Resource(resource_id=1200d9c6b7ba4406bd97d44ef17fea4b, tag=[Addressable,CodeRegion,ElfSection,MemoryRegion,ProgramSection,NamedProgramSection,ElfSectionStructure], data=1200d9c6b7ba4406bd97d44ef17fea4b)]"
       ]
      },
      "execution_count": 7,


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Refactor ELF components to remove UnanalyzedElfSection, UnanalyzedElfSegment.

- These two ResourceViews are not needed, and do not add value to the user.

**Please describe the changes in your request.**
See above.

**Anyone you think should look at this, specifically?**
@EdwardLarson 