### PR TITLE
Save resources affected by data patches and dependency updates on a re…

### DIFF
--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -693,6 +693,9 @@ class MutableResourceModel(ResourceModel):
         self.is_deleted = False
         self._diff: Optional[ResourceModelDiff] = None
 
+    def __hash__(self):
+        return self.id.__hash__()
+
     @property
     def diff(self):
         if not self._diff:

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -296,12 +296,12 @@ class Resource:
             self._resource_view_context,
         )
 
-    def _save(
-        self,
-        resources_to_delete: List[bytes],
-        patches_to_apply: List[DataPatch],
-        resources_to_update: List[MutableResourceModel],
-    ):
+    def _save(self) -> Tuple[List[bytes], List[DataPatch], List[MutableResourceModel]]:
+
+        resources_to_delete: List[bytes] = []
+        patches_to_apply: List[DataPatch] = []
+        resources_to_update: List[MutableResourceModel] = []
+
         if self._resource.is_deleted:
             resources_to_delete.append(self._resource.id)
         elif self._resource.is_modified:
@@ -315,6 +315,8 @@ class Resource:
             patches_to_apply.extend(modification_tracker.data_patches)
             resources_to_update.append(self._resource)
             modification_tracker.data_patches.clear()
+
+        return resources_to_delete, patches_to_apply, resources_to_update
 
     async def _fetch(self, resource: MutableResourceModel):
         """
@@ -1543,11 +1545,11 @@ async def save_resources(
     resources_to_update: List[MutableResourceModel] = []
 
     for resource in resources:
-        resource._save(
-            resources_to_delete,
-            patches_to_apply,
-            resources_to_update,
-        )
+        _resources_to_delete, _patches_to_apply, _resources_to_update = resource._save()
+
+        resources_to_delete.extend(_resources_to_delete)
+        patches_to_apply.extend(_patches_to_apply)
+        resources_to_update.extend(_resources_to_update)
 
     deleted_descendants = await resource_service.delete_resources(resources_to_delete)
     data_ids_to_delete = [
@@ -1555,7 +1557,9 @@ async def save_resources(
     ]
     await data_service.delete_models(data_ids_to_delete)
     patch_results = await data_service.apply_patches(patches_to_apply)
-    await dependency_handler.handle_post_patch_dependencies(patch_results)
+    resources_to_update.extend(
+        await dependency_handler.handle_post_patch_dependencies(patch_results)
+    )
     diffs = []
     updated_ids = []
     for resource_m in resources_to_update:


### PR DESCRIPTION
…source being saved

- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Save resources affected by data patches and dependency updates on a resource being saved

**Link to Related Issue(s)**
Calling `resource.save()` will apply data patches, which for mapped resources will also modify one or more ancestors. Without these changes, those resources would be marked as "dirty" after the original `save` call. This has the confusing result of making local state overall "dirtier" after a `save` call, rather than less.

**Please describe the changes in your request.**
With these changes, if `save` call on one resource modifies other resources, those resources' models will also be pushed and not dirty.

**Anyone you think should look at this, specifically?**
@dannyp303 
