### PR TITLE
Bugfix: use ghidra config

### DIFF
--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -187,7 +187,7 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
         if skip_analysis:
             args.append("-noanalysis")
 
-        args.extend(["-scriptPath", "'" + (";".join(self._script_directories)) + "'"])
+        args.extend(["-scriptPath", (";".join(self._script_directories))])
 
         args.extend(["-postScript", "AnalysisServer.java"])
         args.extend(self._build_ghidra_server_args())

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -104,7 +104,7 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
             with open(full_fname, "wb") as f:
                 f.write(data)
 
-        ghidra_project = f"{GHIDRA_REPOSITORY_HOST}:{GHIDRA_REPOSITORY_PORT}/ofrak"
+        ghidra_project = f"ghidra://{GHIDRA_REPOSITORY_HOST}:{GHIDRA_REPOSITORY_PORT}/ofrak"
 
         program_name = await self._do_ghidra_import(ghidra_project, full_fname)
         await self._do_ghidra_analyze_and_serve(
@@ -114,7 +114,7 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
         if tmp_dir:
             tmp_dir.cleanup()
 
-        return GhidraProject(ghidra_project, f"{GHIDRA_SERVER_HOST}:{GHIDRA_SERVER_PORT}")
+        return GhidraProject(ghidra_project, f"http://{GHIDRA_SERVER_HOST}:{GHIDRA_SERVER_PORT}")
 
     async def _do_ghidra_import(self, ghidra_project: str, full_fname: str):
         args = [

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/config/ofrak_ghidra.conf.yml.default
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/config/ofrak_ghidra.conf.yml.default
@@ -6,8 +6,8 @@ server:
   user: root
   pass: changeme
   repository:
-    host: ghidra://localhost
+    host: localhost
     port: 13100
   analysis:
-    host: http://localhost
+    host: localhost
     port: 13300

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/config/ofrak_ghidra_config.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/config/ofrak_ghidra_config.py
@@ -49,10 +49,10 @@ server:
   user: # User for the local Ghidra repository and server OFRAK will create
   pass: # Password for the local Ghidra repository and server OFRAK will create
   repository:
-    host: # Host for the Ghidra repository OFRAK will create, e.g. ghidra://localhost
+    host: # Host for the Ghidra repository OFRAK will create, e.g. localhost
     port: # Port for the Ghidra repository OFRAK will create
   analysis:
-    host: # Host for the server OFRAK will create in a headless Ghidra instance, e.g. http://localhost
+    host: # Host for the server OFRAK will create in a headless Ghidra instance, e.g. localhost
     port: # Host for the port OFRAK will create in a headless Ghidra instance
 """
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/constants.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/constants.py
@@ -14,9 +14,13 @@ GHIDRA_HEADLESS_EXEC = os.path.join(GHIDRA_PATH, "support/analyzeHeadless")
 # Environment
 GHIDRA_USER = conf.ghidra_server_user
 GHIDRA_PASS = conf.ghidra_server_pass
-GHIDRA_REPOSITORY_HOST = conf.ghidra_repository_host
+GHIDRA_REPOSITORY_HOST = conf.ghidra_repository_host.lstrip(
+    "ghidra://"  # existing configs have this prefix
+)
 GHIDRA_REPOSITORY_PORT = conf.ghidra_repository_port
-GHIDRA_SERVER_HOST = conf.ghidra_analysis_host
+GHIDRA_SERVER_HOST = conf.ghidra_analysis_host.lstrip(
+    "http://"  # existing configs have this prefix
+)
 GHIDRA_SERVER_PORT = conf.ghidra_analysis_port
 
 # Other

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/CreateRepository.java
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/CreateRepository.java
@@ -13,7 +13,8 @@ public class CreateRepository extends HeadlessScript {
 
     @Override
     public void run() throws Exception {
-        setServerCredentials("root", "changeme");
-        GhidraProject.getServerRepository("localhost", 13100, "ofrak", true);
+        String[] args = getScriptArgs();
+        setServerCredentials(args[0], args[1]);
+        GhidraProject.getServerRepository(args[2], Integer.parseInt(args[3]), "ofrak", true);
     }
 }

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
@@ -9,13 +9,13 @@ GHIDRA_REPO_HOST=$5
 GHIDRA_REPO_PORT=$6
 
 # cd /opt/rbs/ghidra_10.1.2_PUBLIC
-cd ${GHIDRA_PATH}
+cd "${GHIDRA_PATH}"
 ./server/svrInstall
 
 # The following command sometimes fails for unclear reasons, so we give it a few tries.
 max_retries=5
 retry_counter=0
-while ! ./server/svrAdmin -add $GHIDRA_USER; do
+while ! ./server/svrAdmin -add "$GHIDRA_USER"; do
   if [ $retry_counter -ge $max_retries ]; then
     echo "Failure running './server/svrAdmin -add $GHIDRA_USER'. Retried $retry_counter times." >&2
     exit 1
@@ -44,9 +44,9 @@ done
 
 
 ./server/ghidraSvr restart
-./support/analyzeHeadless . dummy -postScript CreateRepository.java $GHIDRA_USER $GHIDRA_PASS $GHIDRA_REPO_HOST $GHIDRA_REPO_PORT -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis
+./support/analyzeHeadless . dummy -postScript CreateRepository.java "$GHIDRA_USER" "$GHIDRA_PASS" "$GHIDRA_REPO_HOST" "$GHIDRA_REPO_PORT" -scriptPath "${OFRAK_GHIDRA_SCRIPTS_PATH}" -deleteProject -noanalysis
 
 # Some versions of Ghidra have a command to add permissions to users, in addition to -add
 if (./server/svrAdmin --help 2>&1 | grep "\-grant" ) then
-  ./server/svrAdmin -grant $GHIDRA_USER +w ofrak
+  ./server/svrAdmin -grant "$GHIDRA_USER" +w ofrak
 fi

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
@@ -27,6 +27,21 @@ while ! ./server/svrAdmin -add $GHIDRA_USER; do
   echo "Retrying running './server/svrAdmin -add $GHIDRA_USER' ($retry_counter/$max_retries)..."
 done
 
+# Also add root for when running with sudo, to make sure the repository can be created
+max_retries=5
+retry_counter=0
+while ! ./server/svrAdmin -add root; do
+  if [ $retry_counter -ge $max_retries ]; then
+    echo "Failure running './server/svrAdmin -add root'. Retried $retry_counter times." >&2
+    exit 1
+  fi
+  # Use ++v instead of v++ since bash returns 1 when an arithmetic operation returns 0,
+  # and we exit on failures with `set -e`.
+  ((++retry_counter))
+  sleep 0.5
+  echo "Retrying running './server/svrAdmin -add root' ($retry_counter/$max_retries)..."
+done
+
 
 ./server/ghidraSvr restart
 ./support/analyzeHeadless . dummy -postScript CreateRepository.java $GHIDRA_USER $GHIDRA_PASS $GHIDRA_REPO_HOST $GHIDRA_REPO_PORT -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
@@ -27,10 +27,11 @@ while ! ./server/svrAdmin -add $GHIDRA_USER; do
   echo "Retrying running './server/svrAdmin -add $GHIDRA_USER' ($retry_counter/$max_retries)..."
 done
 
+
+./server/ghidraSvr restart
+./support/analyzeHeadless . dummy -postScript CreateRepository.java $GHIDRA_USER $GHIDRA_PASS $GHIDRA_REPO_HOST $GHIDRA_REPO_PORT -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis
+
 # Some versions of Ghidra have a command to add permissions to users, in addition to -add
 if (./server/svrAdmin --help 2>&1 | grep "\-grant" ) then
   ./server/svrAdmin -grant $GHIDRA_USER +w ofrak
 fi
-
-./server/ghidraSvr restart
-./support/analyzeHeadless . dummy -postScript CreateRepository.java $GHIDRA_USER $GHIDRA_PASS $GHIDRA_REPO_HOST $GHIDRA_REPO_PORT -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
@@ -27,7 +27,10 @@ while ! ./server/svrAdmin -add $GHIDRA_USER; do
   echo "Retrying running './server/svrAdmin -add $GHIDRA_USER' ($retry_counter/$max_retries)..."
 done
 
-./server/svrAdmin -grant $GHIDRA_USER +w ofrak
+# Some versions of Ghidra have a command to add permissions to users, in addition to -add
+if (./server/svrAdmin --help 2>&1 | grep "\-grant" ) then
+  ./server/svrAdmin -grant $GHIDRA_USER +w ofrak
+fi
 
 ./server/ghidraSvr restart
 ./support/analyzeHeadless . dummy -postScript CreateRepository.java $GHIDRA_USER $GHIDRA_PASS $GHIDRA_REPO_HOST $GHIDRA_REPO_PORT -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
@@ -15,16 +15,16 @@ cd ${GHIDRA_PATH}
 # The following command sometimes fails for unclear reasons, so we give it a few tries.
 max_retries=5
 retry_counter=0
-while ! ./server/svrAdmin -add root; do
+while ! ./server/svrAdmin -add $GHIDRA_USER; do
   if [ $retry_counter -ge $max_retries ]; then
-    echo "Failure running './server/svrAdmin -add root'. Retried $retry_counter times." >&2
+    echo "Failure running './server/svrAdmin -add $GHIDRA_USER'. Retried $retry_counter times." >&2
     exit 1
   fi
   # Use ++v instead of v++ since bash returns 1 when an arithmetic operation returns 0,
   # and we exit on failures with `set -e`.
   ((++retry_counter))
   sleep 0.5
-  echo "Retrying running './server/svrAdmin -add root' ($retry_counter/$max_retries)..."
+  echo "Retrying running './server/svrAdmin -add $GHIDRA_USER' ($retry_counter/$max_retries)..."
 done
 
 ./server/ghidraSvr restart

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
@@ -27,5 +27,7 @@ while ! ./server/svrAdmin -add $GHIDRA_USER; do
   echo "Retrying running './server/svrAdmin -add $GHIDRA_USER' ($retry_counter/$max_retries)..."
 done
 
+./server/svrAdmin -grant $GHIDRA_USER +w ofrak
+
 ./server/ghidraSvr restart
 ./support/analyzeHeadless . dummy -postScript CreateRepository.java $GHIDRA_USER $GHIDRA_PASS $GHIDRA_REPO_HOST $GHIDRA_REPO_PORT -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/run_ghidra_server.sh
@@ -3,6 +3,10 @@ set -e
 
 GHIDRA_PATH=$1
 OFRAK_GHIDRA_SCRIPTS_PATH=$2
+GHIDRA_USER=$3
+GHIDRA_PASS=$4
+GHIDRA_REPO_HOST=$5
+GHIDRA_REPO_PORT=$6
 
 # cd /opt/rbs/ghidra_10.1.2_PUBLIC
 cd ${GHIDRA_PATH}
@@ -24,4 +28,4 @@ while ! ./server/svrAdmin -add root; do
 done
 
 ./server/ghidraSvr restart
-./support/analyzeHeadless . dummy -postScript CreateRepository.java -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis
+./support/analyzeHeadless . dummy -postScript CreateRepository.java $GHIDRA_USER $GHIDRA_PASS $GHIDRA_REPO_HOST $GHIDRA_REPO_PORT -scriptPath ${OFRAK_GHIDRA_SCRIPTS_PATH} -deleteProject -noanalysis

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
@@ -14,7 +14,7 @@ from ofrak_ghidra.constants import (
 )
 
 
-def _run_ghidra_server(args):
+def _run_ghidra_server(*args):
     if sys.platform == "linux" or sys.platform == "darwin":
         subprocess.call(["chmod", "+x", GHIDRA_START_SERVER_SCRIPT])
         subprocess.call(
@@ -32,7 +32,7 @@ def _run_ghidra_server(args):
         raise NotImplementedError(f"Native OFRAK Ghidra server not supported for {sys.platform}!")
 
 
-def _stop_ghidra_server(args):
+def _stop_ghidra_server(*args):
     if sys.platform == "linux" or sys.platform == "darwin":
         subprocess.call([os.path.join(GHIDRA_PATH, "server", "ghidraSvr"), "stop"])
     else:

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import stat
 import subprocess
 import sys
 
@@ -16,7 +17,9 @@ from ofrak_ghidra.constants import (
 
 def _run_ghidra_server(*args):
     if sys.platform == "linux" or sys.platform == "darwin":
-        subprocess.call(["chmod", "+x", GHIDRA_START_SERVER_SCRIPT])
+        os.chmod(
+            GHIDRA_START_SERVER_SCRIPT, os.stat(GHIDRA_START_SERVER_SCRIPT).st_mode | stat.S_IEXEC
+        )
         subprocess.call(
             [
                 GHIDRA_START_SERVER_SCRIPT,

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/server/__main__.py
@@ -7,13 +7,27 @@ from ofrak_ghidra.constants import (
     GHIDRA_START_SERVER_SCRIPT,
     GHIDRA_PATH,
     CORE_OFRAK_GHIDRA_SCRIPTS,
+    GHIDRA_USER,
+    GHIDRA_PASS,
+    GHIDRA_REPOSITORY_HOST,
+    GHIDRA_REPOSITORY_PORT,
 )
 
 
 def _run_ghidra_server(args):
     if sys.platform == "linux" or sys.platform == "darwin":
         subprocess.call(["chmod", "+x", GHIDRA_START_SERVER_SCRIPT])
-        subprocess.call([GHIDRA_START_SERVER_SCRIPT, GHIDRA_PATH, CORE_OFRAK_GHIDRA_SCRIPTS])
+        subprocess.call(
+            [
+                GHIDRA_START_SERVER_SCRIPT,
+                GHIDRA_PATH,
+                CORE_OFRAK_GHIDRA_SCRIPTS,
+                GHIDRA_USER,
+                GHIDRA_PASS,
+                GHIDRA_REPOSITORY_HOST,
+                str(GHIDRA_REPOSITORY_PORT),
+            ]
+        )
     else:
         raise NotImplementedError(f"Native OFRAK Ghidra server not supported for {sys.platform}!")
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_config.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_config.py
@@ -10,11 +10,11 @@ DEFAULT_CONFIG = """ghidra_install:
   path: /opt/rbs/ghidra_10.1.2_PUBLIC
 server:
   analysis:
-    host: http://localhost
+    host: localhost
     port: 13300
   pass: changeme
   repository:
-    host: ghidra://localhost
+    host: localhost
     port: 13100
   user: root
 """

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_server.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_server.py
@@ -1,26 +1,25 @@
 import psutil
 import pytest
+from typing import Optional
 
 import ofrak_ghidra.server.__main__ as server_main
 
 
-def _get_ghidra_server_process() -> psutil.Process:
+def _get_ghidra_server_process() -> Optional[psutil.Process]:
     for proc in psutil.process_iter():
         cmdline = proc.cmdline()
         if (
-            cmdline[0] == "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+            len(cmdline) > 1
+            and cmdline[0] == "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
             and cmdline[1] == "-Dwrapper.pidfile=/run/wrapper.ghidraSvr.pid"
         ):
             return proc
-    raise ValueError("Could not find Ghidra server process")
+    return None
 
 
 def _is_ghidra_server_running() -> bool:
-    try:
-        pid = _get_ghidra_server_process()
-        return True
-    except ValueError:
-        return False
+    proc = _get_ghidra_server_process()
+    return proc is not None
 
 
 @pytest.fixture
@@ -33,9 +32,9 @@ def ghidra_is_running() -> bool:
     yield ghidra_is_running
 
     if ghidra_is_running:
-        server_main._run_ghidra_server("start")
+        server_main._run_ghidra_server()
     else:
-        server_main._stop_ghidra_server("stop")
+        server_main._stop_ghidra_server()
 
 
 def test_start_stop_ghidra_server(ghidra_is_running: bool):
@@ -46,8 +45,8 @@ def test_start_stop_ghidra_server(ghidra_is_running: bool):
     If the server is not running ,start
     """
     if ghidra_is_running:
-        server_main._stop_ghidra_server("stop")
+        server_main._stop_ghidra_server()
         assert not _is_ghidra_server_running(), "Could not stop Ghidra server"
     else:
-        server_main._run_ghidra_server("start")
+        server_main._run_ghidra_server()
         assert _is_ghidra_server_running(), "Could not start Ghidra Server"


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Actually use the fields of the ofrak_ghidra.config when setting up the ghidra repository

**Link to Related Issue(s)**
Basically we had infrastructure to configure ofrak for a local ghidra setup, but the ofrak_ghidra code was not looking at that config at all.

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
