### PR TITLE
Bump black versions to be consistent with #323.

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -48,7 +48,7 @@ jobs:
           cd frontend
           npm install
           sudo apt-get install shellcheck
-          python3 -m pip install black==22.6.0
+          python3 -m pip install black==23.3.0
       - name: Lint frontend
         run: |
           cd frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
       - id: pyupgrade
         args: ['--py37-plus']
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
       - id: black-jupyter

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -138,7 +138,6 @@ class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
     async def analyze(
         self, resource: Resource, config: Optional[GhidraProjectConfig] = None
     ) -> GhidraProject:
-
         gzf = config.ghidra_zip_file if config is not None else None
 
         async with self._prepare_ghidra_project(resource, gzf) as (ghidra_project, full_fname):
@@ -451,7 +450,6 @@ class GhidraCustomLoadAnalyzer(GhidraProjectAnalyzer):
     async def analyze(
         self, resource: Resource, config: Optional[GhidraProjectConfig] = None
     ) -> GhidraProject:
-
         arch_info: ArchInfo = await resource.analyze(ProgramAttributes)
         mem_blocks = await self._get_memory_blocks(await resource.view_as(Program))
 

--- a/ofrak_io/setup.py
+++ b/ofrak_io/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
-            "black==22.6.0",
+            "black==23.3.0",
             "fun-coverage==0.2.0",
             "hypothesis~=6.39.3",
             "mypy==0.942",

--- a/ofrak_type/setup.py
+++ b/ofrak_type/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     },
     extras_require={
         "test": [
-            "black==22.6.0",
+            "black==23.3.0",
             "fun-coverage==0.2.0",
             "hypothesis~=6.39.3",
             "mypy==0.942",


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
#323 attempted to bump black versions, but missed a few files.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Use black==23.3.0 throughout.

**Link to Related Issue(s)**
Relates to #323.
