### PR TITLE
Fix occasional spurious test failures.

### DIFF
--- a/ofrak_core/test_ofrak/components/test_comments.py
+++ b/ofrak_core/test_ofrak/components/test_comments.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import pytest
 from hypothesis import given, HealthCheck, settings
 from hypothesis.strategies import text
@@ -38,7 +39,10 @@ async def test_adding_comments(executable_resource: Resource):
 # We suppress the function_scoped_fixture health check because the executable_resource fixture
 # doesn't need to be reset between individual runs of hypothesis (since the comment overrides
 # the previous one every time).
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    deadline=timedelta(seconds=5),
+)
 @given(comment_str=text())
 async def test_comment_content(executable_resource: Resource, comment_str: str):
     """Test comments with all kinds of string contents."""

--- a/ofrak_core/test_ofrak/unit/test_ofrak_context.py
+++ b/ofrak_core/test_ofrak/unit/test_ofrak_context.py
@@ -64,6 +64,9 @@ def test_ofrak_context_exclude_components_missing_dependencies():
 
 
 def test_get_ofrak_context_over_time():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     # No active context before running OFRAK
     with pytest.raises(InvalidStateError):
         get_current_ofrak_context()


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix two tests that fail on occasion for [IMHO] no good reason.

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Two tests would sometime fail for me:
- `ofrak_core/test_ofrak/components/test_comments.py::test_comment_content` had a default 200ms time limit, and once in a while, the limit would be violated (particularly, if other things happen to be running at the same time the tests run) - I have seem numbers as high as 1.6 s on occasion. I bumped the limit to 5s.
- `ofrak_core/test_ofrak/unit/test_ofrak_context.py::test_get_ofrak_context_over_time` would occasionally fail with the `RuntimeError: There is no current event loop in thread 'MainThread'` error message. I am guessing that would happen when another test executed earlier in the same worker would happen to mess with the asyncio event loop, so I made sure an event loop was available (similar to how the other tests in the same file do it). Not 100% sure this is the right thing, but seems to work.

**Anyone you think should look at this, specifically?**
Not sure. @whyitfor maybe?