### PR TITLE
Revert using SUBALIGN(0) for .bss sections

### DIFF
--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
+### Changed
+- Removed `SUBALIGN(0)` for `.bss` sections
+
 ## [4.0.2](https://github.com/redballoonsecurity/ofrak/compare/ofrak-patch-maker-v.4.0.1...ofrak-patch-maker-v.4.0.2)
 ### Fixed
 - Remove option to read or install toolchain.conf from/to "/etc/toolchain.conf" ([#342](https://github.com/redballoonsecurity/ofrak/pull/342))

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -185,7 +185,7 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
     ) -> str:
         bss_section_name = ".bss"
         return (
-            f"    {bss_section_name} : SUBALIGN(0) {{\n"
+            f"    {bss_section_name} : {{\n"
             f"        *.o({bss_section_name}, {bss_section_name}.*)\n"
             f"    }} > {memory_region_name}"
         )


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

- Removed `SUBALIGN(0)` for `.bss` sections

**Link to Related Issue(s)**

- N/A

**Please describe the changes in your request.**

The `SUBALIGN(0)` option was leading to the following linker errors when building AARCH64 patches:
```
relocation truncated to fit: R_AARCH64_LDST64_ABS_LO12_NC against `.bss'
warning: one possible cause of this error is that the symbol is being referenced in the indicated code as if it
had a larger alignment than was declared where it was defined.
```
`SUBALIGN(0)` strips any alignment which is specified. It is not clear what issue was fixed by adding this originally. Future alignment issues should be fixed by setting the alignment of bss variables with the `__attribute__ ((aligned()))` attribute.

**Anyone you think should look at this, specifically?**

@whyitfor 
