### PR TITLE
create root resource from directory

### DIFF
--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -92,6 +92,15 @@ class OFRAKContext:
         await root_resource.save()
         return root_resource
 
+    async def create_root_resource_from_directory(self, dir_path: str) -> Resource:
+        full_dir_path = os.path.abspath(dir_path)
+        root_resource = await self.create_root_resource(
+            os.path.basename(full_dir_path), b"", (FilesystemRoot,)
+        )
+        root_resource_v = await root_resource.view_as(FilesystemRoot)
+        await root_resource_v.initialize_from_disk(full_dir_path)
+        return root_resource
+
     async def start_context(self):
         if "_ofrak_context" in globals():
             raise InvalidStateError(

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -297,7 +297,6 @@ class Resource:
         )
 
     def _save(self) -> Tuple[List[bytes], List[DataPatch], List[MutableResourceModel]]:
-
         resources_to_delete: List[bytes] = []
         patches_to_apply: List[DataPatch] = []
         resources_to_update: List[MutableResourceModel] = []


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add new method to OFRAKContext that will create a new FilesystemRoot and all of its children from a directory path. 
**Link to Related Issue(s)**

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
