### PR TITLE
Minor bugfix: detect when Ghidra client dies unexpectedly

### DIFF
--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -143,6 +143,9 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
 
             if len(line) > 0:
                 LOGGER.debug(line)
+            elif ghidra_proc.stdout.at_eof():
+                raise GhidraComponentException("Ghidra client exited unexpectedly")
+
             if "Repository Server: localhost" in line:
                 time.sleep(0.5)
                 ghidra_proc.stdin.write((GHIDRA_PASS + "\n").encode("ascii"))


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Minor bugfix: detect when Ghidra client dies unexpectedly

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
If the Ghidra headless client dies unexpectedly, `ghidra_proc.stdout.readline()` in `GhidraProjectAnalyzer._do_ghidra_import` keeps returning an empty string, and the `white True:` would keep spinning forever. This change catches this scenario.

Just for context, I hit this issue with
```
[ghidra_analyzer.py:  139] Started ghidra import.: 619
User home directory does not exist: ?
User home directory does not exist: ?
User home directory does not exist: ?
[ghidra_analyzer.py:  145] 

[ghidra_analyzer.py:  145] Failed to find a supported JDK.  Please refer to the Ghidra Installation Guide's Troubleshooting section.
```

Not sure whether it's worth handling `Failed to find a supported JDK` explicitly. And I have not yet tried to figure out why "Failed to find a supported JDK" happened in the first place (although I am sure it's something trivial).

**Anyone you think should look at this, specifically?**
Not sure. 