### PR TITLE
Bump aiohttp to ~=3.9.3

### DIFF
--- a/disassemblers/ofrak_ghidra/requirements.txt
+++ b/disassemblers/ofrak_ghidra/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML>=5.4
-aiohttp~=3.8.1
+aiohttp~=3.9.3

--- a/frontend/backend/ofrak_server.Dockerfile
+++ b/frontend/backend/ofrak_server.Dockerfile
@@ -2,7 +2,7 @@ FROM redballoonsecurity/ofrak/dev:latest
 
 ARG BACKEND_DIR=.
 
-RUN python3 -m pip install aiohttp~=3.8.1
+RUN python3 -m pip install aiohttp~=3.9.3
 
 ENTRYPOINT python3 -m ofrak_ghidra.server start \
   & python3 -m ofrak gui -H 0.0.0.0 -p 8877 \

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp~=3.8.1
+aiohttp~=3.9.3
 aiohttp-cors~=0.7.0
 beartype~=0.12.0
 black==23.3.0


### PR DESCRIPTION
- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

aiohttp <3.9.3 has known security issues:
- https://github.com/redballoonsecurity/ofrak/security/dependabot/12
- https://github.com/redballoonsecurity/ofrak/security/dependabot/11
- https://github.com/redballoonsecurity/ofrak/security/dependabot/18
- https://github.com/redballoonsecurity/ofrak/security/dependabot/17
- https://github.com/redballoonsecurity/ofrak/security/dependabot/16
- https://github.com/redballoonsecurity/ofrak/security/dependabot/15
- https://github.com/redballoonsecurity/ofrak/security/dependabot/10
- https://github.com/redballoonsecurity/ofrak/security/dependabot/9

**Link to Related Issue(s)**
See above.

**Please describe the changes in your request.**
This bumps aiohttp to ~=3.9.3

**Anyone you think should look at this, specifically?**
