### PR TITLE
isolate non-python dependencies

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -199,7 +199,7 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
         "",
     ]
 
-    requirement_suffixes = [""]
+    requirement_suffixes = ["", "non-pypi"]
     if config.install_target is InstallTarget.DEVELOP:
         requirement_suffixes += ["-docs", "-test"]
 

--- a/build_image.py
+++ b/build_image.py
@@ -199,7 +199,7 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
         "",
     ]
 
-    requirement_suffixes = ["", "non-pypi"]
+    requirement_suffixes = ["", "-non-pypi"]
     if config.install_target is InstallTarget.DEVELOP:
         requirement_suffixes += ["-docs", "-test"]
 

--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -58,12 +58,6 @@ RUN cd /tmp && \
     cd /tmp && \
     rm -r squashfs-tools
 
-# Install binwalk
-RUN cd /tmp && \
-    git clone https://github.com/ReFirmLabs/binwalk && \
-    cd binwalk && \
-    python3 setup.py install
-
 # Install Jefferson
 WORKDIR /tmp
 RUN wget https://bootstrap.pypa.io/pip/get-pip.py && python3.9 get-pip.py && python3.7 get-pip.py && rm get-pip.py

--- a/ofrak_core/ofrak/core/ihex.py
+++ b/ofrak_core/ofrak/core/ihex.py
@@ -97,8 +97,6 @@ class IhexProgramUnpacker(Unpacker[None]):
     targets = (IhexProgram,)
     children = (ProgramSection,)
 
-    external_dependencies = (_BINCOPY_TOOL,)
-
     async def unpack(self, resource: Resource, config=None):
         ihex_program = await resource.view_as(IhexProgram)
         for seg_vaddr_range in ihex_program.segments:
@@ -118,8 +116,6 @@ class IhexProgramPacker(Packer[None]):
     """
 
     targets = (IhexProgram,)
-
-    external_dependencies = (_BINCOPY_TOOL,)
 
     async def pack(self, resource: Resource, config=None) -> None:
         updated_segments = []
@@ -149,6 +145,9 @@ class IhexPacker(Packer[None]):
     external_dependencies = (_BINCOPY_TOOL,)
 
     async def pack(self, resource: Resource, config=None) -> None:
+        if not BINCOPY_INSTALLED:
+            raise ComponentMissingDependencyError(self, _BINCOPY_TOOL)
+
         program_child = await resource.get_only_child_as_view(IhexProgram)
         vaddr_offset = -program_child.address_limits.start
         binfile = BinFile()

--- a/ofrak_core/requirements-non-pypi.txt
+++ b/ofrak_core/requirements-non-pypi.txt
@@ -1,0 +1,2 @@
+bincopy @ git+https://github.com/eerimoq/bincopy.git@17.14.5
+binwalk @ git+https://github.com/ReFirmLabs/binwalk.git@v2.3.4

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -1,7 +1,6 @@
 aiohttp~=3.8.1
 aiohttp-cors~=0.7.0
 beartype~=0.12.0
-bincopy @ git+https://github.com/eerimoq/bincopy.git@17.14.5
 black==23.3.0
 fdt==0.3.3
 importlib-metadata>=4.13

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -56,6 +56,7 @@ setuptools.setup(
         "docs": read_requirements("requirements-docs.txt"),
         "test": ["ofrak_angr~=1.0", "ofrak_capstone~=1.0"]
         + read_requirements("requirements-test.txt"),
+        "non-pypi": read_requirements("requirements-non-pypi.txt"),
     },
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",


### PR DESCRIPTION
- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**
I added the bincopy dependency to the requirements.txt as a github link, but it turns out that blocks PyPI:
>ERROR: Packages installed from PyPI cannot depend on packages which are not also hosted on PyPI.
> ofrak depends on bincopy@ git+https://github.com/eerimoq/bincopy.git@17.14.5

So I've moved bincopy (and binwalk) into a `requirements-non-pypi.txt`, and a pip extras rule for them under "non-pypi", which is installed in the `build-image.py`. I also added the necessary ComponentExternalTool and protections in the ihex components which use `bincopy`.

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
