### PR TITLE
Create free space when parent is not MemoryView

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix `java` and `apktool` CLI arguments for checking components. ([#390](https://github.com/redballoonsecurity/ofrak/pull/390))
 - Bump GitPython version from 3.1.35 to 3.1.41 to mitigate CVEs. ([#400](https://github.com/redballoonsecurity/ofrak/pull/400))
 - Fixes erroneous Free Space Modifier expectation that resource parents are memory views. ([#404](https://github.com/redballoonsecurity/ofrak/pull/404))
+- Prevent `_find_and_delete_overlapping_children` from deleting children which are next to the freed region, but not overlapping. ([#396](https://github.com/redballoonsecurity/ofrak/pull/396))
 
 ### Changed
 - `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Improved flushing of filesystem entries (including symbolic links and other types) to disk. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
 - Fix `java` and `apktool` CLI arguments for checking components. ([#390](https://github.com/redballoonsecurity/ofrak/pull/390))
+- Fixes erroneous Free Space Modifier expectation that resource parents are memory views. ([#404](https://github.com/redballoonsecurity/ofrak/pull/404))
 
 ### Changed
 - `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))

--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -440,7 +440,7 @@ async def _find_and_delete_overlapping_children(resource: Resource, freed_range:
                 tags=(MemoryRegion,),
                 attribute_filters=(
                     ResourceAttributeRangeFilter(MemoryRegion.VirtualAddress, max=freed_range.end),
-                    ResourceAttributeRangeFilter(MemoryRegion.EndVaddr, min=freed_range.start),
+                    ResourceAttributeRangeFilter(MemoryRegion.EndVaddr, min=freed_range.start + 1),
                 ),
             ),
         )

--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -440,7 +440,7 @@ async def _find_and_delete_overlapping_children(resource: Resource, freed_range:
                 tags=(MemoryRegion,),
                 attribute_filters=(
                     ResourceAttributeRangeFilter(MemoryRegion.VirtualAddress, max=freed_range.end),
-                    ResourceAttributeRangeFilter(MemoryRegion.EndVaddr, min=freed_range.start + 1),
+                    ResourceAttributeRangeFilter(MemoryRegion.EndVaddr, min=freed_range.start),
                 ),
             ),
         )
@@ -490,19 +490,17 @@ class FreeSpaceModifier(Modifier[FreeSpaceModifierConfig]):
             mem_region_view.virtual_address + mem_region_view.size,
         )
         patch_data = _get_fill(freed_range, config.fill)
-        parent_mr_view = await resource.get_parent_as_view(MemoryRegion)
-        patch_offset = parent_mr_view.get_offset_in_self(freed_range.start)
+        parent = await resource.get_parent()
+        patch_offset = (await resource.get_data_range_within_parent()).start
         patch_range = freed_range.translate(patch_offset - freed_range.start)
 
         await resource.delete()
         await resource.save()
 
         # Patch in the patch_data
-        await parent_mr_view.resource.run(
-            BinaryPatchModifier, BinaryPatchConfig(patch_offset, patch_data)
-        )
+        await parent.run(BinaryPatchModifier, BinaryPatchConfig(patch_offset, patch_data))
         # Create the FreeSpace child
-        await parent_mr_view.resource.create_child_from_view(
+        await parent.create_child_from_view(
             FreeSpace(
                 mem_region_view.virtual_address,
                 mem_region_view.size,


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fixes erroneous Free Space Modifier expectation that resource parents are memory views.

**Anyone you think should look at this, specifically?**

@whyitfor 