### PR TITLE
Use aiofiles for filesystem IO

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - View resource attribute string values containing only digits primarily as strings, alternatively as hex numbers. ([#423](https://github.com/redballoonsecurity/ofrak/pull/423))
 
 ### Changed
+- Use `aiofiles` for filesystem reads/writes instead of blocking IO. ([#466](https://github.com/redballoonsecurity/ofrak/pull/466))
 - Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 - `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
 - `build_image.py` supports building Docker images with OFRAK packages from any ancestor directory. ([#425](https://github.com/redballoonsecurity/ofrak/pull/425))

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -1,6 +1,7 @@
 import os
 import stat
 import tempfile
+import aiofiles
 from dataclasses import dataclass
 from typing import Dict, Iterable, Optional, Type, Union
 
@@ -193,8 +194,8 @@ class FilesystemEntry(ResourceView):
                 os.makedirs(folder_name)
         elif self.is_file():
             file_name = os.path.join(root_path, entry_path)
-            with open(file_name, "wb") as f:
-                f.write(await self.resource.get_data())
+            async with aiofiles.open(file_name, "wb") as f:
+                await f.write(await self.resource.get_data())
             self.apply_stat_attrs(file_name)
         elif self.is_device():
             device_name = os.path.join(root_path, entry_path)
@@ -411,10 +412,10 @@ class FilesystemRoot(ResourceView):
                         ),
                     )
                 elif os.path.isfile(absolute_path):
-                    with open(absolute_path, "rb") as fh:
+                    async with aiofiles.open(absolute_path, "rb") as fh:
                         await self.add_file(
                             relative_path,
-                            fh.read(),
+                            await fh.read(),
                             file_attributes_stat,
                             file_attributes_xattr,
                         )

--- a/ofrak_core/requirements-test.txt
+++ b/ofrak_core/requirements-test.txt
@@ -13,4 +13,5 @@ pytest-lazy-fixture
 pytest-cov
 pytest-xdist
 requests
+types-aiofiles
 fun-coverage==0.2.0

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles
 aiohttp~=3.9.3
 aiohttp-cors~=0.7.0
 beartype~=0.12.0


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Use `aiofiles` for filesystem IO

**Link to Related Issue(s)**

**Please describe the changes in your request.**
Replace blocking IO for file read/write with async io using `aiofiles`

**Anyone you think should look at this, specifically?**
Not sure