### PR TITLE
Fix minimap bottom overlapping version number

### DIFF
--- a/frontend/src/Pane.svelte
+++ b/frontend/src/Pane.svelte
@@ -113,7 +113,9 @@
       <div
         class="minimap"
         style:margin-top="{paddingVertical}"
-        style:margin-bottom="{paddingVertical}"
+        style:margin-bottom="{!!window.chrome
+          ? `calc(${paddingVertical} * 2)`
+          : paddingVertical}"
         style:margin-right="{paddingHorizontal}"
       >
         <slot name="minimap" />

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fixed a bug where clicking "Unpack" or "Identify" (for example) too quickly after loading a large resource causes an error that freezes up the whole GUI ([#297](https://github.com/redballoonsecurity/ofrak/pull/297))
 - Bump `importlib-metadata` version to fix import errors ([#296](https://github.com/redballoonsecurity/ofrak/pull/296))
 - Treat `libmagic`, `strings` as `ComponentExternalTools` so that they are considered dependencies. ([#299](https://github.com/redballoonsecurity/ofrak/pull/299/))
+- Fixed GUI minimap bottom overlapping version number ([#327](https://github.com/redballoonsecurity/ofrak/pull/327))
 
 ## [3.0.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v2.2.1...ofrak-v3.0.0)
 ### Added


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix minimap bottom overlapping version number.

**Anyone you think should look at this, specifically?**

@EdwardLarson 