### PR TITLE
Add initial USB DDR pad support to the GUI

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -34,9 +34,8 @@
   import AudioPlayer from "./AudioPlayer.svelte";
   import ByteclassView from "./ByteclassView.svelte";
   import CarouselSelector from "./CarouselSelector.svelte";
-  import ComponentsView from "./ComponentsView.svelte";
   import EntropyView from "./EntropyView.svelte";
-  import FindReplaceView from "./FindReplaceView.svelte";
+  import Gamepad from "./Gamepad.svelte";
   import HexView from "./HexView.svelte";
   import JumpToOffset from "./JumpToOffset.svelte";
   import LoadingAnimation from "./LoadingAnimation.svelte";
@@ -168,6 +167,7 @@ Answer by running riddle.answer('your answer here') from the console.`);
 </script>
 
 <svelte:window on:popstate="{backButton}" on:keyup="{handleShortcut}" />
+<Gamepad />
 
 {#if showRootResource}
   {#await rootResourceLoadPromise}

--- a/frontend/src/Gamepad.svelte
+++ b/frontend/src/Gamepad.svelte
@@ -1,0 +1,108 @@
+<script>
+  import { onMount } from "svelte";
+
+  import { shortcuts } from "./keyboard.js";
+
+  let animationLoop,
+    gamepad,
+    buttons = {
+      0: {
+        name: "Up",
+        shortcut: "arrowup",
+      },
+      1: {
+        name: "Down",
+        shortcut: "arrowdown",
+      },
+      2: {
+        name: "Right",
+        shortcut: "arrowright",
+      },
+      3: {
+        name: "Left",
+        shortcut: "arrowleft",
+      },
+      4: {
+        name: "Square",
+        shortcut: "p",
+      },
+      5: {
+        name: "Triangle",
+        shortcut: "u",
+      },
+      6: {
+        name: "X",
+        shortcut: "i",
+      },
+      7: {
+        name: "O",
+        shortcut: "a",
+      },
+      8: {
+        name: "Select",
+      },
+      9: {
+        name: "Start",
+        shortcut: "n",
+      },
+    };
+
+  function isValidGamepad(gamepad) {
+    // TODO: Refine selection criteria to handle non-DDR gamepads
+    return gamepad.axes.length == 0 && gamepad.buttons.length >= 16;
+  }
+
+  function loop() {
+    if (!gamepad || !gamepad.connected) {
+      disconnected();
+      return;
+    }
+
+    gamepad.buttons.forEach((b, i) => {
+      if (!buttons[i]) {
+        return;
+      }
+      if (buttons[i].pressed && !b.pressed) {
+        buttons[i].shortcut &&
+          shortcuts[buttons[i].shortcut] &&
+          shortcuts[buttons[i].shortcut]();
+      }
+      buttons[i].pressed = b.pressed;
+    });
+
+    animationLoop = requestAnimationFrame(loop);
+  }
+
+  function connected(e) {
+    let _gamepad = e.gamepad;
+    if (isValidGamepad(_gamepad)) {
+      gamepad = _gamepad;
+    } else {
+      return;
+    }
+    animationLoop = requestAnimationFrame(loop);
+  }
+
+  function disconnected() {
+    gamepad = undefined;
+    if (animationLoop) {
+      cancelAnimationFrame(animationLoop);
+    }
+  }
+
+  onMount(() => {
+    for (const _gamepad of navigator.getGamepads()) {
+      if (isValidGamepad(_gamepad)) {
+        gamepad = _gamepad;
+        break;
+      }
+    }
+
+    animationLoop = requestAnimationFrame(loop);
+  });
+</script>
+
+<svelte:window
+  on:gamepadconnected="{connected}"
+  on:gamepaddisconnected="{disconnected}"
+/>

--- a/frontend/src/Gamepad.svelte
+++ b/frontend/src/Gamepad.svelte
@@ -49,7 +49,7 @@
 
   function isValidGamepad(gamepad) {
     // TODO: Refine selection criteria to handle non-DDR gamepads
-    return gamepad.axes.length == 0 && gamepad.buttons.length >= 16;
+    return gamepad.axes.length == 0 && gamepad.buttons.length >= 10;
   }
 
   function loop() {

--- a/frontend/src/Gamepad.svelte
+++ b/frontend/src/Gamepad.svelte
@@ -62,7 +62,8 @@
       if (!buttons[i]) {
         return;
       }
-     // on button release, if the button corresponds to an OFRAK shortcut and that shortcut is found, trigger the shortcut
+      // On button release, if the button corresponds to an OFRAK shortcut and
+      // that shortcut is found, trigger the shortcut
       if (buttons[i].pressed && !b.pressed) {
         buttons[i].shortcut &&
           shortcuts[buttons[i].shortcut] &&

--- a/frontend/src/Gamepad.svelte
+++ b/frontend/src/Gamepad.svelte
@@ -62,6 +62,7 @@
       if (!buttons[i]) {
         return;
       }
+     // on button release, if the button corresponds to an OFRAK shortcut and that shortcut is found, trigger the shortcut
       if (buttons[i].pressed && !b.pressed) {
         buttons[i].shortcut &&
           shortcuts[buttons[i].shortcut] &&

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add a "copy to clipboard" button to the "Show Snippet" view for easy exporting. ([#301](https://github.com/redballoonsecurity/ofrak/pull/301))
 - Add a settings pane to the OFRAK GUI that supports theming and changing colors ([#309](https://github.com/redballoonsecurity/ofrak/pull/309))
 - Add a button and interface in the OFRAK GUI to specifically select any component to run on a resource ([#287](https://github.com/redballoonsecurity/ofrak/pull/287))
+- Add DDR pad support to the OFRAK GUI ([#322](https://github.com/redballoonsecurity/ofrak/pull/322))
 
 ### Fixed 
 - Fixed a bug where clicking "Unpack" or "Identify" (for example) too quickly after loading a large resource causes an error that freezes up the whole GUI ([#297](https://github.com/redballoonsecurity/ofrak/pull/297))


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add DDR pad support to the OFRAK GUI. Only maps buttons on the pad to keyboard shortcut callbacks – some more work is required to handle combos. 

**Anyone you think should look at this, specifically?**

@EdwardLarson 