### PR TITLE
Move away from $OFRAK_DIR argument to $PACKAGE_PATH for Docker builds

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -192,6 +192,8 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
             continue
         with open(dockerstage_path) as file_handle:
             dockerstub = file_handle.read()
+        # Cannot use ENV here because of multi-stage build FROM, so replace direclty in Docerkstage contents
+        dockerstub = dockerstub.replace("$PACKAGE_DIR", package_path)
         dockerfile_base_parts += [f"### {dockerstage_path}", dockerstub]
 
     dockerfile_base_parts += [
@@ -207,7 +209,11 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
         dockerstub_path = os.path.join(package_path, "Dockerstub")
         with open(dockerstub_path) as file_handle:
             dockerstub = file_handle.read()
-        dockerfile_base_parts += [f"### {dockerstub_path}", dockerstub]
+        dockerfile_base_parts += [
+            f"### {dockerstub_path}",
+            f"ENV PACKAGE_PATH={package_path}",
+            dockerstub,
+        ]
         # Collect python dependencies
         python_reqs = []
         for suff in requirement_suffixes:

--- a/disassemblers/ofrak_binary_ninja/Dockerstub
+++ b/disassemblers/ofrak_binary_ninja/Dockerstub
@@ -1,7 +1,6 @@
 RUN apt-get update && apt-get install -y libdbus-1-3
-ARG OFRAK_DIR=.
-COPY $OFRAK_DIR/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh /tmp/
-COPY $OFRAK_DIR/disassemblers/ofrak_binary_ninja/pin_version.py /tmp/
+COPY $PACKAGE_PATH/install_binary_ninja_headless_linux.sh /tmp/
+COPY $PACKAGE_PATH/pin_version.py /tmp/
 RUN --mount=type=secret,id=serial --mount=type=secret,id=license.dat,dst=/root/.binaryninja/license.dat /tmp/install_binary_ninja_headless_linux.sh && \
   python3 /tmp/pin_version.py "3.2.3814 Headless" && \
   rm /tmp/install_binary_ninja_headless_linux.sh && \

--- a/disassemblers/ofrak_ghidra/Dockerstub
+++ b/disassemblers/ofrak_ghidra/Dockerstub
@@ -9,6 +9,5 @@ RUN mkdir -p /opt/rbs && \
     rm -f ghidra_10.1.2_PUBLIC_20220125.zip && \
     mv ghidra_10.1.2_PUBLIC/ /opt/rbs/ghidra_10.1.2_PUBLIC
 
-ARG OFRAK_DIR=.
 WORKDIR /
-COPY $OFRAK_DIR/disassemblers/ofrak_ghidra/server.conf /opt/rbs/ghidra_10.1.2_PUBLIC/server/
+COPY $PACKAGE_PATH/server.conf /opt/rbs/ghidra_10.1.2_PUBLIC/server/

--- a/frontend/Dockerstage
+++ b/frontend/Dockerstage
@@ -1,7 +1,6 @@
 FROM node:latest AS svelte
 
-ARG OFRAK_DIR=.
-COPY --chown=node:node $OFRAK_DIR/frontend /home/node/frontend
+COPY --chown=node:node $PACKAGE_DIR /home/node/frontend
 
 WORKDIR /home/node/frontend
 RUN su node -c "npm install && npm run build"

--- a/frontend/Dockerstub
+++ b/frontend/Dockerstub
@@ -2,9 +2,8 @@ RUN apt-get update && apt-get install --yes nginx
 
 COPY --from=svelte --chown=root:root /home/node/frontend/dist /ofrak_gui
 
-ARG OFRAK_DIR=.
-COPY $OFRAK_DIR/frontend/nginx.conf /etc/nginx/sites-enabled/default
+COPY $PACKAGE_PATH/nginx.conf /etc/nginx/sites-enabled/default
 
-COPY $OFRAK_DIR/mkdocs.yml /mkdocs.yml
-COPY $OFRAK_DIR/docs /docs
-COPY $OFRAK_DIR/examples /examples
+COPY $PACKAGE_PATH/../mkdocs.yml /mkdocs.yml
+COPY $PACKAGE_PATH/../docs /docs
+COPY $PACKAGE_PATH/../examples /examples

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 - `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
+- `build_image.py` supports building Docker images with OFRAK packages from any ancestor directory. ([#425](https://github.com/redballoonsecurity/ofrak/pull/425))
 
 ## [3.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.1.0...ofrak-v3.2.0)
 ### Added

--- a/ofrak_tutorial/Dockerstub
+++ b/ofrak_tutorial/Dockerstub
@@ -1,4 +1,3 @@
-ARG OFRAK_DIR=.
-COPY $OFRAK_DIR/mkdocs.yml /mkdocs.yml
-COPY $OFRAK_DIR/docs /docs
-COPY $OFRAK_DIR/examples /examples
+COPY $PACKAGE_PATH/../mkdocs.yml /mkdocs.yml
+COPY $PACKAGE_PATH/../docs /docs
+COPY $PACKAGE_PATH/../examples /examples


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
- $PACKAGE_PATH generalizes build_image.py such that it works with any yaml file containing a valid list of Python packages

Before this change, it was possible to use build_image.py a directory above the OFRAK repository by passing in an OFRAK_DIR arugment in the yml file. This change generalizes the approach so that build_image.py can be run in any ancestor directory; it also removes the need to pass in an OFRAK_DIR argument.

**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
See above.

**Anyone you think should look at this, specifically?**
@rbs-jacob 