### PR TITLE
Explicitly set the Binary Ninja package file name

### DIFF
--- a/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh
+++ b/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh
@@ -5,12 +5,13 @@ else
     echo "Error: BinaryNinja license serial number not found." >&2 
     exit 1
 fi
+PACKAGE_NAME="binaryninja-headless.zip"
 INSTALL_DIR=/opt/rbs
 mkdir -p $INSTALL_DIR
 cd $INSTALL_DIR
 curl -O https://raw.githubusercontent.com/Vector35/binaryninja-api/dev/scripts/download_headless.py
 python3 -m pip --no-input install requests
-python3 download_headless.py --serial $SERIAL
-unzip BinaryNinja-headless.zip
-rm download_headless.py BinaryNinja-headless.zip
+python3 download_headless.py --serial $SERIAL --output "$PACKAGE_NAME"
+unzip "$PACKAGE_NAME"
+rm download_headless.py "$PACKAGE_NAME"
 python3 binaryninja/scripts/install_api.py


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Explicitly set the Binary Ninja downloaded package file name, so that the installer script knows what to unzip.

**Link to Related Issue(s)**
https://github.com/redballoonsecurity/ofrak/issues/450

**Please describe the changes in your request.**
The Binary Ninja accepts an `--output` argument which sets the name of the downloaded Binary Ninja package. This PR uses that argument to set the output file name to `binaryninja-headless.zip`, so that the script knows what the downloaded .zip is named. This should work across platforms and prevent renaming issues from occurring in the future.

**Anyone you think should look at this, specifically?**
@whyitfor 
