### PR TITLE
Rename two missed usages of Resource.flush_to_disk

### DIFF
--- a/docs/user-guide/advanced/patch-maker/user-guide.md
+++ b/docs/user-guide/advanced/patch-maker/user-guide.md
@@ -383,7 +383,7 @@ await root_resource.run(BinaryPatchModifier, binary_patch_config)
 Finally, the familiar step of packing the results
 ```
 await root_resource.pack()
-await root_resource.flush_to_disk(output_filename)
+await root_resource.flush_data_to_disk(output_filename)
 ```
 
 ### Troubleshooting

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Improved flushing of filesystem entries (including symbolic links and other types) to disk. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
 
+### Changed
+- `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
+
 ## [3.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.1.0...ofrak-v3.2.0)
 ### Added
 - Add a JFFS2 packer and unpacker. ([#326](https://github.com/redballoonsecurity/ofrak/pull/326))

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -857,7 +857,7 @@ class AiohttpOFRAKServer:
         script_str = (
             """
         await {resource}"""
-            f""".flush_to_disk("{output_file_name}")"""
+            f""".flush_data_to_disk("{output_file_name}")"""
         )
         await self.script_builder.add_action(resource, script_str, ActionType.UNDEF)
         await self.script_builder.commit_to_script(resource)

--- a/ofrak_core/test_ofrak/unit/test_ofrak_server.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_server.py
@@ -1090,7 +1090,7 @@ async def test_add_flush_to_disk_to_script(ofrak_client: TestClient, firmware_zi
         "        )",
         "    )",
         "",
-        '    await file_DIR655B1_FW203NAB02_bin.flush_to_disk("DIR655B1_FW203NAB02.bin")',
+        '    await file_DIR655B1_FW203NAB02_bin.flush_data_to_disk("DIR655B1_FW203NAB02.bin")',
         "",
         "",
         'if __name__ == "__main__":',


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**Please describe the changes in your request.**

In PR #373, `Resource.flush_to_disk` was renamed to `Resource.flush_data_to_disk`. In that rename, I missed a couple of usages of the old `flush_to_disk` method. This PR fixes those stragglers.

**Anyone you think should look at this, specifically?**

@whyitfor 