### PR TITLE
Add typing support to ofrak_ghidra package

### DIFF
--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to `ofrak-ghidra` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+## 0.1.1 - 2024-02-15
+### Added
+- Added typing support to the ofrak-ghidra package. This is helpful for users who use `mypy` and `ofrak_ghidra` in a project.
+
+## 0.1.0 - 2022-08-09
+### Added
+Initial release. Hello world!

--- a/disassemblers/ofrak_ghidra/setup.py
+++ b/disassemblers/ofrak_ghidra/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
     description="OFRAK Ghidra Components",
     url="",  # TODO
     packages=setuptools.find_packages(),
+    package_data={"ofrak_ghidra": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Just add typing support to the `ofrak_ghidra` package. This avoids getting errors from mypy like `error: Skipping analyzing "ofrak_ghidra": module is installed, but missing library stubs or py.typed marker`

**Link to Related Issue(s)**

**Please describe the changes in your request.**
Just add typing support to the `ofrak_ghidra` package.

**Anyone you think should look at this, specifically?**
