### PR TITLE
Bugfix: Only list discovered components in the GUI

### DIFF
--- a/ofrak_core/ofrak/core/elf/analyzer.py
+++ b/ofrak_core/ofrak/core/elf/analyzer.py
@@ -46,7 +46,6 @@ class ElfBasicHeaderAttributesAnalyzer(Analyzer[None, ElfBasicHeader]):
     <https://man7.org/linux/man-pages/man5/elf.5.html> for details.
     """
 
-    id = b"ElfHeaderMetadataAttributesAnalyzer"
     targets = (ElfBasicHeader,)
     outputs = (ElfBasicHeader,)
 
@@ -218,7 +217,6 @@ class ElfSymbolAttributesAnalyzer(Analyzer[None, ElfSymbol]):
     table.
     """
 
-    id = b"ElfSymbolAnalyzer"
     targets = (ElfSymbol,)
     outputs = (ElfSymbol,)
 

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -103,10 +103,6 @@ class OFRAKContext:
         await asyncio.gather(*(service.shutdown() for service in self._all_ofrak_services))
         logging.shutdown()
 
-    def get_all_tags(self) -> Iterable[ResourceTag]:
-        all_tags = ResourceTag.all_tags
-        return all_tags
-
 
 class OFRAK:
     DEFAULT_LOG_LEVEL = logging.WARNING

--- a/ofrak_core/test_ofrak/unit/test_ofrak_context.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_context.py
@@ -4,9 +4,7 @@ import logging
 import pytest
 
 from ofrak import OFRAK, OFRAKContext
-from ofrak.core import BasicBlock
 from ofrak.core.apk import ApkIdentifier
-from ofrak.model.viewable_tag_model import ViewableResourceTag
 from ofrak.ofrak_context import get_current_ofrak_context
 from ofrak_type.error import NotFoundError, InvalidStateError
 from pytest_ofrak import mock_library3
@@ -85,10 +83,3 @@ async def test_get_ofrak_context_fixture(ofrak_context: OFRAKContext):
     current_ofrak_context = get_current_ofrak_context()
     assert current_ofrak_context is not None
     assert current_ofrak_context is ofrak_context
-
-
-async def test_get_all_tags(ofrak_context: OFRAKContext):
-    tags = set(ofrak_context.get_all_tags())
-    print(tags)
-    assert BasicBlock in tags
-    assert ViewableResourceTag not in tags


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**
Previously the GUI backend server used an `OFRAKEnvironment` object to get the list of components offered to the user to run. However this includes components from all installed OFRAK packages, including ones that weren't discovered as part of spinning up the server. So if the user selected one of these components, they would get an error. 

Additionally, if an OFRAK package was installed without all of its dependencies, any import errors could be avoided by not importing/discovering the package. However since getting the component list through the `OFRAKEnvironment` always imports all installed modules, a user could not avoid getting import errors for such installed, incomplete, and *unused* packages when using the OFRAK GUI.

**Please describe the changes in your request.**
* Use the current `OFRAKContext`'s `ComponentLocator` to get components
* Replace most of the filtering logic with the standard `ComponentLocator` filters
* Also get rid of an unnecessary `OFRAKContext` method `get_all_tags`, replace it with the call it wrapped `ResourceTag.all_tags`

**Anyone you think should look at this, specifically?**
@rbs-jacob 