### PR TITLE
build_image.py: Auto-enable Docker buildkit, and make git optional

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -39,6 +39,7 @@ class OfrakImageConfig:
     install_target: InstallTarget
     cache_from: List[str]
     entrypoint: Optional[str]
+    buildkit: bool
 
     def validate_serial_txt_existence(self):
         """
@@ -78,6 +79,12 @@ def main():
         f.write(dockerfile_finish)
     print(f"{FINISH_DOCKERFILE} built.")
 
+    env = {k: v for k, v in os.environ.items()}
+    if config.buildkit:
+        env["DOCKER_BUILDKIT"] = "1"
+    else:
+        env["DOCKER_BUILDKIT"] = "0"
+
     if config.build_base:
         full_base_image_name = "/".join((config.registry, config.base_image_name))
         cache_args = []
@@ -107,7 +114,7 @@ def main():
         if config.extra_build_args:
             base_command.extend(config.extra_build_args)
         try:
-            subprocess.run(base_command, check=True)
+            subprocess.run(base_command, check=True, env=env)
         except subprocess.CalledProcessError as error:
             print(f"Error running command: '{' '.join(error.cmd)}'")
             print(f"Exit status: {error.returncode}")
@@ -131,7 +138,7 @@ def main():
         if config.no_cache:
             finish_command.extend(["--no-cache"])
         try:
-            subprocess.run(finish_command, check=True)
+            subprocess.run(finish_command, check=True, env=env)
         except subprocess.CalledProcessError as error:
             print(f"Error running command: '{' '.join(error.cmd)}'")
             print(f"Exit status: {error.returncode}")
@@ -150,6 +157,7 @@ def parse_args() -> OfrakImageConfig:
         default=InstallTarget.DEVELOP.value,
     )
     parser.add_argument("--cache-from", action="append")
+    parser.add_argument("--buildkit", action="store_true", default=True)
     args = parser.parse_args()
     with open(args.config) as file_handle:
         config_dict = yaml.safe_load(file_handle)
@@ -165,6 +173,7 @@ def parse_args() -> OfrakImageConfig:
         InstallTarget(args.target),
         args.cache_from,
         config_dict.get("entrypoint"),
+        args.buidkit,
     )
     image_config.validate_serial_txt_existence()
     return image_config

--- a/build_image.py
+++ b/build_image.py
@@ -39,7 +39,7 @@ class OfrakImageConfig:
     install_target: InstallTarget
     cache_from: List[str]
     entrypoint: Optional[str]
-    buildkit: bool
+    no_forced_buildkit: bool
 
     def validate_serial_txt_existence(self):
         """
@@ -80,10 +80,8 @@ def main():
     print(f"{FINISH_DOCKERFILE} built.")
 
     env = {k: v for k, v in os.environ.items()}
-    if config.buildkit:
+    if not config.no_forced_buildkit:
         env["DOCKER_BUILDKIT"] = "1"
-    else:
-        env["DOCKER_BUILDKIT"] = "0"
 
     if config.build_base:
         full_base_image_name = "/".join((config.registry, config.base_image_name))
@@ -157,7 +155,7 @@ def parse_args() -> OfrakImageConfig:
         default=InstallTarget.DEVELOP.value,
     )
     parser.add_argument("--cache-from", action="append")
-    parser.add_argument("--buildkit", action="store_true", default=True)
+    parser.add_argument("--no-forced-buildkit", action="store_true")
     args = parser.parse_args()
     with open(args.config) as file_handle:
         config_dict = yaml.safe_load(file_handle)
@@ -173,7 +171,7 @@ def parse_args() -> OfrakImageConfig:
         InstallTarget(args.target),
         args.cache_from,
         config_dict.get("entrypoint"),
-        args.buidkit,
+        args.no_forced_buildkit,
     )
     image_config.validate_serial_txt_existence()
     return image_config

--- a/build_image.py
+++ b/build_image.py
@@ -11,9 +11,13 @@ import yaml
 
 BASE_DOCKERFILE = "base.Dockerfile"
 FINISH_DOCKERFILE = "finish.Dockerfile"
-GIT_COMMIT_HASH = (
-    subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"]).decode("ascii").strip()
-)
+try:
+    GIT_COMMIT_HASH = (
+        subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"]).decode("ascii").strip()
+    )
+except:
+    print("Warning: No git history found. It will be hard to uniquely identify this build.")
+    GIT_COMMIT_HASH = "latest"
 
 
 class InstallTarget(Enum):


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Allow Docker build to continue even if there is a problem getting local git history, and default to forcing Docker buildkit to be enabled.

**Link to Related Issue(s)**
Currently if there is a problem with local git repo, `build_image.py` will fail and be unable to build. As this isn't strictly necessary to build the image, just to give it a nice tag, the build should be able to continue without it.

Some features in the build require Docker buildkit to be enabled, and we say as much in the docs to build the image. However, this is a point of failure (for some reason I could not get the buildkit to be enabled in my machine) and a "gotcha" that can be removed entirely by just setting the Docker buildkit enabled in the subprocess we spin up to do the Docker build. In case there is a desire to specifically NOT use the buildkit, an option is added to not alter the subprocess environment at all (buildkit may or may not be enabled depending on user's environment).

**Please describe the changes in your request.**

Sufficiently summarized above.

**Anyone you think should look at this, specifically?**
@whyitfor 
