### PR TITLE
Slim the GUI start view dropdown and fix TextView update bug

### DIFF
--- a/frontend/src/HexView.svelte
+++ b/frontend/src/HexView.svelte
@@ -40,7 +40,7 @@
 
 <script>
   import Breadcrumb from "./Breadcrumb.svelte";
-  import LoadingAnimation from "./LoadingAnimation.svelte";
+  import LoadingText from "./LoadingText.svelte";
 
   import { chunkList, buf2hex, hexToChar } from "./helpers.js";
   import { selectedResource, selected, settings } from "./stores.js";
@@ -240,7 +240,7 @@
 </script>
 
 {#await dataLenPromise}
-  <LoadingAnimation />
+  <LoadingText />
 {:then dataLength}
   {#if dataLength > 0}
     <!-- 
@@ -259,7 +259,7 @@
         </div>
         <div class="hbox">
           {#await chunkDataPromise}
-            <LoadingAnimation />
+            <LoadingText />
           {:then chunks}
             <div>
               {#each chunks as _, chunkIndex}

--- a/frontend/src/StartView.svelte
+++ b/frontend/src/StartView.svelte
@@ -11,7 +11,19 @@
   }
 
   form {
+    width: 35%;
     max-width: 50%;
+    display: flex;
+  }
+
+  form > select {
+    max-width: 90%;
+    flex-grow: 1;
+  }
+
+  form > button {
+    max-width: 10%;
+    flex-grow: 1;
   }
 
   .center {

--- a/frontend/src/TextView.svelte
+++ b/frontend/src/TextView.svelte
@@ -36,7 +36,7 @@
 
   import { selectedResource } from "./stores";
 
-  let dataPromise = $selectedResource
+  $: dataPromise = $selectedResource
     ? $selectedResource.get_data()
     : Promise.resolve([]);
 


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix three small bugs:

- Prevent the dropdown on the GUI StartView from getting too wide
- Make sure the text view contents actually update when the data changes
- The hex view no longer takes a while to load, and thus no longer needs a loading animation – having the animation was initializing and destroying OpenGL contexts on every scroll, which was expensive and wasteful. Now it shows the text "Loading" without animation

**Anyone you think should look at this, specifically?**

@EdwardLarson 