### PR TITLE
Catch PermissionError when testing for dependencies

### DIFF
--- a/ofrak_core/ofrak/core/apk.py
+++ b/ofrak_core/ofrak/core/apk.py
@@ -25,7 +25,6 @@ from ofrak_type.range import Range
 LOGGER = logging.getLogger(__name__)
 
 
-
 APKTOOL = ComponentExternalTool("apktool", "https://ibotpeaches.github.io/Apktool/", "-version")
 JAVA = ComponentExternalTool(
     "java",

--- a/ofrak_core/ofrak/core/apk.py
+++ b/ofrak_core/ofrak/core/apk.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import logging
 from subprocess import CalledProcessError
 from dataclasses import dataclass
 
@@ -20,6 +21,9 @@ from ofrak.core.zip import ZipArchive, UNZIP_TOOL
 from ofrak.core.binary import GenericBinary
 from ofrak.core.magic import Magic, MagicMimeIdentifier
 from ofrak_type.range import Range
+
+LOGGER = logging.getLogger(__name__)
+
 
 
 APKTOOL = ComponentExternalTool("apktool", "https://ibotpeaches.github.io/Apktool/", "-version")
@@ -70,6 +74,9 @@ class _UberApkSignerTool(ComponentExternalTool):
             )
             returncode = await proc.wait()
         except FileNotFoundError:
+            return False
+        except PermissionError:
+            LOGGER.warning("Encountered PermissionError while searching PATH for java.")
             return False
 
         return 0 == returncode

--- a/ofrak_core/ofrak/core/squashfs.py
+++ b/ofrak_core/ofrak/core/squashfs.py
@@ -37,6 +37,9 @@ class _UnsquashfsV45Tool(ComponentExternalTool):
             stdout, stderr = await proc.communicate()
         except FileNotFoundError:
             return False
+        except PermissionError:
+            LOGGER.warning("Encountered PermissionError while searching PATH for unsquashfs.")
+            return False
 
         if 0 != proc.returncode:
             return False

--- a/ofrak_core/ofrak/core/strings_analyzer.py
+++ b/ofrak_core/ofrak/core/strings_analyzer.py
@@ -11,6 +11,7 @@ from ofrak.model.resource_model import ResourceAttributes
 
 LOGGER = logging.getLogger(__name__)
 
+
 @dataclass
 class StringsAnalyzerConfig(ComponentConfig):
     min_length: int = 8

--- a/ofrak_core/ofrak/core/strings_analyzer.py
+++ b/ofrak_core/ofrak/core/strings_analyzer.py
@@ -1,5 +1,6 @@
 import asyncio
 import tempfile
+import logging
 from dataclasses import dataclass
 from typing import Dict, Optional
 
@@ -8,6 +9,7 @@ from ofrak.resource import Resource
 from ofrak.model.component_model import ComponentConfig, ComponentExternalTool
 from ofrak.model.resource_model import ResourceAttributes
 
+LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class StringsAnalyzerConfig(ComponentConfig):
@@ -44,6 +46,9 @@ class _StringsToolDependency(ComponentExternalTool):
             # ignore returncode because "strings --help" on Mac has returncode 1
             await proc.wait()
         except FileNotFoundError:
+            return False
+        except PermissionError:
+            LOGGER.warning("Encountered PermissionError while searching PATH for strings command.")
             return False
 
         return True

--- a/ofrak_core/ofrak/model/component_model.py
+++ b/ofrak_core/ofrak/model/component_model.py
@@ -72,7 +72,7 @@ class ComponentExternalTool:
         except FileNotFoundError:
             return False
         except PermissionError:
-            LOGGER.warning(f"Encountered PermissionError while searching PATH for {tool}.")
+            LOGGER.warning(f"Encountered PermissionError while searching PATH for {self.tool}.")
             return False
 
         return 0 == returncode

--- a/ofrak_core/ofrak/model/component_model.py
+++ b/ofrak_core/ofrak/model/component_model.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set, Type, TypeVar
@@ -9,6 +10,9 @@ from ofrak_type.range import Range
 
 CLIENT_COMPONENT_ID = b"__client_context__"
 CLIENT_COMPONENT_VERSION = -1
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -66,6 +70,9 @@ class ComponentExternalTool:
 
             returncode = await proc.wait()
         except FileNotFoundError:
+            return False
+        except PermissionError:
+            LOGGER.warning(f"Encountered PermissionError while searching PATH for {tool}.")
             return False
 
         return 0 == returncode


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

Catch PermissionErrors when testing for dependencies, and log a warning message.

Fixes [this issue](https://github.com/redballoonsecurity/ofrak/issues/430)
