### PR TITLE
Ghidra custom "loader"

### DIFF
--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -365,7 +365,6 @@ class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
         args: List[str] = []
 
         for i, block in enumerate(blocks):
-
             block_info: List[str] = [
                 str(block.virtual_address),
                 str(block.size),

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -365,6 +365,9 @@ class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
         if default_proc_id_found:
             return default_proc_id
 
+        if len(processors_rejected) == 1:
+            return processors_rejected.pop()
+
         raise GhidraComponentException(
             f"Could not determine a Ghidra language spec for the given architecture info "
             f"{processor}. Considered the following specs:\n{', '.join(processors_rejected)}"

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -4,11 +4,13 @@ import logging
 import os
 import tempfile
 import time
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional, List, Dict
+from xml.etree import ElementTree
 
 from ofrak import ResourceFilter
-from ofrak.core import CodeRegion
+from ofrak.core import CodeRegion, MemoryRegion, NamedProgramSection, ProgramAttributes, Program
 from ofrak.component.analyzer import Analyzer
 from ofrak.component.modifier import Modifier
 from ofrak.model.component_model import ComponentConfig
@@ -26,13 +28,17 @@ from ofrak_ghidra.constants import (
     GHIDRA_SERVER_PORT,
     GHIDRA_LOG_FILE,
     CORE_OFRAK_GHIDRA_SCRIPTS,
+    GHIDRA_PATH,
 )
 from ofrak_ghidra.ghidra_model import (
     GhidraProject,
     OfrakGhidraScript,
     OfrakGhidraMixin,
     GhidraComponentException,
+    GhidraCustomLoadProject,
+    GhidraAutoLoadProject,
 )
+from ofrak_type import ArchInfo, InstructionSet, Endianness
 
 LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +57,38 @@ class GhidraProjectConfig(ComponentConfig):
     ghidra_zip_file: str
 
 
-class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProject]):
+@dataclass
+class GhidraProgramLoadConfig(ComponentConfig):
+    """
+    Config for GhidraProjectAnalyzer to pass in a pre-analyzed Ghidra project for a binary as a
+    Ghidra Zip file.
+
+    A Ghidra Zip File can be exported from Ghidra's project window, right-clicking on an analyzed
+    file and "Export...". Then select the Ghidra Zip File format and save the file. This will
+    create a .gzf file that you can import with this GhidraProjectConfig.
+    """
+
+    ghidra_zip_file: str
+
+
+#
+#
+
+
+#
+#
+# class _GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProject]):
+#     id = b"GhidraProjectAnalyzer"
+#     targets = (GhidraProject,)
+#     outputs = (GhidraProject,)
+#
+#     """
+#     Legacy
+#     TODO
+#     """
+
+
+class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
     """
     Use Ghidra backend to create project for and analyze a binary. This analyzer must run before
     Ghidra analysis can be accessed from OFRAK. This Analyzer can either create a new project and
@@ -59,7 +96,7 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
     """
 
     id = b"GhidraProjectAnalyzer"
-    targets = (GhidraProject,)
+    targets = (GhidraAutoLoadProject,)
     outputs = (GhidraProject,)
 
     def __init__(
@@ -86,13 +123,14 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
                 self._script_directories.add(script.script_dir)
                 self._scripts.add(script.script_name)
 
-    async def analyze(
-        self, resource: Resource, config: Optional[GhidraProjectConfig] = None
-    ) -> GhidraProject:
+    @asynccontextmanager
+    async def _prepare_ghidra_project(
+        self, resource: Resource, ghidra_zip_file: Optional[str] = None
+    ):
         # TODO: allow multiple headless server instances
         os.system("pkill -if analyzeHeadless")
-        if config is not None:
-            full_fname = config.ghidra_zip_file
+        if ghidra_zip_file is not None:
+            full_fname = ghidra_zip_file
             tmp_dir = None
         else:
             tmp_dir = tempfile.TemporaryDirectory()
@@ -106,17 +144,40 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
 
         ghidra_project = f"ghidra://{GHIDRA_REPOSITORY_HOST}:{GHIDRA_REPOSITORY_PORT}/ofrak"
 
-        program_name = await self._do_ghidra_import(ghidra_project, full_fname)
-        await self._do_ghidra_analyze_and_serve(
-            ghidra_project, program_name, skip_analysis=config is not None
-        )
+        try:
+            yield ghidra_project, full_fname
+        finally:
+            if tmp_dir is not None:
+                tmp_dir.cleanup()
 
-        if tmp_dir:
-            tmp_dir.cleanup()
+    async def analyze(
+        self, resource: Resource, config: Optional[GhidraProjectConfig] = None
+    ) -> GhidraProject:
 
-        return GhidraProject(ghidra_project, f"http://{GHIDRA_SERVER_HOST}:{GHIDRA_SERVER_PORT}")
+        gzf = config.ghidra_zip_file if config is not None else None
 
-    async def _do_ghidra_import(self, ghidra_project: str, full_fname: str):
+        async with self._prepare_ghidra_project(resource, gzf) as (ghidra_project, full_fname):
+            program_name = await self._do_ghidra_import(
+                ghidra_project, full_fname, use_binary_loader=False
+            )
+            await self._do_ghidra_analyze_and_serve(
+                ghidra_project,
+                program_name,
+                skip_analysis=config is not None,
+            )
+
+            return GhidraProject(
+                ghidra_project, f"http://{GHIDRA_SERVER_HOST}:{GHIDRA_SERVER_PORT}"
+            )
+
+    async def _do_ghidra_import(
+        self,
+        ghidra_project: str,
+        full_fname: str,
+        use_binary_loader: bool,
+        processor: Optional[ArchInfo] = None,
+        blocks: Optional[List[MemoryRegion]] = None,
+    ):
         args = [
             ghidra_project,
             "-connect",
@@ -126,6 +187,18 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
             full_fname,
             "-overwrite",
         ]
+
+        if use_binary_loader:
+            args.extend(["-loader", "BinaryLoader"])
+
+        if processor:
+            processor_id = self._arch_info_to_processor_id(processor)
+            args.extend(["-processor", processor_id])
+
+        if blocks is not None:
+            args.extend(["-scriptPath", (";".join(self._script_directories))])
+            args.extend(["-preScript", "CreateMemoryBlocks.java"])
+            args.extend(await self._build_create_memory_args(blocks))
 
         cmd_str = " ".join([GHIDRA_HEADLESS_EXEC] + args)
         LOGGER.debug(f"Running command: {cmd_str}")
@@ -172,7 +245,10 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
                 return program_name
 
     async def _do_ghidra_analyze_and_serve(
-        self, ghidra_project: str, program_name: str, skip_analysis: bool
+        self,
+        ghidra_project: str,
+        program_name: str,
+        skip_analysis: bool,
     ):
         args = [
             ghidra_project,
@@ -230,6 +306,97 @@ class GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProjec
 
         return args
 
+    def _arch_info_to_processor_id(self, processor: ArchInfo):
+        # return "ARM:BE:32:v8T"
+
+        families: Dict[InstructionSet, str] = {
+            InstructionSet.ARM: "ARM",
+            InstructionSet.AARCH64: "AARCH64",
+            InstructionSet.MIPS: "MIPS",
+            InstructionSet.PPC: "PowerPC",
+            InstructionSet.M68K: "68000",
+            InstructionSet.X86: "x86",
+        }
+        family = families.get(processor.isa)
+
+        endian = "BE" if processor.endianness is Endianness.BIG_ENDIAN else "LE"
+        # sub = "default"
+        partial_proc_id = f"{family}:{endian}:{processor.bit_width.value}"
+        default_proc_id = f"{partial_proc_id}:default"
+
+        ldefs = os.path.join(GHIDRA_PATH, "Ghidra", "Processors", family, "data", "languages")
+        processors_rejected = set()
+        default_proc_id_found = False
+        for file in os.listdir(ldefs):
+            if not file.endswith(".ldefs"):
+                continue
+
+            tree = ElementTree.parse(os.path.join(ldefs, file))
+            for language in tree.getroot().iter(tag="language"):
+                proc_id = language.attrib["id"]
+                # Ghidra has a list of alternative names for each support language spec
+                # This is useful and interesting, for example it has the IDA equivalent name
+                if not proc_id.startswith(partial_proc_id):
+                    # Don't even consider language if it doesn't match ISA, bitwidth, endianness
+                    continue
+                if proc_id == default_proc_id:
+                    default_proc_id_found = True
+
+                for name_elem in language.iter(tag="external_name"):
+                    name = name_elem.attrib["name"].lower()
+
+                    if not processor.sub_isa and not processor.processor:
+                        if name.endswith("_any"):
+                            return proc_id
+
+                    if processor.sub_isa and processor.sub_isa.value.lower() == name:
+                        return proc_id
+
+                    if processor.processor and processor.processor.value.lower() == name:
+                        return proc_id
+
+                processors_rejected.add(proc_id)
+
+        if default_proc_id_found:
+            return default_proc_id
+
+        raise GhidraComponentException(
+            f"Could not determine a Ghidra language spec for the given architecture info "
+            f"{processor}. Considered the following specs:\n{', '.join(processors_rejected)}"
+        )
+
+    async def _build_create_memory_args(self, blocks: List[MemoryRegion]) -> List[str]:
+        args: List[str] = []
+
+        for i, block in enumerate(blocks):
+
+            block_info: List[str] = [
+                str(block.virtual_address),
+                str(block.size),
+            ]
+
+            if block.resource.has_tag(CodeRegion):
+                block_info.append("rx")
+            else:
+                block_info.append("rw")
+
+            if block.resource.has_tag(NamedProgramSection):
+                named_section = await block.resource.view_as(NamedProgramSection)
+                block_info.append(named_section.name)
+            else:
+                block_info.append(f"block_{i}")
+
+            try:
+                block_offset_range = await block.resource.get_data_range_within_parent()
+                block_info.append(str(block_offset_range.start))
+            except ValueError:
+                # region has no data
+                block_info.append("-1")
+
+            args.append("!".join(block_info))
+
+        return args
+
 
 class GhidraCodeRegionModifier(Modifier, OfrakGhidraMixin):
     id = b"GhidraCodeRegionModifier"
@@ -274,3 +441,40 @@ class GhidraCodeRegionModifier(Modifier, OfrakGhidraMixin):
             )
         else:
             LOGGER.debug("No OFRAK code regions to match in Ghidra")
+
+
+class GhidraCustomLoadAnalyzer(GhidraProjectAnalyzer):
+    id = b"GhidraCustomLoadProjectAnalyzer"
+    targets = (GhidraCustomLoadProject,)
+    outputs = (GhidraCustomLoadProject,)
+
+    async def analyze(
+        self, resource: Resource, config: Optional[GhidraProjectConfig] = None
+    ) -> GhidraProject:
+
+        arch_info: ArchInfo = await resource.analyze(ProgramAttributes)
+        mem_blocks = await self._get_memory_blocks(await resource.view_as(Program))
+
+        async with self._prepare_ghidra_project(resource) as (ghidra_project, full_fname):
+            program_name = await self._do_ghidra_import(
+                ghidra_project,
+                full_fname,
+                use_binary_loader=True,
+                processor=arch_info,
+                blocks=mem_blocks,
+            )
+            await self._do_ghidra_analyze_and_serve(
+                ghidra_project,
+                program_name,
+                skip_analysis=config is not None,
+            )
+
+            return GhidraProject(
+                ghidra_project, f"http://{GHIDRA_SERVER_HOST}:{GHIDRA_SERVER_PORT}"
+            )
+
+    async def _get_memory_blocks(self, program: Program):
+        mem_regions = await program.resource.get_children_as_view(
+            MemoryRegion, r_filter=ResourceFilter.with_tags(MemoryRegion)
+        )
+        return list(mem_regions)

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -72,23 +72,6 @@ class GhidraProgramLoadConfig(ComponentConfig):
     ghidra_zip_file: str
 
 
-#
-#
-
-
-#
-#
-# class _GhidraProjectAnalyzer(Analyzer[Optional[GhidraProjectConfig], GhidraProject]):
-#     id = b"GhidraProjectAnalyzer"
-#     targets = (GhidraProject,)
-#     outputs = (GhidraProject,)
-#
-#     """
-#     Legacy
-#     TODO
-#     """
-
-
 class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
     """
     Use Ghidra backend to create project for and analyze a binary. This analyzer must run before

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/identifiers.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/identifiers.py
@@ -1,11 +1,11 @@
 from ofrak.component.identifier import Identifier
-from ofrak.core import Elf, Ihex
+from ofrak.core import Elf, Ihex, Pe
 from ofrak.core.program import Program
 from ofrak.resource import Resource
 from ofrak_ghidra.ghidra_model import GhidraAutoLoadProject, GhidraCustomLoadProject
 
 
-_GHIDRA_AUTO_LOADABLE_FORMATS = [Elf, Ihex]
+_GHIDRA_AUTO_LOADABLE_FORMATS = [Elf, Ihex, Pe]
 
 
 class GhidraAnalysisIdentifier(Identifier):

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/identifiers.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/identifiers.py
@@ -1,7 +1,11 @@
 from ofrak.component.identifier import Identifier
+from ofrak.core import Elf, Ihex
 from ofrak.core.program import Program
 from ofrak.resource import Resource
-from ofrak_ghidra.ghidra_model import GhidraProject
+from ofrak_ghidra.ghidra_model import GhidraAutoLoadProject, GhidraCustomLoadProject
+
+
+_GHIDRA_AUTO_LOADABLE_FORMATS = [Elf, Ihex]
 
 
 class GhidraAnalysisIdentifier(Identifier):
@@ -14,4 +18,9 @@ class GhidraAnalysisIdentifier(Identifier):
     targets = (Program,)
 
     async def identify(self, resource: Resource, config=None):
-        resource.add_tag(GhidraProject)
+        for tag in _GHIDRA_AUTO_LOADABLE_FORMATS:
+            if resource.has_tag(tag):
+                resource.add_tag(GhidraAutoLoadProject)
+                return
+
+        resource.add_tag(GhidraCustomLoadProject)

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_model.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_model.py
@@ -22,7 +22,7 @@ class GhidraProject(ResourceView):
 @dataclass
 class GhidraAutoLoadProject(GhidraProject):
     """
-    A resource which Ghidra can automatically load with one of its existing Loaders (e.g. ELF)
+    A resource which Ghidra can automatically load with one of its existing Loaders (e.g. ELF).
     """
 
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_model.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_model.py
@@ -19,6 +19,21 @@ class GhidraProject(ResourceView):
     ghidra_url: str
 
 
+@dataclass
+class GhidraAutoLoadProject(GhidraProject):
+    """
+    A resource which Ghidra can automatically load with one of its existing Loaders (e.g. ELF)
+    """
+
+
+@dataclass
+class GhidraCustomLoadProject(GhidraProject):
+    """
+    A resource which Ghidra does not have an existing loader for and cannot load automatically.
+    Before analysis, we need to inform Ghidra of correct processor and segments.
+    """
+
+
 class GhidraComponentException(Exception):
     pass
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/CreateMemoryBlocks.java
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/CreateMemoryBlocks.java
@@ -52,8 +52,7 @@ public class CreateMemoryBlocks extends HeadlessScript {
 
     @Override
     public void run() throws Exception {
-        //String[] args = getScriptArgs();
-	String[] args = {"4096!4096!rw!block_0!4096", "8192!4096!rx!block_1!8192", "0!4096!rw!FIRST_SECTION!0"};
+        String[] args = getScriptArgs();
 
         Memory mem = currentProgram.getMemory();
         FileBytes fileBytes = mem.getAllFileBytes().get(0);
@@ -84,19 +83,7 @@ public class CreateMemoryBlocks extends HeadlessScript {
                 block.setPermissions(
                     permissions.contains("r"), permissions.contains("w"), permissions.contains("x")
                 );
-            } catch (LockException e) {
-                    e.printStackTrace();
-                    continue;
-            } catch (IllegalArgumentException e) {
-                    e.printStackTrace();
-                    continue;
-            } catch (IndexOutOfBoundsException e) {
-                    e.printStackTrace();
-                    continue;
-            } catch (MemoryConflictException e) {
-                    e.printStackTrace();
-                    throw e;
-            } catch (AddressOverflowException e) {
+            } catch (Exception e) {
                     e.printStackTrace();
                     continue;
             }

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/CreateMemoryBlocks.java
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/CreateMemoryBlocks.java
@@ -1,0 +1,93 @@
+import com.google.common.base.Strings;
+import com.google.common.base.Strings;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import ghidra.app.util.headless.HeadlessScript;
+import ghidra.app.script.GhidraState;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressRange;
+import ghidra.program.model.address.AddressRangeIterator;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.block.BasicBlockModel;
+import ghidra.program.model.block.CodeBlock;
+import ghidra.program.model.block.CodeBlockIterator;
+import ghidra.program.model.block.CodeBlockModel;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.mem.MemoryBlockSourceInfo;
+import ghidra.program.model.pcode.PcodeOp;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.task.TaskMonitor;
+import ghidra.program.model.lang.Register;
+import ghidra.program.model.lang.RegisterValue;
+import java.math.BigInteger;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.block.CodeBlockReferenceIterator;
+import ghidra.program.model.symbol.ReferenceIterator;
+import ghidra.program.model.symbol.RefType;
+import ghidra.framework.store.LockException;
+import ghidra.util.exception.DuplicateNameException;
+import ghidra.program.model.mem.MemoryConflictException;
+import ghidra.program.model.address.AddressOverflowException;
+import ghidra.program.database.mem.FileBytes;
+
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.*;
+import java.lang.IllegalArgumentException;
+import java.lang.IndexOutOfBoundsException;
+
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+public class CreateMemoryBlocks extends HeadlessScript {
+
+    @Override
+    public void run() throws Exception {
+        String[] args = getScriptArgs();
+
+        Memory mem = currentProgram.getMemory();
+        FileBytes fileBytes = mem.getAllFileBytes().get(0);
+
+        for (String memRegionRaw : args) {
+
+            String[] memRegionInfo = memRegionRaw.split("!");
+
+            int address = Integer.parseInt(memRegionInfo[0]);
+            int size = Integer.parseInt(memRegionInfo[1]);
+            String permissions = memRegionInfo[2];
+            String name = memRegionInfo[3];
+            int offset = Integer.parseInt(memRegionInfo[4]);
+
+            MemoryBlock block;
+
+            try {
+                if (offset >= 0){
+                    block = mem.createInitializedBlock(name, toAddr(address), fileBytes, offset, size, true);
+                } else {
+                    block = mem.createUninitializedBlock(name, toAddr(address), size, false);
+                }
+                block.setPermissions(
+                    permissions.contains("r"), permissions.contains("w"), permissions.contains("x")
+                );
+            } catch (LockException e) {
+                    e.printStackTrace();
+            } catch (IllegalArgumentException e) {
+                    e.printStackTrace();
+            } catch (IndexOutOfBoundsException e) {
+                    e.printStackTrace();
+            } catch (MemoryConflictException e) {
+                    e.printStackTrace();
+            } catch (AddressOverflowException e) {
+                    e.printStackTrace();
+            }
+
+
+        }
+    }
+
+
+}

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/conftest.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/conftest.py
@@ -1,4 +1,5 @@
 from ofrak import OFRAKContext
+from ofrak.core import Elf
 from ofrak.resource import Resource
 
 import ofrak_ghidra
@@ -26,6 +27,7 @@ async def hello_world_elf_resource(
     resource = await ofrak_context.create_root_resource(
         test_id,
         hello_world_elf,
+        tags=(Elf,),
     )
     return resource
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/conftest.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/conftest.py
@@ -1,5 +1,4 @@
 from ofrak import OFRAKContext
-from ofrak.core.program import Program
 from ofrak.resource import Resource
 
 import ofrak_ghidra
@@ -24,7 +23,10 @@ def ghidra_components(ofrak_injector):
 async def hello_world_elf_resource(
     hello_world_elf, ofrak_context: OFRAKContext, test_id: str
 ) -> Resource:
-    resource = await ofrak_context.create_root_resource(test_id, hello_world_elf, tags=(Program,))
+    resource = await ofrak_context.create_root_resource(
+        test_id,
+        hello_world_elf,
+    )
     return resource
 
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
@@ -21,9 +21,11 @@ from ofrak_ghidra.ghidra_model import GhidraProject, GhidraCustomLoadProject
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.abstract import Toolchain
+from ofrak_patch_maker.toolchain.gnu_aarch64 import GNU_AARCH64_LINUX_10_Toolchain
 from ofrak_patch_maker.toolchain.gnu_arm import GNU_ARM_NONE_EABI_10_2_1_Toolchain
 from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_10_Toolchain
 from ofrak_patch_maker.toolchain.gnu_vbcc_m68k import VBCC_0_9_GNU_Hybrid_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_10_3_0_Toolchain
 from ofrak_patch_maker.toolchain.model import (
     ToolchainConfig,
     CompilerOptimizationLevel,
@@ -67,6 +69,20 @@ async def test_ghidra_project_analyzer(hello_world_elf_resource: Resource):
             InstructionSet.M68K,
             None,
             BitWidth.BIT_32,
+            Endianness.BIG_ENDIAN,
+            None,
+        ),
+        ProgramAttributes(
+            InstructionSet.X86,
+            None,
+            BitWidth.BIT_64,
+            Endianness.LITTLE_ENDIAN,
+            None,
+        ),
+        ProgramAttributes(
+            InstructionSet.AARCH64,
+            None,
+            BitWidth.BIT_64,
             Endianness.BIG_ENDIAN,
             None,
         ),
@@ -142,6 +158,8 @@ async def _make_dummy_program(resource: Resource, arch_info):
         InstructionSet.PPC: GNU_PPC_LINUX_10_Toolchain,
         InstructionSet.ARM: GNU_ARM_NONE_EABI_10_2_1_Toolchain,
         InstructionSet.M68K: VBCC_0_9_GNU_Hybrid_Toolchain,
+        InstructionSet.AARCH64: GNU_AARCH64_LINUX_10_Toolchain,
+        InstructionSet.X86: GNU_X86_64_LINUX_EABI_10_3_0_Toolchain,
     }
 
     tc = arch_map[arch_info.isa](

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
@@ -110,7 +110,7 @@ async def test_ghidra_custom_loader(ofrak_context: OFRAKContext, arch_info: Prog
 
     await _make_dummy_program(prog, arch_info)
 
-    await prog.flush_to_disk("/transfer/dummy_program")
+    await prog.flush_data_to_disk("/transfer/dummy_program")
 
     await prog.identify()
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
@@ -110,17 +110,13 @@ async def test_ghidra_custom_loader(ofrak_context: OFRAKContext, arch_info: Prog
 
     await _make_dummy_program(prog, arch_info)
 
-    await prog.flush_data_to_disk("/transfer/dummy_program")
-
     await prog.identify()
-
     assert prog.has_tag(GhidraCustomLoadProject)
 
     ghidra_project = await prog.view_as(GhidraProject)
     assert isinstance(ghidra_project, GhidraProject)
 
     await cr_child.unpack()
-
     children = list(await cr_child.get_children())
     assert 2 == len(children)
 

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
@@ -1,3 +1,10 @@
+import os.path
+import os.path
+import tempfile
+from typing import Dict, Type
+
+import pytest
+
 from ofrak import OFRAKContext
 from ofrak.core import (
     Program,
@@ -6,10 +13,24 @@ from ofrak.core import (
     MemoryRegion,
     CodeRegion,
     Elf,
+    SegmentInjectorModifier,
+    SegmentInjectorModifierConfig,
 )
 from ofrak.resource import Resource
 from ofrak_ghidra.ghidra_model import GhidraProject, GhidraCustomLoadProject
-from ofrak_type import BitWidth, Endianness, InstructionSet
+from ofrak_patch_maker.model import PatchRegionConfig
+from ofrak_patch_maker.patch_maker import PatchMaker
+from ofrak_patch_maker.toolchain.abstract import Toolchain
+from ofrak_patch_maker.toolchain.gnu_arm import GNU_ARM_NONE_EABI_10_2_1_Toolchain
+from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu_vbcc_m68k import VBCC_0_9_GNU_Hybrid_Toolchain
+from ofrak_patch_maker.toolchain.model import (
+    ToolchainConfig,
+    CompilerOptimizationLevel,
+    BinFileType,
+    Segment,
+)
+from ofrak_type import BitWidth, Endianness, InstructionSet, MemoryPermissions, Range
 
 
 async def test_ghidra_project_analyzer(hello_world_elf_resource: Resource):
@@ -25,26 +46,55 @@ async def test_ghidra_project_analyzer(hello_world_elf_resource: Resource):
     assert isinstance(ghidra_project, GhidraProject)
 
 
-async def test_ghidra_custom_loader(ofrak_context: OFRAKContext):
+@pytest.mark.parametrize(
+    "arch_info",
+    [
+        ProgramAttributes(
+            InstructionSet.PPC,
+            None,
+            BitWidth.BIT_32,
+            Endianness.BIG_ENDIAN,
+            None,
+        ),
+        ProgramAttributes(
+            InstructionSet.ARM,
+            None,
+            BitWidth.BIT_32,
+            Endianness.LITTLE_ENDIAN,
+            None,
+        ),
+        ProgramAttributes(
+            InstructionSet.M68K,
+            None,
+            BitWidth.BIT_32,
+            Endianness.BIG_ENDIAN,
+            None,
+        ),
+    ],
+    ids=lambda arch_info: f"{arch_info.isa.name}-{arch_info.bit_width.value}-{arch_info.endianness.value}",
+)
+async def test_ghidra_custom_loader(ofrak_context: OFRAKContext, arch_info: ProgramAttributes):
     file_data = b"\xed" * 0x10000
 
     prog = await ofrak_context.create_root_resource("test_custom_load", data=file_data)
 
     prog.add_tag(Program)
-    prog.add_attributes(
-        ProgramAttributes(
-            InstructionSet.PPC,
-            None,
-            BitWidth.BIT_32,
-            Endianness.LITTLE_ENDIAN,
-            None,
-        )
-    )
+    prog.add_attributes(arch_info)
     await prog.save()
 
-    await prog.create_child_from_view(NamedProgramSection(0x0, 0x1000, "FIRST_SECTION"))
-    await prog.create_child_from_view(MemoryRegion(0x1000, 0x2000))
-    await prog.create_child_from_view(CodeRegion(0x2000, 0x3000))
+    await prog.create_child_from_view(
+        NamedProgramSection(0x0, 0x1000, "FIRST_SECTION"), data_range=Range.from_size(0x0, 0x1000)
+    )
+    await prog.create_child_from_view(
+        MemoryRegion(0x1000, 0x1000), data_range=Range.from_size(0x1000, 0x1000)
+    )
+    cr_child = await prog.create_child_from_view(
+        CodeRegion(0x2000, 0x1000), data_range=Range.from_size(0x2000, 0x1000)
+    )
+
+    await _make_dummy_program(prog, arch_info)
+
+    await prog.flush_to_disk("/transfer/dummy_program")
 
     await prog.identify()
 
@@ -52,3 +102,87 @@ async def test_ghidra_custom_loader(ofrak_context: OFRAKContext):
 
     ghidra_project = await prog.view_as(GhidraProject)
     assert isinstance(ghidra_project, GhidraProject)
+
+    await cr_child.unpack()
+
+    children = list(await cr_child.get_children())
+    assert 2 == len(children)
+
+
+async def _make_dummy_program(resource: Resource, arch_info):
+    src = """
+    int foo(int x, int y);
+    
+    int main(int argc, char** argv){
+        int x = 5;
+        int y = 3;
+        for (int i = 0; i < x; i++){
+            y *= argc;
+        }
+        
+        return foo(x, y);
+    }
+    
+    int foo(int x, int y){
+        switch (x){
+            case 1:
+                return y + 2;
+            case 2:
+                return y * 2;
+            case 3:
+                return y * y;
+            default:
+                return x + y;
+        
+        }
+    }
+    """
+
+    arch_map: Dict[InstructionSet, Type[Toolchain]] = {
+        InstructionSet.PPC: GNU_PPC_LINUX_10_Toolchain,
+        InstructionSet.ARM: GNU_ARM_NONE_EABI_10_2_1_Toolchain,
+        InstructionSet.M68K: VBCC_0_9_GNU_Hybrid_Toolchain,
+    }
+
+    tc = arch_map[arch_info.isa](
+        arch_info,
+        toolchain_config=ToolchainConfig(
+            file_format=BinFileType.ELF,
+            force_inlines=True,
+            relocatable=True,
+            no_std_lib=True,
+            no_jump_tables=True,
+            no_bss_section=True,
+            compiler_optimization_level=CompilerOptimizationLevel.NONE,
+            compiler_target=None,
+            compiler_cpu=None,
+            assembler_target=None,
+            assembler_cpu=None,
+        ),
+    )
+    build_dir = tempfile.mkdtemp()
+    pm = PatchMaker(tc, build_dir=build_dir)
+
+    src_path = os.path.join(build_dir, "src.c")
+    with open(src_path, "w") as f:
+        f.write(src)
+
+    bom = pm.make_bom("name", [src_path], [], [])
+
+    patch_config = PatchRegionConfig(
+        "name",
+        {
+            list(bom.object_map.values())[0].path: (
+                Segment(".text", 0x2000, 0x0, True, 0x800, MemoryPermissions.RX),
+            ),
+        },
+    )
+
+    exec_path = os.path.join(build_dir, "exec")
+
+    fem = pm.make_fem([(bom, patch_config)], exec_path)
+
+    await resource.run(
+        SegmentInjectorModifier,
+        SegmentInjectorModifierConfig.from_fem(fem),
+    )

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
@@ -1,5 +1,15 @@
+from ofrak import OFRAKContext
+from ofrak.core import (
+    Program,
+    ProgramAttributes,
+    NamedProgramSection,
+    MemoryRegion,
+    CodeRegion,
+    Elf,
+)
 from ofrak.resource import Resource
-from ofrak_ghidra.ghidra_model import GhidraProject
+from ofrak_ghidra.ghidra_model import GhidraProject, GhidraCustomLoadProject
+from ofrak_type import BitWidth, Endianness, InstructionSet
 
 
 async def test_ghidra_project_analyzer(hello_world_elf_resource: Resource):
@@ -8,6 +18,37 @@ async def test_ghidra_project_analyzer(hello_world_elf_resource: Resource):
     [GhidraProject][ofrak_ghidra.components.ghidra_analyzer.GhidraProject] object can
     be successfully generated
     """
+    hello_world_elf_resource.add_tag(Elf)
+    await hello_world_elf_resource.save()
     await hello_world_elf_resource.identify()
     ghidra_project = await hello_world_elf_resource.view_as(GhidraProject)
+    assert isinstance(ghidra_project, GhidraProject)
+
+
+async def test_ghidra_custom_loader(ofrak_context: OFRAKContext):
+    file_data = b"\xed" * 0x10000
+
+    prog = await ofrak_context.create_root_resource("test_custom_load", data=file_data)
+
+    prog.add_tag(Program)
+    prog.add_attributes(
+        ProgramAttributes(
+            InstructionSet.PPC,
+            None,
+            BitWidth.BIT_32,
+            Endianness.LITTLE_ENDIAN,
+            None,
+        )
+    )
+    await prog.save()
+
+    await prog.create_child_from_view(NamedProgramSection(0x0, 0x1000, "FIRST_SECTION"))
+    await prog.create_child_from_view(MemoryRegion(0x1000, 0x2000))
+    await prog.create_child_from_view(CodeRegion(0x2000, 0x3000))
+
+    await prog.identify()
+
+    assert prog.has_tag(GhidraCustomLoadProject)
+
+    ghidra_project = await prog.view_as(GhidraProject)
     assert isinstance(ghidra_project, GhidraProject)

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_vbcc_m68k.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_vbcc_m68k.py
@@ -61,16 +61,11 @@ class VBCC_0_9_GNU_Hybrid_Toolchain(Abstract_GNU_Toolchain, ABC):
                 "--no-dynamic-linker",
             )
 
-        vbcc_compiler_optimization_map = {
-            CompilerOptimizationLevel.NONE: "",
-            CompilerOptimizationLevel.SOME: "",
-            CompilerOptimizationLevel.SPACE: "-size",
-            # TODO: Look into O=16384 for full cross-module optimizations. Bit encoded.
-            CompilerOptimizationLevel.FULL: "-speed",
-        }
-        self._compiler_flags.append(
-            vbcc_compiler_optimization_map[self._config.compiler_optimization_level]
-        )
+        # TODO: Look into O=16384 for full cross-module optimizations. Bit encoded.
+        if self._config.compiler_optimization_level is CompilerOptimizationLevel.SPACE:
+            self._compiler_flags.append("-size")
+        elif self._config.compiler_optimization_level is CompilerOptimizationLevel.FULL:
+            self._compiler_flags.append("-speed")
 
         if not self._config.hard_float:
             self._compiler_flags.append("-soft-float")


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add a Ghidra script to create a memory map for a binary, mirroring OFRAK's, when Ghidra cannot load the target binary itself.

**Link to Related Issue(s)**
Ghidra has loaders for some formats, but OFRAK has unpackers for some programs that Ghidra does not (e.g. Uimage). So although OFRAK unpacks these and can find the memory sections, Ghidra cannot analyze any of the code. It would be desirable for future formats as well, once an OFRAK unpacker is written, for them to automatically be supported by Ghidra (as best they can).

**Please describe the changes in your request.**
* Custom Ghidra "loader" that runs as a pre-script, creating memory blocks and marking code blocks
* Minor fix to m68k toolchain, some optimization levels led to empty arguments that made the toolchain invocation fail

**Anyone you think should look at this, specifically?**
