### PR TITLE
Maintenance: Install python-lzo from pip

### DIFF
--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -19,9 +19,6 @@ RUN apt-get -y update && \
       unar \
       zstd
 
-# python-lzo needed by ubireader
-RUN python3 -m pip install python-lzo
-
 # Install apktool and uber-apk-signer
 RUN apt-get -y update && apt-get -y install openjdk-11-jdk
 RUN wget https://raw.githubusercontent.com/iBotPeaches/Apktool/v2.3.3/scripts/linux/apktool -O /usr/local/bin/apktool && \

--- a/ofrak_core/ofrak/core/ubi.py
+++ b/ofrak_core/ofrak/core/ubi.py
@@ -40,26 +40,6 @@ UBINIZE_TOOL = ComponentExternalTool(
 )
 
 
-class _PyLzoTool(ComponentExternalTool):
-    def __init__(self):
-        super().__init__(
-            "python-lzo",
-            "https://github.com/jd-boyd/python-lzo",
-            install_check_arg="",
-        )
-
-    async def is_tool_installed(self) -> bool:
-        try:
-            import lzo  # type: ignore
-
-            return True
-        except ModuleNotFoundError:
-            return False
-
-
-PY_LZO_TOOL = _PyLzoTool()
-
-
 @dataclass
 class UbiVolume(ResourceView):
     """
@@ -127,8 +107,6 @@ class UbiAnalyzer(Analyzer[None, Ubi]):
     targets = (Ubi,)
     outputs = (Ubi,)
 
-    external_dependencies = (PY_LZO_TOOL,)
-
     async def analyze(self, resource: Resource, config=None) -> Ubi:
         # Flush to disk
         with tempfile.NamedTemporaryFile() as temp_file:
@@ -186,7 +164,6 @@ class UbiUnpacker(Unpacker[None]):
 
     targets = (Ubi,)
     children = (UbiVolume,)
-    external_dependencies = (PY_LZO_TOOL,)
 
     async def unpack(self, resource: Resource, config=None):
         with tempfile.TemporaryDirectory() as temp_flush_dir:
@@ -236,7 +213,7 @@ class UbiPacker(Packer[None]):
     """
 
     targets = (Ubi,)
-    external_dependencies = (UBINIZE_TOOL, PY_LZO_TOOL)
+    external_dependencies = (UBINIZE_TOOL,)
 
     async def pack(self, resource: Resource, config=None) -> None:
         ubi_view = await resource.view_as(Ubi)
@@ -307,8 +284,6 @@ class UbiIdentifier(Identifier):
     """
 
     targets = (File, GenericBinary)
-
-    external_dependencies = (PY_LZO_TOOL,)
 
     async def identify(self, resource: Resource, config=None) -> None:
         datalength = await resource.get_data_length()

--- a/ofrak_core/ofrak/core/ubifs.py
+++ b/ofrak_core/ofrak/core/ubifs.py
@@ -7,7 +7,6 @@ from subprocess import CalledProcessError
 from ofrak import Identifier, Analyzer
 from ofrak.component.packer import Packer
 from ofrak.component.unpacker import Unpacker
-from ofrak.core import PY_LZO_TOOL
 from ofrak.resource import Resource
 from ofrak.core.filesystem import File, Folder, FilesystemRoot, SpecialFileType
 from ofrak.core.binary import GenericBinary
@@ -94,8 +93,6 @@ class UbifsAnalyzer(Analyzer[None, Ubifs]):
     targets = (Ubifs,)
     outputs = (Ubifs,)
 
-    external_dependencies = (PY_LZO_TOOL,)
-
     async def analyze(self, resource: Resource, config=None) -> Ubifs:
         with tempfile.NamedTemporaryFile() as temp_file:
             resource_data = await resource.get_data()
@@ -131,8 +128,6 @@ class UbifsUnpacker(Unpacker[None]):
 
     targets = (Ubifs,)
     children = (File, Folder, SpecialFileType)
-
-    external_dependencies = (PY_LZO_TOOL,)
 
     async def unpack(self, resource: Resource, config=None):
         with tempfile.TemporaryDirectory() as temp_flush_dir:
@@ -213,8 +208,6 @@ class UbifsIdentifier(Identifier):
     """
 
     targets = (File, GenericBinary)
-
-    external_dependencies = (PY_LZO_TOOL,)
 
     async def identify(self, resource: Resource, config=None) -> None:
         datalength = await resource.get_data_length()

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -12,6 +12,7 @@ lief==0.12.3
 orjson~=3.8.7
 pefile==2023.2.7
 pycdlib==1.12.0
+python-lzo==1.15
 python-magic;platform_system!="Windows"
 python-magic-bin;platform_system=="Windows"
 reedsolo==1.7.0

--- a/ofrak_core/test_ofrak/unit/test_ofrak_server.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_server.py
@@ -1405,7 +1405,7 @@ async def test_git_clone_project(ofrak_client: TestClient):
     git_url = "https://github.com/redballoonsecurity/ofrak-project-example.git"
     await ofrak_client.post("/set_projects_path", json={"path": "/tmp/test-ofrak-projects"})
     resp = await ofrak_client.post("/clone_project_from_git", json={"url": git_url})
-    resp_body = await resp.json()
+    resp_body = await resp.json(content_type=None)
     id = resp_body["id"]
     resp = await ofrak_client.get("/get_project_by_id", params={"id": id})
     resp_body = await resp.json()


### PR DESCRIPTION
- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Move/"promote" `python-lzo` module from an external dependency of the Ubi and Ubifs components to a normal pip dependency

**Link to Related Issue(s)**
Not sure why `python-lzo` was marked as an external dependency originally, but it seems erroneous. It of course adds an extra dependency not installed as part of a pip install.

**Please describe the changes in your request.**
Remove that dependency object and installation line in Dockerstub, add it to requirements.txt.
Also make a small change to one of the ofrak server tests, that sometimes causes a problem ([this error](https://stackoverflow.com/questions/48840378/python-attempt-to-decode-json-with-unexpected-mimetype)).

**Anyone you think should look at this, specifically?**
