### PR TITLE
bump black version

### DIFF
--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp~=3.8.1
 aiohttp-cors~=0.7.0
 beartype~=0.12.0
-black==22.6.0
+black==23.3.0
 fdt==0.3.3
 importlib-metadata>=4.13
 intervaltree==3.1.0


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Bump black version to avoid spurious import-time errors with INFO logging level.

**Link to Related Issue(s)**

With the logging level set to INFO, at import time, black generates some errors about missing cache etc. These are completely inconsequential but do look a bit nasty (error file not found etc.) so could concern/confuse users. The issue in black is documented here:
https://github.com/psf/black/pull/3193

It has been resolved (making these errors show up with DEBUG log level only, which is fine I guess) but we are on an older version which doesn't include these changes.

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
