### PR TITLE
Fix GUI docs URLs in nav bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,10 +65,10 @@ nav:
           - Modifier: "user-guide/key-concepts/component/modifier.md"
           - Packer: "user-guide/key-concepts/component/packer.md"
       - GUI:
-        - Minimap View: "user-guide/key-concepts/gui/minimap.md"
-        - Keybindings: "user-guide/key-concepts/gui/keybindings.md"
-        - Settings: "user-guide/key-concepts/gui/settings.md"
-        - Projects: "user-guide/key-concepts/gui/projects.md"
+        - Minimap View: "user-guide/gui/minimap.md"
+        - Keybindings: "user-guide/gui/keybindings.md"
+        - Settings: "user-guide/gui/settings.md"
+        - Projects: "user-guide/gui/projects.md"
       - Disassembler Backends:
         - Ghidra Backend: "user-guide/disassembler-backends/ghidra.md"
         - Binary Ninja Backend: "user-guide/disassembler-backends/binary_ninja.md"


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix GUI docs nav bar URLs. Right now they 404.

**Anyone you think should look at this, specifically?**

@dannyp303 