### PR TITLE
Display strings with numbers primarily as strings

### DIFF
--- a/frontend/src/utils/StructuredList.svelte
+++ b/frontend/src/utils/StructuredList.svelte
@@ -9,10 +9,6 @@
       }
 
       return Object.fromEntries(obj);
-    } else if (typeof object === "string") {
-      if (/^-?\d+$/.test(obj)) {
-        return parseInt(obj);
-      }
     }
   }
 
@@ -37,6 +33,9 @@
   {object}
 {:else if typeof object === "string" && !noQuotes}
   "{object}"
+  {#if /^-?\d+$/.test(object)}
+    (0x{parseInt(object).toString(16)})
+  {/if}
 {:else if typeof object === "object" && Object.keys(object).length === 0}
   None
 {:else if typeof object === "object"}

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix running scripts without a project selected, and without a config selected. ([#407](https://github.com/redballoonsecurity/ofrak/pull/407))
 - Fix bug in OFRAK GUI server which causes an error when parsing a default config value of bytes. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 - Set default fallback font to system default monospace, instead of variable-width sans-serif. ([#422](https://github.com/redballoonsecurity/ofrak/pull/422))
+- View resource attribute string values containing only digits primarily as strings, alternatively as hex numbers. ([#423](https://github.com/redballoonsecurity/ofrak/pull/423))
 
 ### Changed
 - Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Display strings with numbers primarily as strings in the GUI attributes view.

**Anyone you think should look at this, specifically?**

@dannyp303 