### PR TITLE
Disable content_type checking in OFRAK Server testing code.

### DIFF
--- a/ofrak_core/test_ofrak/unit/test_ofrak_server.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_server.py
@@ -1405,10 +1405,10 @@ async def test_git_clone_project(ofrak_client: TestClient):
     git_url = "https://github.com/redballoonsecurity/ofrak-project-example.git"
     await ofrak_client.post("/set_projects_path", json={"path": "/tmp/test-ofrak-projects"})
     resp = await ofrak_client.post("/clone_project_from_git", json={"url": git_url})
-    resp_body = await resp.json()
+    resp_body = await resp.json(content_type=None)
     id = resp_body["id"]
     resp = await ofrak_client.get("/get_project_by_id", params={"id": id})
-    resp_body = await resp.json()
+    resp_body = await resp.json(content_type=None)
     assert resp_body["scripts"] == [
         {"name": "unpack-and-comment.py"},
         {"name": "unpack.py"},
@@ -1427,12 +1427,12 @@ async def test_open_project(ofrak_client: TestClient):
     git_url = "https://github.com/redballoonsecurity/ofrak-project-example.git"
     await ofrak_client.post("/set_projects_path", json={"path": "/tmp/test-ofrak-projects"})
     resp = await ofrak_client.post("/clone_project_from_git", json={"url": git_url})
-    resp_body = await resp.json()
+    resp_body = await resp.json(content_type=None)
     id = resp_body["id"]
     resp = await ofrak_client.post(
         "/open_project",
         json={"id": id, "binary": "example_program", "script": "unpack-and-comment.py"},
     )
-    resp_body = await resp.json()
+    resp_body = await resp.json(content_type=None)
     assert resp_body["id"] == "00000001"
     shutil.rmtree("/tmp/test-ofrak-projects")


### PR DESCRIPTION
These changes avoid unhelpful content-type errors in OFRAK testing code. They do not impact test functionality.

- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Update testing code to avoid unhelpful warnings on unexpected JSON content type.

**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
Testing code ignores these warnings to focus on actual test content.

**Anyone you think should look at this, specifically?**
@EdwardLarson 