### PR TITLE
Allow running forks with secrets

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,7 +1,7 @@
 name: OFRAK CI Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
   push:


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Allow running GitHub Actions with secrets on external contributor forked PRs.

**Link to Related Issue(s)**

#338 

**Please describe the changes in your request.**

This change makes actions on pull requests run in the context of the original repo, instead of the context of the fork. This gives the running PR code access to the secrets of the original repo. Since secrets are required for complete test coverage following #338, they will be need for the tests to run on PRs. 

To mitigate the risk of users introducing malicious code to PRs to leak and exfiltrate secrets, I have changed the repo settings such that every PR from an external contributor must have the tests be manually run by someone with appropriate repo privileges. In any case, the only secrets are the NXP email and password, which aren't that secret, anyway.

**Anyone you think should look at this, specifically?**

@whyitfor @paulnoalhyt 