### PR TITLE
Use python3.8 in docker images

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -195,7 +195,7 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
         dockerfile_base_parts += [f"### {dockerstage_path}", dockerstub]
 
     dockerfile_base_parts += [
-        "FROM python:3.7-bullseye@sha256:338ead05c1a0aa8bd8fcba8e4dbbe2afd0283b4732fd30cf9b3bfcfcbc4affab",
+        "FROM python:3.8-bullseye@sha256:e1cd369204123e89646f8c001db830eddfe3e381bd5c837df00141be3bd754cb",
         "",
     ]
 

--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -61,7 +61,7 @@ RUN cd /tmp && \
 
 # Install Jefferson
 WORKDIR /tmp
-RUN wget https://bootstrap.pypa.io/pip/get-pip.py && python3.9 get-pip.py && python3.7 get-pip.py && rm get-pip.py
+RUN wget https://bootstrap.pypa.io/pip/get-pip.py && python3.9 get-pip.py && python3.8 get-pip.py && rm get-pip.py
 RUN python3.9 -m pip install jefferson
 WORKDIR /
 

--- a/ofrak_type/setup.py
+++ b/ofrak_type/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
             "fun-coverage==0.2.0",
             "hypothesis~=6.39.3",
             "mypy==0.942",
-            "pytest",
+            "pytest<8.0",
             "pytest-cov",
         ]
     },


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Update docker configuration to use Python 3.8, rather than 3.7

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Switches the docker configuration from the previous pinned python:3.7-bullseye docker version to the latest-as-of-today python:3.8-bullseye one.

**Anyone you think should look at this, specifically?**
@whyitfor 
