### PR TITLE
Modified the FreeSpaceModifier to mark patch bytes written to the binary as not free

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix running scripts without a project selected, and without a config selected. ([#407](https://github.com/redballoonsecurity/ofrak/pull/407))
 
 ### Changed
+- Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 - `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
 
 ## [3.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.1.0...ofrak-v3.2.0)

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fixed front end "Replace" button. Before it was appending new data instead of replacing it as intended. ([#403](https://github.com/redballoonsecurity/ofrak/pull/403))
 - Fix dragging and dropping in the GUI. ([#407](https://github.com/redballoonsecurity/ofrak/pull/407))
 - Fix running scripts without a project selected, and without a config selected. ([#407](https://github.com/redballoonsecurity/ofrak/pull/407))
+- Fix bug in OFRAK GUI server which causes an error when parsing a default config value of bytes. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 
 ### Changed
 - Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))

--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -473,6 +473,10 @@ class FreeSpaceModifierConfig(ComponentConfig):
     stub: bytes = b""
     fill: bytes = b"\x00"
 
+    def __post_init__(self):
+        if len(self.fill) == 0:
+            raise ValueError(f"The minimum size for fill is 1 byte, got 0: {self}")
+
 
 class FreeSpaceModifier(Modifier[FreeSpaceModifierConfig]):
     """
@@ -544,6 +548,10 @@ class PartialFreeSpaceModifierConfig(ComponentConfig):
     range_to_remove: Range
     stub: bytes = b""
     fill: bytes = b"\x00"
+
+    def __post_init__(self):
+        if len(self.fill) == 0:
+            raise ValueError(f"The minimum size for fill is 1 byte, got 0: {self}")
 
 
 class PartialFreeSpaceModifier(Modifier[PartialFreeSpaceModifierConfig]):

--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -500,7 +500,7 @@ class FreeSpaceModifier(Modifier[FreeSpaceModifierConfig]):
         # Patch in the patch_data
         await parent.run(BinaryPatchModifier, BinaryPatchConfig(patch_offset, patch_data))
 
-	free_offset = len(config.fill) if config.fill else 0
+        free_offset = len(config.fill) if config.fill else 0
 
         # Create the FreeSpace child
         await parent.create_child_from_view(

--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -499,11 +499,14 @@ class FreeSpaceModifier(Modifier[FreeSpaceModifierConfig]):
 
         # Patch in the patch_data
         await parent.run(BinaryPatchModifier, BinaryPatchConfig(patch_offset, patch_data))
+
+	free_offset = len(config.fill) if config.fill else 0
+
         # Create the FreeSpace child
         await parent.create_child_from_view(
             FreeSpace(
-                mem_region_view.virtual_address,
-                mem_region_view.size,
+                mem_region_view.virtual_address + free_offset,
+                mem_region_view.size - free_offset,
                 config.permissions,
             ),
             data_range=patch_range,

--- a/ofrak_core/ofrak/gui/server.py
+++ b/ofrak_core/ofrak/gui/server.py
@@ -919,7 +919,7 @@ class AiohttpOFRAKServer:
                         "args": self._construct_arg_response(field.type),
                         "fields": self._construct_field_response(field.type),
                         "enum": self._construct_enum_response(field.type),
-                        "default": field.default
+                        "default": _format_default(field.default)
                         if not isinstance(field.default, dataclasses._MISSING_TYPE)
                         else None,
                     }
@@ -1550,3 +1550,7 @@ def json_response(
         headers=headers,
         content_type=content_type,
     )
+
+
+def _format_default(default):
+    return default.decode() if isinstance(default, bytes) else default

--- a/ofrak_core/test_ofrak/components/test_free_space.py
+++ b/ofrak_core/test_ofrak/components/test_free_space.py
@@ -105,3 +105,21 @@ async def test_free_space_modifier(resource_under_test: Resource):
     )
     child_data = await child.get_data()
     assert child_data == config.stub
+
+
+def test_free_space_modifier_config_fill_parameters():
+    """
+    Test that the length of fill passed to `FreeSpaceModifierConfig` is greater than 0.
+    """
+    with pytest.raises(ValueError):
+        FreeSpaceModifierConfig(MemoryPermissions.RX, stub=b"", fill=b"")
+
+
+def test_partial_space_modifier_config_fill_parameters():
+    """
+    Test that the length of fill passed to `PartialFreeSpaceModifierConfig` is greater than 0.
+    """
+    with pytest.raises(ValueError):
+        PartialFreeSpaceModifierConfig(
+            MemoryPermissions.RX, range_to_remove=Range(0, 10), stub=b"", fill=b""
+        )

--- a/ofrak_core/test_ofrak/components/test_free_space.py
+++ b/ofrak_core/test_ofrak/components/test_free_space.py
@@ -1,9 +1,9 @@
 import pytest
-from ofrak.core import FreeSpace
+from ofrak.core import FreeSpace, FreeSpaceModifier, FreeSpaceModifierConfig
 
 from ofrak.component.modifier import ModifierError
 
-from ofrak import OFRAKContext, Resource
+from ofrak import OFRAKContext, Resource, ResourceFilter, ResourceAttributeValueFilter
 from ofrak.core import (
     MemoryRegion,
     Program,
@@ -19,11 +19,14 @@ async def resource_under_test(ofrak_context: OFRAKContext) -> Resource:
     resource = await ofrak_context.create_root_resource(
         "mock_memory_region",
         b"\xff" * 0x100,
-        (Program, MemoryRegion),
+        (Program,),
     )
-    resource.add_view(MemoryRegion(0x0, 0x100))
+    memory_region = await resource.create_child_from_view(
+        MemoryRegion(0, 0x100), data_range=Range(0, 0x100)
+    )
     await resource.save()
-    return resource
+    await memory_region.save()
+    return memory_region
 
 
 async def test_partial_free_modifier_out_of_bounds(resource_under_test: Resource):
@@ -35,7 +38,8 @@ async def test_partial_free_modifier_out_of_bounds(resource_under_test: Resource
     config = PartialFreeSpaceModifierConfig(
         MemoryPermissions.RX,
         range_to_remove=Range.from_size(0, data_length + 4),
-        fill=b"\xfe\xed\xfa\xce",
+        stub=b"\xfe\xed\xfa\xce",
+        fill=b"\x00",
     )
     with pytest.raises(ModifierError):
         await resource_under_test.run(PartialFreeSpaceModifier, config)
@@ -45,13 +49,59 @@ async def test_partial_free_modifier(resource_under_test: Resource):
     """
     Test that the PartialFreeSpaceModifier returns expected results.
     """
+    partial_start_offset = 4
+    partial_end_offset = 10
+    parent = await resource_under_test.get_parent()
     data_length = await resource_under_test.get_data_length()
+    range_to_remove = Range.from_size(4, data_length - 4 - 10)
     config = PartialFreeSpaceModifierConfig(
         MemoryPermissions.RX,
-        range_to_remove=Range.from_size(0, data_length - 10),
-        fill=b"\xfe\xed\xfa\xce",
+        range_to_remove=range_to_remove,
+        stub=b"\xfe\xed\xfa\xce",
+        fill=b"\x00",
     )
     await resource_under_test.run(PartialFreeSpaceModifier, config)
+
+    # Assert free space is as required
     free_space = await resource_under_test.get_only_child_as_view(FreeSpace)
     free_space_data = await free_space.resource.get_data()
-    assert free_space_data == config.fill + (b"\x00" * (data_length - 10 - len(config.fill)))
+    assert free_space_data == (b"\x00" * (range_to_remove.length() - len(config.stub)))
+
+    # Assert stub is injected
+    memory_region_data = await resource_under_test.get_data()
+    assert (
+        memory_region_data[partial_start_offset : partial_start_offset + len(config.stub)]
+        == config.stub
+    )
+
+
+async def test_free_space_modifier(resource_under_test: Resource):
+    """
+    Test that the FreeSpaceModifier returns expected results
+    """
+    data_length = await resource_under_test.get_data_length()
+    config = FreeSpaceModifierConfig(
+        MemoryPermissions.RX,
+        stub=b"\xfe\xed\xfa\xce",
+        fill=b"\x00",
+    )
+    parent = await resource_under_test.get_parent()
+    await resource_under_test.run(FreeSpaceModifier, config)
+
+    # Assert free space created as required
+    free_space = await parent.get_only_child_as_view(
+        FreeSpace, r_filter=ResourceFilter.with_tags(FreeSpace)
+    )
+    free_space_data = await free_space.resource.get_data()
+    # Free space should not include the stub
+    assert free_space_data == (config.fill * (data_length - len(config.stub)))
+
+    # If stub exists, assert that it matches
+    child = await parent.get_only_child(
+        r_filter=ResourceFilter(
+            tags=(MemoryRegion,),
+            attribute_filters=(ResourceAttributeValueFilter(MemoryRegion.Size, len(config.stub)),),
+        )
+    )
+    child_data = await child.get_data()
+    assert child_data == config.stub


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. 

**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
This changes the signature and intended behavior of the configs for `FreeSpaceModifier` and `PartialFreeSpaceModifier`. Each modifier now allows for injecting a "stub" at the beginning of the targeted code to be freed. This stub is not included in the `FreeSpace`. The config's "fill" parameter is now the data pattern used to overwrite the bytes that fall in the `FreeSpace`.

**Anyone you think should look at this, specifically?**
@rbs-afflitto, @rbs-alexr.
Optionally: @rbs-jacob, @EdwardLarson .
