### PR TITLE
Add initial ELF first load seg extension modifier

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add an improved ISO9660 packer that leverages `mkisofs` instead of PyCdLib. ([#393](https://github.com/redballoonsecurity/ofrak/pull/393))
 - Add UEFI binary unpacker. ([#399](https://github.com/redballoonsecurity/ofrak/pull/399))
 - Add recursive identify functionality in the GUI. ([#435](https://github.com/redballoonsecurity/ofrak/pull/435))
+- Add ELF modifier to reverse extend first load segment to the beginning of the ELF if it does not already. ([#463](https://github.com/redballoonsecurity/ofrak/pull/463))
 
 ### Fixed
 - Improved flushing of filesystem entries (including symbolic links and other types) to disk. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))

--- a/ofrak_core/ofrak/core/elf/extend_first_load.py
+++ b/ofrak_core/ofrak/core/elf/extend_first_load.py
@@ -1,0 +1,80 @@
+import asyncio
+
+from ofrak import Modifier, Resource
+from ofrak.core import (
+    Elf,
+    ElfProgramHeaderModifier,
+    ElfProgramHeaderModifierConfig,
+    ElfProgramHeaderType,
+    FreeSpace,
+    Allocatable,
+)
+from ofrak_type import Range
+
+
+class ElfExtendFirstLoadSegmentModifier(Modifier[None]):
+    targets = (Elf,)
+
+    async def modify(self, resource: Resource, config=None) -> None:
+        used_space = Range.merge_ranges(
+            await asyncio.gather(
+                *(
+                    c.get_data_range_within_parent()
+                    for c in await resource.get_children()
+                    if c.get_data_id()
+                )
+            )
+        )
+        unused_space = []
+        for i in range(len(used_space) - 1):
+            first, second = used_space[i], used_space[i + 1]
+            unused_space.append(Range(first.end, second.start))
+
+        elf = await resource.view_as(Elf)
+        program_headers = await elf.get_program_headers()
+        first_program_header = list(sorted(program_headers, key=lambda p: p.p_offset))[0]
+        load_segment_offset_ranges = Range.merge_ranges(
+            Range.from_size(seg.p_offset, seg.p_filesz)
+            for seg in program_headers
+            if seg.p_type == ElfProgramHeaderType.LOAD.value
+        )
+
+        if first_program_header.p_offset == 0:
+            raise RuntimeError("ELF already has LOAD segment that maps offset 0.")
+
+        new_load_range = Range(0, first_program_header.p_offset)
+        free_space = [
+            space.intersect(new_load_range)
+            for space in unused_space
+            if new_load_range.overlaps(space)
+            and not any(space.overlaps(load_segment) for load_segment in load_segment_offset_ranges)
+        ]
+        if len(free_space) == 0:
+            raise RuntimeError("First LOAD segment cannot be made to intersect any free space.")
+
+        for space in free_space:
+            await resource.create_child_from_view(
+                FreeSpace(
+                    first_program_header.p_vaddr - first_program_header.p_offset + space.start,
+                    first_program_header.p_offset - space.start,
+                    first_program_header.get_memory_permissions(),
+                ),
+                data_range=space,
+            )
+        resource.add_tag(Allocatable)
+
+        await first_program_header.resource.run(
+            ElfProgramHeaderModifier,
+            ElfProgramHeaderModifierConfig(
+                p_offset=0,
+                p_vaddr=first_program_header.p_vaddr - first_program_header.p_offset,
+                p_paddr=(
+                    first_program_header.p_vaddr - first_program_header.p_offset
+                    if first_program_header.p_paddr != 0
+                    else 0
+                ),
+                p_filesz=first_program_header.p_filesz + first_program_header.p_offset,
+                p_memsz=first_program_header.p_memsz + first_program_header.p_offset,
+                p_align=0,
+            ),
+        )


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add ELF modifier to reverse extend first load segment to the beginning of the ELF if it does not already.