### PR TITLE
Dropping the .altinstr_replacement section from the toolchain

### DIFF
--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 - X86_64 toolchain now installs on Docker image builds for AARCH64 hosts. ([#405](https://github.com/redballoonsecurity/ofrak/pull/405))
+- Toolchain now drops the .altinstrs_replacement as well as the .altinstructions section in our generated linker scripts ([#414](https://github.com/redballoonsecurity/ofrak/pull/414))
 
 ## [4.0.2](https://github.com/redballoonsecurity/ofrak/compare/ofrak-patch-maker-v.4.0.1...ofrak-patch-maker-v.4.0.2)
 ### Fixed

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/abstract.py
@@ -95,6 +95,7 @@ class Toolchain(ABC):
             ".dynstr",
             ".eh_frame",
             ".altinstructions",
+            ".altinstr_replacement",
         ]
 
         self._assembler_target = self._get_assembler_target(processor)


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
We also want to drop the .altinstr_replacement section when we are performing patches

**Link to Related Issue(s)**

**Please describe the changes in your request.**
This PR adds .altinstr_replacement to the toolchain's linker section droplist

**Anyone you think should look at this, specifically?**
@rbs-afflitto also ran into this issue
