### PR TITLE
Data service search

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
 - Add a JFFS2 packer and unpacker. ([#326](https://github.com/redballoonsecurity/ofrak/pull/326))
+- Add method to Resource and data service to search for patterns in its data ([#333](https://github.com/redballoonsecurity/ofrak/pull/333))
 
 ### Changed
 - Support uploading files in chunks to handle files larger than 2GB from the GUI ([#324](https://github.com/redballoonsecurity/ofrak/pull/324))

--- a/ofrak_core/ofrak/core/elf/analyzer.py
+++ b/ofrak_core/ofrak/core/elf/analyzer.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import re
 from typing import Optional, TypeVar
 
 from ofrak.component.analyzer import Analyzer
@@ -28,7 +29,6 @@ from ofrak.model.viewable_tag_model import AttributesType
 from ofrak.resource import Resource
 from ofrak.service.resource_service_i import ResourceFilter
 from ofrak_io.deserializer import BinaryDeserializer
-from ofrak_type.range import Range
 
 LOGGER = logging.getLogger(__name__)
 
@@ -322,14 +322,10 @@ class ElfSectionNameAnalyzer(Analyzer[None, AttributesType[NamedProgramSection]]
         elf_r = await section.get_elf()
         string_section = await elf_r.get_section_name_string_section()
         try:
-            string_section_data = await string_section.resource.get_data(
-                Range(section_header.sh_name, Range.MAX)
+            ((_, raw_section_name),) = await string_section.resource.search_data(
+                re.compile(b".*\x00"), start=section_header.sh_name
             )
-            name_string_end = string_section_data.find(b"\x00")
-            raw_section_name = await string_section.resource.get_data(
-                Range(section_header.sh_name, section_header.sh_name + name_string_end)
-            )
-            section_name = raw_section_name.decode("ascii")
+            section_name = raw_section_name[:-1].decode("ascii")
         except ValueError:
             LOGGER.info("String section is empty! Using '<no-strings>' as section name")
             section_name = "<no-strings>"  # This is what readelf returns in this situation

--- a/ofrak_core/ofrak/core/elf/analyzer.py
+++ b/ofrak_core/ofrak/core/elf/analyzer.py
@@ -323,10 +323,10 @@ class ElfSectionNameAnalyzer(Analyzer[None, AttributesType[NamedProgramSection]]
         string_section = await elf_r.get_section_name_string_section()
         try:
             ((_, raw_section_name),) = await string_section.resource.search_data(
-                re.compile(b".*\x00"), start=section_header.sh_name
+                re.compile(b".[^\x00]+\x00"), start=section_header.sh_name, max_matches=1
             )
             section_name = raw_section_name[:-1].decode("ascii")
-        except ValueError:
+        except ValueError as e:
             LOGGER.info("String section is empty! Using '<no-strings>' as section name")
             section_name = "<no-strings>"  # This is what readelf returns in this situation
         return AttributesType[NamedProgramSection](

--- a/ofrak_core/ofrak/core/elf/model.py
+++ b/ofrak_core/ofrak/core/elf/model.py
@@ -514,7 +514,7 @@ class ElfSymbol(ElfSymbolStructure):
         elf = await self.resource.get_only_ancestor_as_view(Elf, ResourceFilter.with_tags(Elf))
         string_section = await elf.get_string_section()
         ((_, raw_symbol_name),) = await string_section.resource.search_data(
-            re.compile(b".*\x00"), self.st_name
+            re.compile(b".[^\x00]+\x00"), start=self.st_name, max_matches=1
         )
         return raw_symbol_name[:-1].decode("ascii")
 

--- a/ofrak_core/ofrak/core/elf/model.py
+++ b/ofrak_core/ofrak/core/elf/model.py
@@ -1,3 +1,4 @@
+import re
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -512,10 +513,10 @@ class ElfSymbol(ElfSymbolStructure):
     async def get_name(self) -> str:
         elf = await self.resource.get_only_ancestor_as_view(Elf, ResourceFilter.with_tags(Elf))
         string_section = await elf.get_string_section()
-        string_section_data = await string_section.resource.get_data(Range(self.st_name, Range.MAX))
-        name_string_end = string_section_data.find(b"\x00")
-        raw_symbol_name = string_section_data[:name_string_end]
-        return raw_symbol_name.decode("ascii")
+        ((_, raw_symbol_name),) = await string_section.resource.search_data(
+            re.compile(b".*\x00"), self.st_name
+        )
+        return raw_symbol_name[:-1].decode("ascii")
 
     @index
     def SymbolValue(self) -> int:

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -250,16 +250,21 @@ class Resource:
         query: Pattern[bytes],
         start: Optional[int] = None,
         end: Optional[int] = None,
+        max_matches: Optional[int] = None,
     ) -> Tuple[Tuple[int, bytes], ...]:
         ...
 
     @overload
     async def search_data(
-        self, query: bytes, start: Optional[int] = None, end: Optional[int] = None
+        self,
+        query: bytes,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        max_matches: Optional[int] = None,
     ) -> Tuple[int, ...]:
         ...
 
-    async def search_data(self, query, start=None, end=None):
+    async def search_data(self, query, start=None, end=None, max_matches=None):
         """
         Search for some data in this resource. The query may be a regex pattern (a return value
         of `re.compile`). If the query is a regex pattern, returns a list of pairs with both the
@@ -273,7 +278,7 @@ class Resource:
         :return: A list of offsets matching a plain bytes query, or a list of (offset, match) pairs
         for a regex pattern query
         """
-        return await self._data_service.search(self.get_data_id(), query, start, end)
+        return await self._data_service.search(self.get_data_id(), query, start, end, max_matches)
 
     async def save(self):
         """

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -17,6 +17,8 @@ from typing import (
     Sequence,
     Callable,
     Set,
+    Pattern,
+    overload,
 )
 
 from ofrak.component.interface import ComponentInterface
@@ -241,6 +243,37 @@ class Resource:
                 "resource with no data."
             )
         return await self._data_service.get_data_range_within_root(self._resource.data_id)
+
+    @overload
+    async def search_data(
+        self,
+        query: Pattern[bytes],
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+    ) -> List[Tuple[int, bytes]]:
+        ...
+
+    @overload
+    async def search_data(
+        self, query: bytes, start: Optional[int] = None, end: Optional[int] = None
+    ) -> List[int]:
+        ...
+
+    async def search_data(self, query, start=None, end=None):
+        """
+        Search for some data in this resource. The query may be a regex pattern (a return value
+        of `re.compile`). If the query is a regex pattern, returns a list of pairs with both the
+        offset of the match and the contents of the match itself. If the query is plain bytes, a
+        list of only the match offsets are returned.
+
+        :param query: Plain bytes to exactly match or a regex pattern to search for
+        :param start: Start offset in the data model to begin searching
+        :param end: End offset in the data model to stop searching
+
+        :return: A list of offsets matching a plain bytes query, or a list of (offset, match) pairs
+        for a regex pattern query
+        """
+        return await self._data_service.search(self.get_data_id(), query, start, end)
 
     async def save(self):
         """

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -250,13 +250,13 @@ class Resource:
         query: Pattern[bytes],
         start: Optional[int] = None,
         end: Optional[int] = None,
-    ) -> List[Tuple[int, bytes]]:
+    ) -> Tuple[Tuple[int, bytes], ...]:
         ...
 
     @overload
     async def search_data(
         self, query: bytes, start: Optional[int] = None, end: Optional[int] = None
-    ) -> List[int]:
+    ) -> Tuple[int, ...]:
         ...
 
     async def search_data(self, query, start=None, end=None):

--- a/ofrak_core/ofrak/service/data_service.py
+++ b/ofrak_core/ofrak/service/data_service.py
@@ -148,7 +148,7 @@ class DataService(DataServiceInterface):
 
     async def search(self, data_id, query, start=None, end=None):
         model = self._get_by_id(data_id)
-        root = self._get_root_by_id(data_id)
+        root = self._get_root_by_id(model.root_id)
         start = model.range.start if start is None else model.range.start + start
         end = model.range.end if end is None else min(model.range.end, model.range.start + end)
         if type(query) is bytes:

--- a/ofrak_core/ofrak/service/data_service.py
+++ b/ofrak_core/ofrak/service/data_service.py
@@ -158,14 +158,15 @@ class DataService(DataServiceInterface):
                 if match_offset < 0:
                     break
 
-                matches.append(match_offset)
+                matches.append(match_offset - model.range.start)
                 start = match_offset + 1
 
             return tuple(matches)
         else:
             query = cast(Pattern, query)
             matches = [
-                (match.start(), match.group(0)) for match in query.finditer(root.data, start, end)
+                (match.start() - model.range.start, match.group(0))
+                for match in query.finditer(root.data, start, end)
             ]
             return tuple(matches)
 

--- a/ofrak_core/ofrak/service/data_service.py
+++ b/ofrak_core/ofrak/service/data_service.py
@@ -161,13 +161,13 @@ class DataService(DataServiceInterface):
                 matches.append(match_offset)
                 start = match_offset + 1
 
-            return matches
+            return tuple(matches)
         else:
             query = cast(Pattern, query)
             matches = [
                 (match.start(), match.group(0)) for match in query.finditer(root.data, start, end)
             ]
-            return matches
+            return tuple(matches)
 
     def _get_by_id(self, data_id: DataId) -> DataModel:
         model = self._model_store.get(data_id)

--- a/ofrak_core/ofrak/service/data_service_i.py
+++ b/ofrak_core/ofrak/service/data_service_i.py
@@ -189,18 +189,24 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         query: Pattern[bytes],
         start: Optional[int] = None,
         end: Optional[int] = None,
+        max_matches: Optional[int] = None,
     ) -> Tuple[Tuple[int, bytes], ...]:
         ...
 
     @overload
     @abstractmethod
     async def search(
-        self, data_id: bytes, query: bytes, start: Optional[int] = None, end: Optional[int] = None
+        self,
+        data_id: bytes,
+        query: bytes,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        max_matches: Optional[int] = None,
     ) -> Tuple[int, ...]:
         ...
 
     @abstractmethod
-    async def search(self, data_id, query, start=None, end=None):
+    async def search(self, data_id, query, start=None, end=None, max_matches=None):
         """
         Search for some data in one of the models. The query may be a regex pattern (a return value
         of `re.compile`). If the query is a regex pattern, returns a list of pairs with both the
@@ -211,6 +217,7 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         :param query: Plain bytes to exactly match or a regex pattern to search for
         :param start: Start offset in the data model to begin searching
         :param end: End offset in the data model to stop searching
+        :param max_matches: Maximum number of matches to return
 
         :return: A list of offsets matching a plain bytes query, or a list of (offset, match) pairs
         for a regex pattern query

--- a/ofrak_core/ofrak/service/data_service_i.py
+++ b/ofrak_core/ofrak/service/data_service_i.py
@@ -189,7 +189,7 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         query: Pattern[bytes],
         start: Optional[int] = None,
         end: Optional[int] = None,
-    ) -> List[Tuple[int, int]]:
+    ) -> List[Tuple[int, bytes]]:
         ...
 
     @overload
@@ -203,7 +203,7 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
     async def search(self, data_id, query, start=None, end=None):
         """
         Search for some data in one of the models. The query may be a regex pattern (a return value
-        of re.compile). If the query is a regex pattern, returns a list of pairs with both the
+        of `re.compile`). If the query is a regex pattern, returns a list of pairs with both the
         offset of the match and the contents of the match itself. If the query is plain bytes, a
         list of only the match offsets are returned.
 

--- a/ofrak_core/ofrak/service/data_service_i.py
+++ b/ofrak_core/ofrak/service/data_service_i.py
@@ -187,16 +187,20 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         self,
         data_id: bytes,
         query: Pattern[bytes],
+        start: Optional[int] = None,
+        end: Optional[int] = None,
     ) -> List[Tuple[int, int]]:
         ...
 
     @overload
     @abstractmethod
-    async def search(self, data_id: bytes, query: bytes) -> List[int]:
+    async def search(
+        self, data_id: bytes, query: bytes, start: Optional[int] = None, end: Optional[int] = None
+    ) -> List[int]:
         ...
 
     @abstractmethod
-    async def search(self, data_id, query):
+    async def search(self, data_id, query, start=None, end=None):
         """
         Search for some data in one of the models. The query may be a regex pattern (a return value
         of re.compile). If the query is a regex pattern, returns a list of pairs with both the
@@ -205,6 +209,8 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
 
         :param data_id: Data model to search
         :param query: Plain bytes to exactly match or a regex pattern to search for
+        :param start: Start offset in the data model to begin searching
+        :param end: End offset in the data model to stop searching
 
         :return: A list of offsets matching a plain bytes query, or a list of (offset, match) pairs
         for a regex pattern query

--- a/ofrak_core/ofrak/service/data_service_i.py
+++ b/ofrak_core/ofrak/service/data_service_i.py
@@ -189,14 +189,14 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         query: Pattern[bytes],
         start: Optional[int] = None,
         end: Optional[int] = None,
-    ) -> List[Tuple[int, bytes]]:
+    ) -> Tuple[Tuple[int, bytes], ...]:
         ...
 
     @overload
     @abstractmethod
     async def search(
         self, data_id: bytes, query: bytes, start: Optional[int] = None, end: Optional[int] = None
-    ) -> List[int]:
+    ) -> Tuple[int, ...]:
         ...
 
     @abstractmethod

--- a/ofrak_core/ofrak/service/data_service_i.py
+++ b/ofrak_core/ofrak/service/data_service_i.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import List, Iterable, Optional
+from typing import List, Iterable, Optional, Tuple, overload, Pattern
 
 from ofrak.model.data_model import DataModel, DataPatch, DataPatchesResult
 from ofrak.service.abstract_ofrak_service import AbstractOfrakService
@@ -178,5 +178,35 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         :param data_ids: Multiple unique IDs for data models
 
         :raises NotFoundError: if any ID in `data_ids` is not associated with any known model
+        """
+        raise NotImplementedError()
+
+    @overload
+    @abstractmethod
+    async def search(
+        self,
+        data_id: bytes,
+        query: Pattern[bytes],
+    ) -> List[Tuple[int, int]]:
+        ...
+
+    @overload
+    @abstractmethod
+    async def search(self, data_id: bytes, query: bytes) -> List[int]:
+        ...
+
+    @abstractmethod
+    async def search(self, data_id, query):
+        """
+        Search for some data in one of the models. The query may be a regex pattern (a return value
+        of re.compile). If the query is a regex pattern, returns a list of pairs with both the
+        offset of the match and the contents of the match itself. If the query is plain bytes, a
+        list of only the match offsets are returned.
+
+        :param data_id: Data model to search
+        :param query: Plain bytes to exactly match or a regex pattern to search for
+
+        :return: A list of offsets matching a plain bytes query, or a list of (offset, match) pairs
+        for a regex pattern query
         """
         raise NotImplementedError()

--- a/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
+++ b/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
@@ -382,6 +382,14 @@ class TestDataServiceInterface:
         results = await populated_data_service.search(DATA_0, b"\x00\x10")
         assert results == [0x10 - 1]
 
+        results = await populated_data_service.search(DATA_0, b"\x10", start=0x10)
+        assert results == [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17]
+
     async def test_search_regex(self, populated_data_service: DataServiceInterface):
         results = await populated_data_service.search(DATA_0, re.compile(b"\x00\x10+"))
         assert results == [(0x10 - 1, b"\x00\x10\x10\x10\x10\x10\x10\x10\x10")]
+
+        results = await populated_data_service.search(
+            DATA_0, re.compile(b"\x00+\x10+"), start=0xC, end=0x14
+        )
+        assert results == [(0xC, b"\x00\x00\x00\x00\x10\x10\x10\x10")]

--- a/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
+++ b/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from ofrak.model.data_model import DataPatch
@@ -375,3 +377,11 @@ class TestDataServiceInterface:
         for data_id in [DATA_0, DATA_1, DATA_2, DATA_3, DATA_4, DATA_5]:
             with pytest.raises(NotFoundError):
                 await populated_data_service.get_by_id(data_id)
+
+    async def test_search_bytes(self, populated_data_service: DataServiceInterface):
+        results = await populated_data_service.search(DATA_0, b"\x00\x10")
+        assert results == [0x10 - 1]
+
+    async def test_search_regex(self, populated_data_service: DataServiceInterface):
+        results = await populated_data_service.search(DATA_0, re.compile(b"\x00\x10+"))
+        assert results == [(0x10 - 1, b"\x00\x10\x10\x10\x10\x10\x10\x10\x10")]

--- a/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
+++ b/ofrak_core/test_ofrak/service/data_service/data_service_interface_test.py
@@ -379,17 +379,17 @@ class TestDataServiceInterface:
                 await populated_data_service.get_by_id(data_id)
 
     async def test_search_bytes(self, populated_data_service: DataServiceInterface):
-        results = await populated_data_service.search(DATA_0, b"\x00\x10")
-        assert results == [0x10 - 1]
+        (results,) = await populated_data_service.search(DATA_0, b"\x00\x10")
+        assert results == 0x10 - 1
 
         results = await populated_data_service.search(DATA_0, b"\x10", start=0x10)
-        assert results == [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17]
+        assert results == (0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17)
 
     async def test_search_regex(self, populated_data_service: DataServiceInterface):
         results = await populated_data_service.search(DATA_0, re.compile(b"\x00\x10+"))
-        assert results == [(0x10 - 1, b"\x00\x10\x10\x10\x10\x10\x10\x10\x10")]
+        assert results == ((0x10 - 1, b"\x00\x10\x10\x10\x10\x10\x10\x10\x10"),)
 
         results = await populated_data_service.search(
             DATA_0, re.compile(b"\x00+\x10+"), start=0xC, end=0x14
         )
-        assert results == [(0xC, b"\x00\x00\x00\x00\x10\x10\x10\x10")]
+        assert results == ((0xC, b"\x00\x00\x00\x00\x10\x10\x10\x10"),)


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add method to Resource and data service to search for patterns in its data

**Link to Related Issue(s)**
Previously the only way to search was to request all the data then search it. This copying of data is inefficient, and searching for patterns in data is something users are likely to be interested in, so this makes sense to add to the API.

**Please describe the changes in your request.**
- Add a `search` method to the data service that allows searching for either literal bytes or a regex pattern
- Add a `search_data` method to Resource which calls the DataService's `search` method on itself

**Anyone you think should look at this, specifically?**
