### PR TITLE
Add an ability to install OFRAK from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ frontend/public/build
 ofrak_core/ofrak/core/entropy/entropy_c.cpython*
 ofrak_core/ofrak/gui/public
 ofrak_core/build
+ofrak_io/build/
+ofrak_patch_maker/build/
+ofrak_type/build/
+disassemblers/ofrak_ghidra/ofrak_ghidra/config/ofrak_ghidra.conf.yml

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,14 @@ tutorial-image:
 
 tutorial-run:
 	make -C ofrak_tutorial run
+
+.PHONY: install_tutorial install_code install_develop
+install_tutorial:
+	python3 install.py --config ofrak-tutorial.yml --target install
+
+install_core:
+	python3 install.py --config ofrak-core-dev.yml --target install
+
+install_develop:
+	python3 install.py --config ofrak-dev.yml --target develop
+

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,13 @@ OFRAK_INSTALL_PYTHON=python3
 
 .PHONY: install_tutorial install_code install_develop
 install_tutorial:
+	$(OFRAK_INSTALL_PYTHON) -m pip install pyyaml
 	$(OFRAK_INSTALL_PYTHON) install.py --config ofrak-tutorial.yml --target install
 
 install_core:
+	$(OFRAK_INSTALL_PYTHON) -m pip install pyyaml
 	$(OFRAK_INSTALL_PYTHON) install.py --config ofrak-core-dev.yml --target install
 
 install_develop:
+	$(OFRAK_INSTALL_PYTHON) -m pip install pyyaml
 	$(OFRAK_INSTALL_PYTHON) install.py --config ofrak-dev.yml --target develop

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,14 @@ tutorial-image:
 tutorial-run:
 	make -C ofrak_tutorial run
 
+OFRAK_INSTALL_PYTHON=python3
+
 .PHONY: install_tutorial install_code install_develop
 install_tutorial:
-	python3 install.py --config ofrak-tutorial.yml --target install
+	$(OFRAK_INSTALL_PYTHON) install.py --config ofrak-tutorial.yml --target install
 
 install_core:
-	python3 install.py --config ofrak-core-dev.yml --target install
+	$(OFRAK_INSTALL_PYTHON) install.py --config ofrak-core-dev.yml --target install
 
 install_develop:
-	python3 install.py --config ofrak-dev.yml --target develop
-
+	$(OFRAK_INSTALL_PYTHON) install.py --config ofrak-dev.yml --target develop

--- a/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/blocks/unpackers.py
@@ -24,7 +24,7 @@ from ofrak_binary_ninja.model import BinaryNinjaAnalysis
 if BINJA_INSTALLED:
     from binaryninja import BinaryView, Endianness, TypeClass
 else:
-    BinaryView=None
+    BinaryView = None
 
 LOGGER = logging.getLogger(__name__)
 

--- a/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/data/ref_analyzer.py
+++ b/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/data/ref_analyzer.py
@@ -21,6 +21,7 @@ class BinaryNinjaReferencedDataAnalyzer(ReferencedDataAnalyzer):
     """
     Analyzer to get all data references in the program
     """
+
     external_dependencies = (BINJA_TOOL,)
 
     async def analyze(self, resource: Resource, config=None) -> Tuple[ReferencedDataAttributes]:

--- a/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/data/ref_analyzer.py
+++ b/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/components/data/ref_analyzer.py
@@ -2,11 +2,14 @@ import logging
 from collections import defaultdict
 from typing import DefaultDict, Iterable, List, Tuple
 
-from binaryninja import BinaryView
+try:
+    from binaryninja.binaryview import BinaryView
+except ImportError:
+    BinaryView = None
 
 from ofrak.core.data import ReferencedDataAttributes
 from ofrak.core.program import ReferencedDataAnalyzer
-from ofrak_binary_ninja.components.binary_ninja_analyzer import BinaryNinjaAnalyzer
+from ofrak_binary_ninja.components.binary_ninja_analyzer import BINJA_TOOL, BinaryNinjaAnalyzer
 from ofrak_binary_ninja.model import BinaryNinjaAnalysis
 
 from ofrak.resource import Resource
@@ -18,6 +21,7 @@ class BinaryNinjaReferencedDataAnalyzer(ReferencedDataAnalyzer):
     """
     Analyzer to get all data references in the program
     """
+    external_dependencies = (BINJA_TOOL,)
 
     async def analyze(self, resource: Resource, config=None) -> Tuple[ReferencedDataAttributes]:
         if not resource.has_attributes(BinaryNinjaAnalysis):

--- a/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/model.py
+++ b/disassemblers/ofrak_binary_ninja/ofrak_binary_ninja/model.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
-from binaryninja.binaryview import BinaryView
+try:
+    from binaryninja.binaryview import BinaryView
+except ImportError:
+    BinaryView = None
 from ofrak.model.resource_model import ResourceAttributes
 
 

--- a/install.py
+++ b/install.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+import argparse
+import os
+import subprocess
+import sys
+import pkg_resources
+import yaml
+import shutil
+
+from build_image import InstallTarget
+
+
+class DependencyMechanism(Enum):
+    NONE = "none"
+    SHOW = "show"
+    APT = "apt"
+    BREW = "brew"
+
+
+@dataclass
+class OfrakInstallConfig:
+    packages_paths: List[str]
+    python_command: str
+    install_target: InstallTarget
+    dependency_mechanism: DependencyMechanism
+    dep_install: List[str]
+    quiet: bool
+
+
+def main():
+    config = parse_args()
+
+    for package_path in config.packages_paths:
+        check_package_contents(package_path)
+
+    if not config.quiet:
+        print(f"*** Checking whether npm and rollup are installed")
+    check_executable(config, "npm")
+    check_executable(config, "rollup")
+
+    if not config.quiet:
+        install_type = (
+            "development environment " if config.install_target == InstallTarget.DEVELOP else ""
+        )
+        print(
+            f"*** Installing OFRAK {install_type} for {config.python_command} from: "
+            f"{', '.join(config.packages_paths)}."
+        )
+    for package_path in config.packages_paths:
+        if not config.quiet:
+            print(f"** Installing {package_path}")
+        install_package(config, package_path)
+
+    if config.dependency_mechanism == DependencyMechanism.NONE:
+        pass
+    elif config.dependency_mechanism == DependencyMechanism.SHOW:
+        print("*** Checking for missing OFRAK dependencies")
+        show_dependencies(config)
+        show_install(config, "apt", "sudo apt install -y")
+        show_install(config, "brew", "brew install")
+    else:
+        install_deps(config)
+        if not config.quiet:
+            print("*** Checking OFRAK dependencies that may need to be installed manually")
+            show_dependencies(config)
+
+
+def parse_args() -> OfrakInstallConfig:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        help="Path to a .yml configuration file specifying which OFRAK packages to install",
+        required=True,
+    )
+    parser.add_argument(
+        "--target",
+        choices=[InstallTarget.DEVELOP.value, InstallTarget.INSTALL.value],
+        default=InstallTarget.DEVELOP.value,
+        help='Installation type. Use "install" for regular installation, and "develop" to install in '
+        'editable mode (i.e. setuptools "develop mode") from the source tree paths, and include '
+        'development (test, build documentation, etc) dependencies. Defaults to "develop"',
+    )
+    parser.add_argument(
+        "--python",
+        default=os.getenv("OFRAK_INSTALL_PYTHON", "python3"),
+        help="Path to, or name of the python executable to install OFRAK for. Defaults to the value of"
+        'the "OFRAK_INSTALL_PYTHON" environment variable if set, and "python3", if not',
+    )
+    parser.add_argument(
+        "--install_deps",
+        choices=[
+            DependencyMechanism.NONE.value,
+            DependencyMechanism.SHOW.value,
+            DependencyMechanism.APT.value,
+            DependencyMechanism.BREW.value,
+        ],
+        default=os.getenv("OFRAK_INSTALL_DEPS", DependencyMechanism.SHOW.value),
+        help='Method for installing non-pip dependencies. One of: "none" - do not install, "show" - '
+        'show how to install them, but do not install automatically, "apt" - install using APT '
+        '(requires sudo), "brew" - install using brew. Defaults to the value of the '
+        '"OFRAK_INSTALL_DEPS" environment variable if set, and "show", if not',
+    )
+    parser.add_argument("--quiet", "-q", action="store_true", help="Reduce verbosity")
+    args = parser.parse_args()
+    python = shutil.which(args.python)
+    if python is None:
+        if not args.quiet:
+            print(
+                "*** Specify correct name or path of python binary to use, using either the "
+                '"--python" command line argument, or the "OFRAK_INSTALL_PYTHON" environment'
+                "variable.",
+                file=sys.stderr,
+            )
+        raise ValueError(f"{args.python} not found")
+    with open(args.config) as file_handle:
+        config_dict = yaml.safe_load(file_handle)
+    if args.install_deps == "apt":
+        install_command = ["sudo", "apt", "install", "-y"]
+    elif args.install_deps == "brew":
+        install_command = ["brew", "install"]
+    else:
+        install_command = []
+    install_config = OfrakInstallConfig(
+        packages_paths=config_dict["packages_paths"],
+        python_command=python,
+        install_target=InstallTarget(args.target),
+        dependency_mechanism=DependencyMechanism(args.install_deps),
+        quiet=args.quiet,
+        dep_install=install_command,
+    )
+    return install_config
+
+
+def check_package_contents(package_path: str):
+    for content in [package_path, os.path.join(package_path, "Makefile")]:
+        if not os.path.exists(content):
+            raise ValueError(f"Required path {content} do not exist")
+    return
+
+
+def check_executable(config: OfrakInstallConfig, executable: str) -> None:
+    if shutil.which(executable) is None:
+        if config.dependency_mechanism in [DependencyMechanism.APT, DependencyMechanism.BREW]:
+            if not config.quiet:
+                print("** {executable} not found, attempting to install")
+            run_command(config, config.dep_install + [executable])
+        elif config.dependency_mechanism in [DependencyMechanism.NONE, DependencyMechanism.SHOW]:
+            if config.dependency_mechanism == DependencyMechanism.SHOW:
+                print("** {executable} not found, please install manually,")
+                print('** or use "--install_deps" / "OFRAK_INSTALL_DEPS"')
+                print("** to have it be installed automatically for you:")
+                print("**    apt:  sudo apt install -y {executable}")
+                print("**    brew: brew install {executable}")
+            raise FileNotFoundError(2, "{executable} not found", executable)
+
+
+def install_package(config: OfrakInstallConfig, package_path: str) -> None:
+    if not config.quiet:
+        print(f"** Installing from {package_path}")
+    etc_dir = os.path.join(os.getenv("HOME", "/"), "etc")
+    run_command(
+        config,
+        [
+            "make",
+            f"PYTHON={config.python_command}",
+            f"PIP={config.python_command} -m pip",
+            f"ETC={etc_dir}",
+            "-C",
+            package_path,
+            config.install_target.value,
+        ],
+    )
+
+
+def show_dependencies(config: OfrakInstallConfig) -> None:
+    run_ofrak_command(config, ["deps", "--missing-only"])
+
+
+def show_install(config: OfrakInstallConfig, dep: str, prefix: str) -> None:
+    deps = run_ofrak_command(
+        config,
+        ["deps", "--missing-only", f"--packages-for={dep}"],
+        True,
+    )
+    if deps:
+        print(f"** If your system has {dep}, you can install some of the dependencies using:")
+        print(f"**    {prefix} {deps}")
+
+
+def install_deps(config: OfrakInstallConfig) -> None:
+    if not config.quiet:
+        print(
+            "*** Installing those OFRAK dependencies that can be installed with "
+            "{config.dependency_mechanism.value}"
+        )
+    deps = run_ofrak_command(
+        config,
+        ["deps", "--missing-only", f"--packages-for={config.dependency_mechanism.value}"],
+        True,
+    )
+    assert deps is not None
+    run_command(config, config.dep_install + deps.split())
+
+
+def run_ofrak_command(
+    config: OfrakInstallConfig, args: List[str], capture_out=False
+) -> Optional[str]:
+    return run_command(config, [config.python_command, "-m", "ofrak"] + args, capture_out)
+
+
+def run_command(config: OfrakInstallConfig, args: List[str], capture_out=False) -> Optional[str]:
+    if not config.quiet:
+        print("% " + " ".join(args))
+    result = subprocess.run(args=args, capture_output=capture_out, check=True)
+    return result.stdout.decode("ascii") if capture_out else None
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as error:
+        print(f"*** Error running shell command, exit status: {error.returncode}", file=sys.stderr)
+        sys.exit(error.returncode)
+    except ValueError as error:
+        print(f"*** Error: {error}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError as error:
+        print(f"*** Error: No such file or directory: {error.filename}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as error:
+        print(f"*** Unexpected exception: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/install.py
+++ b/install.py
@@ -7,7 +7,6 @@ import argparse
 import os
 import subprocess
 import sys
-import pkg_resources
 import yaml
 import shutil
 

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -23,6 +23,7 @@ ofrak/gui/public:
 		cp -r /ofrak_gui ofrak/gui/public ; \
 	elif [ -d ../frontend ]; then \
 		cd ../frontend && \
+		npm install && \
 		npm run build && \
 		cd ../ofrak_core && \
 		cp -r ../frontend/public ofrak/gui/public ; \

--- a/ofrak_patch_maker/Makefile
+++ b/ofrak_patch_maker/Makefile
@@ -1,20 +1,20 @@
 PYTHON=python3
 PIP=pip3
+ETC=/etc
 
 
 # toolchain.conf is a file mapping ID to the various binaries responsible for preprocessing,
 #  assembling, compiling, linking, analyzing binaries for each currently supported toolchain.
-.PHONY: toolchain_conf
-toolchain_conf:
-	cp ofrak_patch_maker/toolchain.conf /etc/toolchain.conf
-	mv ofrak_patch_maker/toolchain.conf ofrak_patch_maker/toolchain.conf.bak
+$(ETC)/toolchain.conf: ofrak_patch_maker/toolchain.conf
+	mkdir -p $(ETC)
+	cp -a $< $@
 
 .PHONY: install
-install: toolchain_conf
+install: $(ETC)/toolchain.conf
 	$(PIP) install .
 
 .PHONY: develop
-develop: toolchain_conf
+develop: $(ETC)/toolchain.conf
 	$(PIP) install -e .[test]
 
 .PHONY: inspect


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add an ability to install OFRAK from source

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
This is a source tree equivalent of `pip install` for OFRAK - works similar to `build_image.py` approach, but does not require docker.
- Run `make install_core`/`make install_tutorial`/`make install_develop` to pip-install OFRAK from the current source tree (the core and tutorial versions do regular install (`make install` for packages listed in the corresponding `.yml`), while the `install_develop` does an "editable mode" install (`make develop` for packages).
- Pass `OFRAK_INSTALL_DEPS=brew`/`OFRAK_INSTALL_DEPS=apt` to `make` to have the dependencies (including the `npm`/`rollout` prerequisites) automatically installed.
- Pass `OFRAK_INSTALL_PYTHON=python3.x` (with or without the full path) to `make` to have OFRAK installed for the particular instance of python on your system.

(This also adds handling of binja as a potentially-missing dependency, as `make install_develop` easily triggers a situation where the ofrak binja modules are there, but binja is not - let me know if you'd rather have that as a separate PR).

**Anyone you think should look at this, specifically?**
@Edward-Larson probably? Maybe @rbs-jacob? 