### PR TITLE
Flush symbolic links and filesystem entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ async def main(ofrak_context: OFRAKContext, add_things_program: str):
   await root_resource.unpack_recursively(do_not_unpack=(ComplexBlock,))
   await root_resource.analyze(ProgramAttributes)
   await root_resource.run(InfiniteLoopModifier, "add_things") # things break here!
-  await root_resource.flush_to_disk("add_things_looped.elf")
+  await root_resource.flush_data_to_disk("add_things_looped.elf")
 
 if __name__ == "__main__":
     ofrak = OFRAK()

--- a/examples/ex1_simple_string_modification.py
+++ b/examples/ex1_simple_string_modification.py
@@ -41,7 +41,7 @@ async def main(ofrak_context: OFRAKContext, file_path: str, output_file_name: st
     await root_resource.run(BinaryPatchModifier, new_string_config)
 
     # Output the modified binary to the disk
-    await root_resource.flush_to_disk(output_file_name)
+    await root_resource.flush_data_to_disk(output_file_name)
     print(f"Done! Output file written to {output_file_name}")
 
 

--- a/examples/ex2_simple_code_modification.py
+++ b/examples/ex2_simple_code_modification.py
@@ -76,7 +76,7 @@ async def main(ofrak_context: OFRAKContext, file_path: str, output_file_name: st
 
     # Dump the modified program to disk
     await binary_resource.pack()
-    await binary_resource.flush_to_disk(output_file_name)
+    await binary_resource.flush_data_to_disk(output_file_name)
     print(f"Done! Output file written to {output_file_name}")
 
 

--- a/examples/ex3_binary_format_modification.py
+++ b/examples/ex3_binary_format_modification.py
@@ -51,7 +51,7 @@ async def main(ofrak_context: OFRAKContext, file_path: str, output_file_name: st
 
     # Dump the modified program to disk
     await root_resource.pack()
-    await root_resource.flush_to_disk(output_file_name)
+    await root_resource.flush_data_to_disk(output_file_name)
     print(f"Done! Output file written to {output_file_name}")
 
 

--- a/examples/ex4_filesystem_modification.py
+++ b/examples/ex4_filesystem_modification.py
@@ -60,7 +60,7 @@ async def main(ofrak_context: OFRAKContext, file_path: str, output_file_name: st
 
     # Dump the repacked file to the disk
     await root_resource.pack()
-    await root_resource.flush_to_disk(output_file_name)
+    await root_resource.flush_data_to_disk(output_file_name)
     print(f"Done! Output file written to {output_file_name}")
 
 

--- a/examples/ex5_binary_extension.py
+++ b/examples/ex5_binary_extension.py
@@ -114,7 +114,7 @@ async def main(ofrak_context: OFRAKContext, file_path: str, output_file_name: st
     await lea_instruction.modify_assembly("lea", f"rdi, [rip + {kitty_offset}]")
 
     await root_resource.pack()
-    await root_resource.flush_to_disk(output_file_name)
+    await root_resource.flush_data_to_disk(output_file_name)
     print(f"Done! Output file written to {output_file_name}")
 
 

--- a/examples/ex6_code_modification_without_extension.py
+++ b/examples/ex6_code_modification_without_extension.py
@@ -169,7 +169,7 @@ async def main(
     await root_resource.run(SegmentInjectorModifier, SegmentInjectorModifierConfig.from_fem(fem))
 
     await root_resource.pack()
-    await root_resource.flush_to_disk(output_file_name)
+    await root_resource.flush_data_to_disk(output_file_name)
     print(f"Done! Output file written to {output_file_name}")
 
 

--- a/examples/ex7_code_insertion_with_extension.py
+++ b/examples/ex7_code_insertion_with_extension.py
@@ -177,7 +177,7 @@ async def main(ofrak_context: OFRAKContext, file_path: str, output_file_name: st
     await call_new_segment_instead(root_resource, new_segment)
 
     await root_resource.pack()
-    await root_resource.flush_to_disk(output_file_name)
+    await root_resource.flush_data_to_disk(output_file_name)
 
     assert os.path.exists(output_file_name)
     assert get_file_format(output_file_name) == BinFileType.ELF

--- a/examples/ex8_recursive_unpacking.py
+++ b/examples/ex8_recursive_unpacking.py
@@ -64,7 +64,7 @@ async def main(ofrak_context: OFRAKContext, file_path: str, output_file_name: st
 
     # Repack the file automagically and save the repacked file to disk
     await root_resource.pack_recursively()
-    await root_resource.flush_to_disk(output_file_name)
+    await root_resource.flush_data_to_disk(output_file_name)
 
 
 if __name__ == "__main__":

--- a/examples/ex9_flash_modification.py
+++ b/examples/ex9_flash_modification.py
@@ -57,7 +57,7 @@ async def main(ofrak_context: OFRAKContext, in_file: str, out_file: str):
     await logical_data_resource.run(BinaryPatchModifier, patch_config)
 
     # Repack and save to disk
-    await root_resource.flush_to_disk(out_file)
+    await root_resource.flush_data_to_disk(out_file)
     print(f"Saved repacked dump to {out_file}!")
     print(await root_resource.summarize_tree())
 

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `ofrak` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Fixed
+- Improved flushing of filesystem entries (including symbolic links and other types) to disk. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
 
 ## [3.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.1.0...ofrak-v3.2.0)
 ### Added

--- a/ofrak_core/ofrak/core/elf/load_alignment_modifier.py
+++ b/ofrak_core/ofrak/core/elf/load_alignment_modifier.py
@@ -162,7 +162,7 @@ async def main(ofrak_context: OFRAKContext, file: str, output_file: str):
         for key, value in allocatable.free_space_ranges.items():
             print(f"[+] {key} free space: {hex(sum([v.length() for v in value]))} bytes")
         # print(f"[+] Fre space by permissions: {}")
-        await root_resource.flush_to_disk(output_file)
+        await root_resource.flush_data_to_disk(output_file)
         print(f"[+] Output file written to {output_file}")
     else:
         print("[+] No free space found")

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -464,7 +464,7 @@ class FilesystemRoot(ResourceView):
         while len(entries) > 0:
             entry = entries.pop(0)
             if entry.is_folder():
-                for child in await self.resource.get_children_as_view(
+                for child in await entry.resource.get_children_as_view(
                     FilesystemEntry, r_filter=ResourceFilter(tags=(FilesystemEntry,))
                 ):
                     entries.append(child)

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -162,8 +162,10 @@ class FilesystemEntry(ResourceView):
     def is_device(self) -> bool:
         return self.is_block_device() or self.is_character_device()
 
-    async def flush_to_disk(self, root_path: str = "."):
+    async def flush_to_disk(self, root_path: str = ".", filename: Optional[str] = None):
         entry_path = await self.get_path()
+        if filename is not None:
+            entry_path = os.path.join(os.path.dirname(entry_path), filename)
         if self.is_link():
             link_name = os.path.join(root_path, entry_path)
             if not os.path.exists(link_name):

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -162,6 +162,63 @@ class FilesystemEntry(ResourceView):
     def is_device(self) -> bool:
         return self.is_block_device() or self.is_character_device()
 
+    async def flush_to_disk(self, root_path: str = "."):
+        entry_path = await self.get_path()
+        if self.is_link():
+            link_name = os.path.join(root_path, entry_path)
+            if not os.path.exists(link_name):
+                link_view = await self.resource.view_as(SymbolicLink)
+                os.symlink(link_view.source_path, link_name)
+            assert len(list(await self.resource.get_children())) == 0
+            if self.stat:
+                # https://docs.python.org/3/library/os.html#os.supports_follow_symlinks
+                if os.chown in os.supports_follow_symlinks:
+                    os.chown(link_name, self.stat.st_uid, self.stat.st_gid, follow_symlinks=False)
+                if os.chmod in os.supports_follow_symlinks:
+                    os.chmod(link_name, self.stat.st_mode, follow_symlinks=False)
+                if os.utime in os.supports_follow_symlinks:
+                    os.utime(
+                        link_name,
+                        (self.stat.st_atime, self.stat.st_mtime),
+                        follow_symlinks=False,
+                    )
+            if self.xattrs:
+                for attr, value in self.xattrs.items():
+                    xattr.setxattr(link_name, attr, value, symlink=True)  # Don't follow links
+        elif self.is_folder():
+            folder_name = os.path.join(root_path, entry_path)
+            if not os.path.exists(folder_name):
+                os.makedirs(folder_name)
+        elif self.is_file():
+            file_name = os.path.join(root_path, entry_path)
+            with open(file_name, "wb") as f:
+                f.write(await self.resource.get_data())
+            self.apply_stat_attrs(file_name)
+        elif self.is_device():
+            device_name = os.path.join(root_path, entry_path)
+            if self.stat is None:
+                raise ValueError(
+                    f"Cannot create a device {entry_path} for a "
+                    f"BlockDevice or CharacterDevice resource with no stat!"
+                )
+            os.mknod(device_name, self.stat.st_mode, self.stat.st_rdev)
+            self.apply_stat_attrs(device_name)
+        elif self.is_fifo_pipe():
+            fifo_name = os.path.join(root_path, entry_path)
+            if self.stat is None:
+                raise ValueError(
+                    f"Cannot create a fifo {entry_path} for a FIFOPipe resource " "with no stat!"
+                )
+            os.mkfifo(fifo_name, self.stat.st_mode)
+            self.apply_stat_attrs(fifo_name)
+        else:
+            entry_info = f"Stat: {stat.S_IFMT(self.stat.st_mode):o}" if self.stat else ""
+            raise NotImplementedError(
+                f"FilesystemEntry {entry_path} has an unknown or "
+                f"unsupported filesystem type! Unable to create it "
+                f"on-disk. {entry_info}"
+            )
+
 
 class File(FilesystemEntry):
     """
@@ -404,68 +461,12 @@ class FilesystemRoot(ResourceView):
         ]
         while len(entries) > 0:
             entry = entries.pop(0)
-            entry_path = await entry.get_path()
-            if entry.is_link():
-                link_name = os.path.join(root_path, entry_path)
-                if not os.path.exists(link_name):
-                    link_view = await entry.resource.view_as(SymbolicLink)
-                    os.symlink(link_view.source_path, link_name)
-                assert len(list(await entry.resource.get_children())) == 0
-                if entry.stat:
-                    # https://docs.python.org/3/library/os.html#os.supports_follow_symlinks
-                    if os.chown in os.supports_follow_symlinks:
-                        os.chown(
-                            link_name, entry.stat.st_uid, entry.stat.st_gid, follow_symlinks=False
-                        )
-                    if os.chmod in os.supports_follow_symlinks:
-                        os.chmod(link_name, entry.stat.st_mode, follow_symlinks=False)
-                    if os.utime in os.supports_follow_symlinks:
-                        os.utime(
-                            link_name,
-                            (entry.stat.st_atime, entry.stat.st_mtime),
-                            follow_symlinks=False,
-                        )
-                if entry.xattrs:
-                    for attr, value in entry.xattrs.items():
-                        xattr.setxattr(link_name, attr, value, symlink=True)  # Don't follow links
-            elif entry.is_folder():
-                folder_name = os.path.join(root_path, entry_path)
-                if not os.path.exists(folder_name):
-                    os.makedirs(folder_name)
-                for child in await entry.resource.get_children_as_view(
+            if entry.is_folder():
+                for child in await self.resource.get_children_as_view(
                     FilesystemEntry, r_filter=ResourceFilter(tags=(FilesystemEntry,))
                 ):
                     entries.append(child)
-            elif entry.is_file():
-                file_name = os.path.join(root_path, entry_path)
-                with open(file_name, "wb") as f:
-                    f.write(await entry.resource.get_data())
-                entry.apply_stat_attrs(file_name)
-            elif entry.is_device():
-                device_name = os.path.join(root_path, entry_path)
-                if entry.stat is None:
-                    raise ValueError(
-                        f"Cannot create a device {entry_path} for a "
-                        f"BlockDevice or CharacterDevice resource with no stat!"
-                    )
-                os.mknod(device_name, entry.stat.st_mode, entry.stat.st_rdev)
-                entry.apply_stat_attrs(device_name)
-            elif entry.is_fifo_pipe():
-                fifo_name = os.path.join(root_path, entry_path)
-                if entry.stat is None:
-                    raise ValueError(
-                        f"Cannot create a fifo {entry_path} for a FIFOPipe resource "
-                        "with no stat!"
-                    )
-                os.mkfifo(fifo_name, entry.stat.st_mode)
-                entry.apply_stat_attrs(fifo_name)
-            else:
-                entry_info = f"Stat: {stat.S_IFMT(entry.stat.st_mode):o}" if entry.stat else ""
-                raise NotImplementedError(
-                    f"FilesystemEntry {entry_path} has an unknown or "
-                    f"unsupported filesystem type! Unable to create it "
-                    f"on-disk. {entry_info}"
-                )
+            await entry.flush_to_disk(root_path=root_path)
 
         return root_path
 

--- a/ofrak_core/ofrak/core/ubi.py
+++ b/ofrak_core/ofrak/core/ubi.py
@@ -257,7 +257,7 @@ class UbiPacker(Packer[None]):
                     volume_path = (
                         f"{temp_flush_dir}/input-{ubi_view.image_seq}_vol-{volume_view.name}.ubivol"
                     )
-                    await volume.flush_to_disk(volume_path)
+                    await volume.flush_data_to_disk(volume_path)
                 else:
                     volume_path = None
                     volume_size = (volume_view.peb_count - 1) * ubi_view.peb_size

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -22,7 +22,6 @@ from typing import (
 )
 
 from ofrak.component.interface import ComponentInterface
-from ofrak.core import FilesystemEntry
 from ofrak.model.component_model import ComponentContext, CC, ComponentRunResult
 from ofrak.model.data_model import DataPatch
 from ofrak.model.job_model import (
@@ -1430,7 +1429,7 @@ class Resource:
         self._resource.is_modified = True
         self._resource.is_deleted = True
 
-    async def flush_to_disk(self, path: str, pack: bool = True):
+    async def flush_data_to_disk(self, path: str, pack: bool = True):
         """
         Recursively repack the resource and write its data out to a file on disk. If this is a
         dataless resource, creates an empty file.
@@ -1439,11 +1438,6 @@ class Resource:
         """
         if pack is True:
             await self.pack_recursively()
-
-        if self.has_tag(FilesystemEntry):
-            entry = await self.view_as(FilesystemEntry)
-            await entry.flush_to_disk(filename=path)
-            return
 
         data = await self.get_data()
         if data is not None:

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -22,6 +22,7 @@ from typing import (
 )
 
 from ofrak.component.interface import ComponentInterface
+from ofrak.core import FilesystemEntry
 from ofrak.model.component_model import ComponentContext, CC, ComponentRunResult
 from ofrak.model.data_model import DataPatch
 from ofrak.model.job_model import (
@@ -1438,6 +1439,12 @@ class Resource:
         """
         if pack is True:
             await self.pack_recursively()
+
+        if self.has_tag(FilesystemEntry):
+            entry = await self.view_as(FilesystemEntry)
+            # TODO: Fix path name ignore
+            await entry.flush_to_disk(root_path=path)
+            return
 
         data = await self.get_data()
         if data is not None:

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -1442,8 +1442,7 @@ class Resource:
 
         if self.has_tag(FilesystemEntry):
             entry = await self.view_as(FilesystemEntry)
-            # TODO: Fix path name ignore
-            await entry.flush_to_disk(root_path=path)
+            await entry.flush_to_disk(filename=path)
             return
 
         data = await self.get_data()

--- a/ofrak_core/test_ofrak/components/test_elf_modifiers.py
+++ b/ofrak_core/test_ofrak/components/test_elf_modifiers.py
@@ -56,7 +56,7 @@ async def test_elf_add_symbols(
     await original_elf.run(ElfAddStringModifier, ElfAddStringModifierConfig(strings_to_add))
 
     output_path = os.path.join(elf_test_directory, "program_with_newstrings")
-    await original_elf.flush_to_disk(output_path)
+    await original_elf.flush_data_to_disk(output_path)
     strings_result = subprocess.run(["strings", output_path], capture_output=True)
     new_strings = set(strings_result.stdout.decode().split("\n"))
 
@@ -92,7 +92,7 @@ async def test_elf_force_relocation(
         ElfRelocateSymbolsModifierConfig({foo_vaddr: bar_vaddr, bar_vaddr: foo_vaddr}),
     )
 
-    await elf.resource.flush_to_disk(os.path.join(elf_test_directory, "program_relocated.o"))
+    await elf.resource.flush_data_to_disk(os.path.join(elf_test_directory, "program_relocated.o"))
     subprocess.run(["make", "-C", elf_test_directory, "program_relocated"])
     result = subprocess.run([os.path.join(elf_test_directory, "program_relocated")])
     assert result.returncode == 24
@@ -146,7 +146,7 @@ async def test_modifier(
         for entry in await view.get_entries():
             await entry.resource.run(modifier, modifier_config)
     mod_path = elf_executable_file + "_mod"
-    await elf.resource.flush_to_disk(mod_path)
+    await elf.resource.flush_data_to_disk(mod_path)
     mod_elf = await ofrak_context.create_root_resource_from_file(mod_path)
     await mod_elf.unpack()
     views = list(
@@ -229,7 +229,7 @@ async def test_lief_add_segment_modifier(hello_out: Resource, tmp_path):
 
     # Assert new segment not in original binary
     original_path = tmp_path / "original"
-    await hello_out.flush_to_disk(original_path)
+    await hello_out.flush_data_to_disk(original_path)
     with pytest.raises(ValueError):
         assert_segment_exists(original_path, segment_vaddr, segment_length)
 
@@ -239,7 +239,7 @@ async def test_lief_add_segment_modifier(hello_out: Resource, tmp_path):
 
     # Assert new segment is in extended binary
     extended_path = tmp_path / "extended"
-    await hello_out.flush_to_disk(extended_path)
+    await hello_out.flush_data_to_disk(extended_path)
     assert_segment_exists(extended_path, segment_vaddr, 0x2000)
 
 

--- a/ofrak_core/test_ofrak/components/test_patch_from_source.py
+++ b/ofrak_core/test_ofrak/components/test_patch_from_source.py
@@ -145,7 +145,7 @@ async def test_patch_from_source_modifier(
     await call_new_segment_instead(resource, new_segment)
 
     await resource.pack()
-    await resource.flush_to_disk(output_file_name)
+    await resource.flush_data_to_disk(output_file_name)
 
     assert os.path.exists(output_file_name)
     assert get_file_format(output_file_name) == BinFileType.ELF

--- a/ofrak_core/test_ofrak/components/test_patch_maker_component.py
+++ b/ofrak_core/test_ofrak/components/test_patch_maker_component.py
@@ -230,7 +230,7 @@ async def test_function_replacement_modifier(ofrak_context: OFRAKContext, config
 
     await target_program.resource.run(FunctionReplacementModifier, function_replacement_config)
     new_program_path = f"replaced_{Path(config.program.path).name}"
-    await target_program.resource.flush_to_disk(new_program_path)
+    await target_program.resource.flush_data_to_disk(new_program_path)
 
     # Check that the modified program looks as expected.
     readobj_path = get_repository_config(config.toolchain_name, "BIN_PARSER")

--- a/ofrak_core/test_ofrak/unit/test_resource.py
+++ b/ofrak_core/test_ofrak/unit/test_resource.py
@@ -212,9 +212,9 @@ async def test_flush_to_disk_pack(ofrak_context: OFRAKContext):
     with tempfile.NamedTemporaryFile() as t:
         # again, should fail because the packer is run automatically
         with pytest.raises(MockFailException):
-            await root_resource.flush_to_disk(t.name)
+            await root_resource.flush_data_to_disk(t.name)
 
-        await root_resource.flush_to_disk(t.name, pack=False)
+        await root_resource.flush_data_to_disk(t.name, pack=False)
 
 
 async def test_is_modified(resource: Resource):

--- a/ofrak_tutorial/notebooks_with_outputs/1_simple_string_modification.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/1_simple_string_modification.ipynb
@@ -65,7 +65,7 @@
     "    await root_resource.run(BinaryPatchModifier, BinaryPatchConfig(hello_world_offset, b\"Meow!\\0\"))\n",
     "\n",
     "    # Flush the modified program to disk\n",
-    "    await root_resource.flush_to_disk(output_filename)"
+    "    await root_resource.flush_data_to_disk(output_filename)"
    ]
   },
   {

--- a/ofrak_tutorial/notebooks_with_outputs/3_binary_format_modification.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/3_binary_format_modification.ipynb
@@ -337,7 +337,7 @@
     "    await make_program_header_noexec(exec_load_program_header)\n",
     "\n",
     "    await root_resource.pack()\n",
-    "    await root_resource.flush_to_disk(output_filename)\n",
+    "    await root_resource.flush_data_to_disk(output_filename)\n",
     "\n",
     "\n",
     "await make_elf_load_header_noexec(basic_context, \"hello_world\", \"nohello_world\")"

--- a/ofrak_tutorial/notebooks_with_outputs/4_simple_code_modification.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/4_simple_code_modification.ipynb
@@ -339,7 +339,7 @@
     "    )\n",
     "\n",
     "    await root_resource.pack()\n",
-    "    await root_resource.flush_to_disk(output_filename)\n",
+    "    await root_resource.flush_data_to_disk(output_filename)\n",
     "\n",
     "\n",
     "await chase_tail(binary_analysis_context, \"hello_world\", \"hello_world_forever\")\n",

--- a/ofrak_tutorial/notebooks_with_outputs/5_filesystem_modification.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/5_filesystem_modification.ipynb
@@ -220,7 +220,7 @@
     "    await hello_world_program.modify_xattr_attribute(\"user.foo\", \"bar\".encode(\"utf-8\"))\n",
     "\n",
     "    await root_resource.pack()\n",
-    "    await root_resource.flush_to_disk(output_filename)"
+    "    await root_resource.flush_data_to_disk(output_filename)"
    ]
   },
   {

--- a/ofrak_tutorial/notebooks_with_outputs/6_code_insertion_with_extension.ipynb
+++ b/ofrak_tutorial/notebooks_with_outputs/6_code_insertion_with_extension.ipynb
@@ -890,7 +890,7 @@
    "outputs": [],
    "source": [
     "await root_resource.pack()\n",
-    "await root_resource.flush_to_disk(output_filename)"
+    "await root_resource.flush_data_to_disk(output_filename)"
    ]
   },
   {


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Better flushing of files to disk.

**Link to Related Issue(s)**

#362 

**Please describe the changes in your request.**

- Add `FilesystemEntry.flush_to_disk` (previously only in `FilesystemRoot`)
- Refactor `FilesystemRoot.flush_to_disk` to use `FilesystemEntry.flush_to_disk`
- Rename `Resource.flush_to_disk` to the more accurate `Resource.flush_data_to_didsk` to indicate that it only flushes data, not any attributes

**Anyone you think should look at this, specifically?**

@EdwardLarson 
