### PR TITLE
Support `make -k test` in docker root

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -269,7 +269,8 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
         + [
             f"test_{package_name}:\\n\\\n\t\\$(MAKE) -C {package_name} test"
             for package_name in package_names
-        ] + ["\\n"]
+        ]
+        + ["\\n"]
     )
     dockerfile_finish_parts.append(f'RUN printf "{finish_makefile}" >> Makefile\n')
     if config.entrypoint is not None:

--- a/build_image.py
+++ b/build_image.py
@@ -253,19 +253,23 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
         [
             "$INSTALL_TARGET:",
             "\\n\\\n".join(
-                [f"\tmake -C {package_name} $INSTALL_TARGET" for package_name in package_names]
+                [f"\t\\$(MAKE) -C {package_name} $INSTALL_TARGET" for package_name in package_names]
             ),
             "\\n",
         ]
     )
     dockerfile_finish_parts.append(f'RUN printf "{develop_makefile}" >> Makefile\n')
     dockerfile_finish_parts.append("RUN make $INSTALL_TARGET\n\n")
+    test_names = " ".join([f"test_{package_name}" for package_name in package_names])
     finish_makefile = "\\n\\\n".join(
         [
-            "test:",
-            "\\n\\\n".join([f"\tmake -C {package_name} test" for package_name in package_names]),
-            "\\n",
+            ".PHONY: test " + test_names,
+            "test: " + test_names,
         ]
+        + [
+            f"test_{package_name}:\\n\\\n\t\\$(MAKE) -C {package_name} test"
+            for package_name in package_names
+        ] + ["\\n"]
     )
     dockerfile_finish_parts.append(f'RUN printf "{finish_makefile}" >> Makefile\n')
     if config.entrypoint is not None:


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Creates an individual target in the root `Makefile` for each package's `make test`, with `test` depending on all of them

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Creates an individual target in the root `Makefile` for each package's `make test`, with `test` depending on all of them. This has a number of advantages, the biggest (and my motivation) is that this way `make -k test` in the container root would run through all the packages, rather than stopping on the first one with errors.

Here is an example of the relevant section of `Makefile` created for `ofrak-core-dev.yml` with this change:
```
.PHONY: test test_ofrak_type test_ofrak_io test_ofrak_patch_maker test_ofrak_core test_frontend
test: test_ofrak_type test_ofrak_io test_ofrak_patch_maker test_ofrak_core test_frontend
test_ofrak_type:
        $(MAKE) -C ofrak_type test
test_ofrak_io:
        $(MAKE) -C ofrak_io test
test_ofrak_patch_maker:
        $(MAKE) -C ofrak_patch_maker test
test_ofrak_core:
        $(MAKE) -C ofrak_core test
test_frontend:
        $(MAKE) -C frontend test
```

**Anyone you think should look at this, specifically?**
Not sure - maybe @whyitfor?