### PR TITLE
Switch from Debian 11 to Debian 12

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -197,7 +197,7 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
         dockerfile_base_parts += [f"### {dockerstage_path}", dockerstub]
 
     dockerfile_base_parts += [
-        "FROM python:3.8-bullseye@sha256:e1cd369204123e89646f8c001db830eddfe3e381bd5c837df00141be3bd754cb",
+        "FROM python:3.8-bookworm@sha256:01a4da15f16395a2d17dd9b673ccedcd6a6dbb4e130c8056d0d804dedac11c81",
         "",
     ]
 

--- a/disassemblers/ofrak_ghidra/Dockerstub
+++ b/disassemblers/ofrak_ghidra/Dockerstub
@@ -1,5 +1,5 @@
 # Download & install java and supervisor
-RUN apt-get update && apt-get install -y openjdk-11-jdk supervisor
+RUN apt-get update && apt-get install -y openjdk-17-jdk supervisor
 
 # Download & install ghidra
 RUN mkdir -p /opt/rbs && \

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_ghidra_program_analyzer.py
@@ -21,11 +21,11 @@ from ofrak_ghidra.ghidra_model import GhidraProject, GhidraCustomLoadProject
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.abstract import Toolchain
-from ofrak_patch_maker.toolchain.gnu_aarch64 import GNU_AARCH64_LINUX_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu_aarch64 import GNU_AARCH64_LINUX_12_Toolchain
 from ofrak_patch_maker.toolchain.gnu_arm import GNU_ARM_NONE_EABI_10_2_1_Toolchain
-from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_12_Toolchain
 from ofrak_patch_maker.toolchain.gnu_vbcc_m68k import VBCC_0_9_GNU_Hybrid_Toolchain
-from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_10_3_0_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_12_2_0_Toolchain
 from ofrak_patch_maker.toolchain.model import (
     ToolchainConfig,
     CompilerOptimizationLevel,
@@ -151,11 +151,11 @@ async def _make_dummy_program(resource: Resource, arch_info):
     """
 
     arch_map: Dict[InstructionSet, Type[Toolchain]] = {
-        InstructionSet.PPC: GNU_PPC_LINUX_10_Toolchain,
+        InstructionSet.PPC: GNU_PPC_LINUX_12_Toolchain,
         InstructionSet.ARM: GNU_ARM_NONE_EABI_10_2_1_Toolchain,
         InstructionSet.M68K: VBCC_0_9_GNU_Hybrid_Toolchain,
-        InstructionSet.AARCH64: GNU_AARCH64_LINUX_10_Toolchain,
-        InstructionSet.X86: GNU_X86_64_LINUX_EABI_10_3_0_Toolchain,
+        InstructionSet.AARCH64: GNU_AARCH64_LINUX_12_Toolchain,
+        InstructionSet.X86: GNU_X86_64_LINUX_EABI_12_2_0_Toolchain,
     }
 
     tc = arch_map[arch_info.isa](

--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -14,7 +14,6 @@ RUN apt-get -y update && \
       mtd-utils \
       pigz \
       zip \
-      qemu \
       qemu-user-static \
       u-boot-tools \
       unar \
@@ -24,7 +23,7 @@ RUN apt-get -y update && \
 RUN python3 -m pip install python-lzo
 
 # Install apktool and uber-apk-signer
-RUN apt-get -y update && apt-get -y install openjdk-11-jdk
+RUN apt-get -y update && apt-get -y install openjdk-17-jdk
 RUN wget https://raw.githubusercontent.com/iBotPeaches/Apktool/v2.3.3/scripts/linux/apktool -O /usr/local/bin/apktool && \
   wget https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.3.3.jar -O /usr/local/bin/apktool.jar && \
   wget https://github.com/patrickfav/uber-apk-signer/releases/download/v1.0.0/uber-apk-signer-1.0.0.jar -O /usr/local/bin/uber-apk-signer.jar && \
@@ -58,12 +57,6 @@ RUN cd /tmp && \
     make install && \
     cd /tmp && \
     rm -r squashfs-tools
-
-# Install Jefferson
-WORKDIR /tmp
-RUN wget https://bootstrap.pypa.io/pip/get-pip.py && python3.9 get-pip.py && python3.8 get-pip.py && rm get-pip.py
-RUN python3.9 -m pip install jefferson
-WORKDIR /
 
 # Install UEFIExtract (build from source, pinned to releae A68)
 RUN cd /tmp && \

--- a/ofrak_core/ofrak/core/apk.py
+++ b/ofrak_core/ofrak/core/apk.py
@@ -215,7 +215,9 @@ class ApkIdentifier(Identifier):
     async def identify(self, resource: Resource, config=None) -> None:
         await resource.run(MagicMimeIdentifier)
         magic = resource.get_attributes(Magic)
-        if magic is not None and magic.mime in ["application/java-archive", "application/zip"]:
+        if magic.mime == "application/vnd.android.package-archive":
+            resource.add_tag(Apk)
+        elif magic is not None and magic.mime in ["application/java-archive", "application/zip"]:
             with tempfile.NamedTemporaryFile(suffix=".zip") as temp_file:
                 temp_file.write(await resource.get_data())
                 temp_file.flush()

--- a/ofrak_core/ofrak/core/apk.py
+++ b/ofrak_core/ofrak/core/apk.py
@@ -25,10 +25,10 @@ from ofrak_type.range import Range
 APKTOOL = ComponentExternalTool("apktool", "https://ibotpeaches.github.io/Apktool/", "-version")
 JAVA = ComponentExternalTool(
     "java",
-    "https://openjdk.org/projects/jdk/11/",
+    "https://openjdk.org/projects/jdk/17/",
     "-help",
-    apt_package="openjdk-11-jdk",
-    brew_package="openjdk@11",
+    apt_package="openjdk-17-jdk",
+    brew_package="openjdk@17",
 )
 
 

--- a/ofrak_core/test_ofrak/components/test_elf_load_aligment_modifier.py
+++ b/ofrak_core/test_ofrak/components/test_elf_load_aligment_modifier.py
@@ -76,7 +76,7 @@ ELF_MODIFIERS_TEST_CASES = [
 async def verify_modifier_result(test_case: ElfModifierTestCase, output_path: str):
     if test_case.ld_preload_host:
         process = subprocess.run(
-            f"LD_PRELOAD={output_path} {test_case.ld_preload_host} "
+            f"LD_PRELOAD=\"/lib/x86_64-linux-gnu/libc.so.6 {output_path}\" {test_case.ld_preload_host} "
             f"{' '.join(test_case.issue_args)}",
             shell=True,
             capture_output=True,

--- a/ofrak_core/test_ofrak/components/test_elf_load_aligment_modifier.py
+++ b/ofrak_core/test_ofrak/components/test_elf_load_aligment_modifier.py
@@ -76,7 +76,7 @@ ELF_MODIFIERS_TEST_CASES = [
 async def verify_modifier_result(test_case: ElfModifierTestCase, output_path: str):
     if test_case.ld_preload_host:
         process = subprocess.run(
-            f"LD_PRELOAD=\"/lib/x86_64-linux-gnu/libc.so.6 {output_path}\" {test_case.ld_preload_host} "
+            f'LD_PRELOAD="/lib/x86_64-linux-gnu/libc.so.6 {output_path}" {test_case.ld_preload_host} '
             f"{' '.join(test_case.issue_args)}",
             shell=True,
             capture_output=True,

--- a/ofrak_core/test_ofrak/components/test_patch_maker_component.py
+++ b/ofrak_core/test_ofrak/components/test_patch_maker_component.py
@@ -8,7 +8,7 @@ import subprocess
 
 from ofrak.core import MemoryRegion
 from ofrak.model.resource_model import EphemeralResourceContextFactory, ClientResourceContextFactory
-from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_10_3_0_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_12_2_0_Toolchain
 
 from ofrak_patch_maker.toolchain.gnu_arm import GNU_ARM_NONE_EABI_10_2_1_Toolchain
 from ofrak_patch_maker.toolchain.llvm_12 import LLVM_12_0_1_Toolchain
@@ -125,12 +125,12 @@ TEST_CASE_CONFIGS = [
     FunctionReplacementTestCaseConfig(
         X86_64_PROGRAM_CONFIG,
         "patch_basic.c",
-        "GNU_X86_64_LINUX_EABI_10_3_0",
-        GNU_X86_64_LINUX_EABI_10_3_0_Toolchain,
+        "GNU_X86_64_LINUX_EABI_12_2_0",
+        GNU_X86_64_LINUX_EABI_12_2_0_Toolchain,
         [
             "00000000004004c4 <main>:",
             "  4004c4: b8 03 00 00 00        mov    $0x3,%eax",
-            "  4004c9: c3                    retq",
+            "  4004c9: c3                    ret",
         ],
     ),
     FunctionReplacementTestCaseConfig(
@@ -144,7 +144,7 @@ TEST_CASE_CONFIGS = [
             "  4004c5: 48 89 e5 movq %rsp, %rbp",
             "  4004c8: b8 03 00 00 00 movl $3, %eax",
             "  4004cd: 5d popq %rbp",
-            "  4004ce: c3 retq",
+            "  4004ce: c3 ret",
         ],
     ),
     FunctionReplacementTestCaseConfig(
@@ -161,21 +161,21 @@ TEST_CASE_CONFIGS = [
     FunctionReplacementTestCaseConfig(
         X86_64_PROGRAM_CONFIG,
         "patch_two_functions.c",
-        "GNU_X86_64_LINUX_EABI_10_3_0",
-        GNU_X86_64_LINUX_EABI_10_3_0_Toolchain,
+        "GNU_X86_64_LINUX_EABI_12_2_0",
+        GNU_X86_64_LINUX_EABI_12_2_0_Toolchain,
         [
             "00000000004004c4 <main>:",
             "  4004c4: 55                    push   %rbp",
             "  4004c5: 48 89 e5              mov    %rsp,%rbp",
             "  4004c8: b8 00 00 00 00        mov    $0x0,%eax",
-            "  4004cd: e8 02 00 00 00        callq  4004d4 <main+0x10>",
+            "  4004cd: e8 02 00 00 00        call   4004d4 <main+0x10>",
             "  4004d2: 5d                    pop    %rbp",
-            "  4004d3: c3                    retq   ",
+            "  4004d3: c3                    ret    ",
             "  4004d4: 55                    push   %rbp",
             "  4004d5: 48 89 e5              mov    %rsp,%rbp",
             "  4004d8: b8 04 00 00 00        mov    $0x4,%eax",
             "  4004dd: 5d                    pop    %rbp",
-            "  4004de: c3                    retq   ",
+            "  4004de: c3                    ret    ",
         ],
         CompilerOptimizationLevel.NONE,
     ),

--- a/ofrak_core/test_ofrak/components/test_symbolic_analysis.py
+++ b/ofrak_core/test_ofrak/components/test_symbolic_analysis.py
@@ -29,7 +29,7 @@ def readelf_get_writable_sections(elf_executable_file) -> Dict[int, bool]:
     lines = proc.stdout.split("\n")
     result = dict()
     for line in lines:
-        lstripped_line = line.lstrip()
+        lstripped_line = line.lstrip(" [")
         if len(lstripped_line) == 0:
             continue
         if (
@@ -48,7 +48,7 @@ def readelf_get_writable_sections(elf_executable_file) -> Dict[int, bool]:
         if len(flg_lk_inf_al) == 0 or not flg_lk_inf_al[0].isalpha():
             continue
         section_flags = flg_lk_inf_al[0]
-        num = int(_num.strip("[]"))
+        num = int(_num.rstrip("]"))
         result[num] = "W" in section_flags
 
     return result

--- a/ofrak_core/test_ofrak/components/test_uefi_component.py
+++ b/ofrak_core/test_ofrak/components/test_uefi_component.py
@@ -66,6 +66,7 @@ class TestUefiComponent(UnpackAndVerifyPattern):
                 await descendent.view_as(FilesystemEntry)
             ).get_path(): await descendent.get_data()
             for descendent in await unpacked_root_resource.get_descendants()
+            if descendent.has_tag(FilesystemEntry)
         }
         return result
 

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -15,17 +15,17 @@ RUN cd /tmp && \
     rm -rf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
 
 # LINUX GNU + BINUTILS
-RUN apt-get -y update  && apt-get -y install software-properties-common gcc-10
+RUN apt-get -y update  && apt-get -y install software-properties-common gcc-12
 
 #X64-64 toolchain for arm64 Docker images
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-    apt-get update && apt-get install -y gcc-10-x86-64-linux-gnu; \
+    apt-get update && apt-get install -y gcc-12-x86-64-linux-gnu; \
 fi;
 
 #M68k GNU 10 Linux
 #Only exists for x86
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-    apt-get update && apt-get install -y gcc-10-m68k-linux-gnu; \
+    apt-get update && apt-get install -y gcc-12-m68k-linux-gnu; \
 fi;
 
 #M68k VBCC
@@ -48,7 +48,7 @@ RUN cd /tmp/vbcc && cp ./bin/* /opt/rbs/toolchain/vbcc_0_9/bin/ && \
 
 #AARCH64 GNU 10 Linux
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-    apt-get update && apt-get install -y gcc-10-aarch64-linux-gnu; \
+    apt-get update && apt-get install -y gcc-12-aarch64-linux-gnu; \
 fi;
 
 #AVR GCC
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y gcc-avr binutils-avr avr-libc
 
 #PPC GNU 10 Linux
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-    apt-get update && apt-get install -y gcc-10-powerpc-linux-gnu; \
+    apt-get update && apt-get install -y gcc-12-powerpc-linux-gnu; \
 fi;
 
 #BCC (GCC) SPARC v8

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain.conf
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain.conf
@@ -12,37 +12,37 @@ LINKER = /opt/rbs/toolchain/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi
 BIN_PARSER = /opt/rbs/toolchain/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
 LIB = /opt/rbs/toolchain/gcc-arm-none-eabi-10-2020-q4-major/lib
 
-[GNU_M68K_LINUX_10]
-PREPROCESSOR = /usr/bin/m68k-linux-gnu-gcc-10
-COMPILER = /usr/bin/m68k-linux-gnu-gcc-10
+[GNU_M68K_LINUX_12]
+PREPROCESSOR = /usr/bin/m68k-linux-gnu-gcc-12
+COMPILER = /usr/bin/m68k-linux-gnu-gcc-12
 LINKER = /usr/bin/m68k-linux-gnu-ld
 BIN_PARSER = /usr/bin/m68k-linux-gnu-objdump
 
 [VBCC_M68K_0_9]
-PREPROCESSOR = /usr/bin/m68k-linux-gnu-gcc-10
+PREPROCESSOR = /usr/bin/m68k-linux-gnu-gcc-12
 COMPILER = /opt/rbs/toolchain/vbcc_0_9/bin/vbccm68k
 LINKER = /usr/bin/m68k-linux-gnu-ld
 BIN_PARSER = /usr/bin/m68k-linux-gnu-objdump
 
-[GNU_X86_64_LINUX_EABI_10_3_0]
+[GNU_X86_64_LINUX_EABI_12_2_0]
 # Expecting the user host is 64-bit GNU/Linux, we're replacing the system compiler
-PREPROCESSOR = /usr/bin/x86_64-linux-gnu-gcc-10
-COMPILER = /usr/bin/x86_64-linux-gnu-gcc-10
+PREPROCESSOR = /usr/bin/x86_64-linux-gnu-gcc-12
+COMPILER = /usr/bin/x86_64-linux-gnu-gcc-12
 LINKER = /usr/bin/x86_64-linux-gnu-ld
 BIN_PARSER = /usr/bin/x86_64-linux-gnu-objdump
 LIB = /usr/lib/x86_64-linux-gnu
 
-[GNU_X86_32_LINUX_EABI_10_3_0]
+[GNU_X86_32_LINUX_EABI_12_2_0]
 # Expecting the user host is 64-bit GNU/Linux, we're replacing the system compiler
-PREPROCESSOR = /usr/bin/x86_64-linux-gnu-gcc-10
-COMPILER = /usr/bin/x86_64-linux-gnu-gcc-10
+PREPROCESSOR = /usr/bin/x86_64-linux-gnu-gcc-12
+COMPILER = /usr/bin/x86_64-linux-gnu-gcc-12
 LINKER = /usr/bin/x86_64-linux-gnu-ld
 BIN_PARSER = /usr/bin/x86_64-linux-gnu-objdump
 LIB = /usr/lib/x86_64-linux-gnu
 
-[GNU_AARCH64_LINUX_10]
-PREPROCESSOR = /usr/bin/aarch64-linux-gnu-gcc-10
-COMPILER = /usr/bin/aarch64-linux-gnu-gcc-10
+[GNU_AARCH64_LINUX_12]
+PREPROCESSOR = /usr/bin/aarch64-linux-gnu-gcc-12
+COMPILER = /usr/bin/aarch64-linux-gnu-gcc-12
 LINKER = /usr/bin/aarch64-linux-gnu-ld
 BIN_PARSER = /usr/bin/aarch64-linux-gnu-objdump
 
@@ -52,9 +52,9 @@ COMPILER = /usr/bin/avr-gcc
 LINKER = /usr/bin/avr-ld
 BIN_PARSER = /usr/bin/avr-objdump
 
-[GNU_PPC_LINUX_10]
-PREPROCESSOR = /usr/bin/powerpc-linux-gnu-gcc-10
-COMPILER = /usr/bin/powerpc-linux-gnu-gcc-10
+[GNU_PPC_LINUX_12]
+PREPROCESSOR = /usr/bin/powerpc-linux-gnu-gcc-12
+COMPILER = /usr/bin/powerpc-linux-gnu-gcc-12
 LINKER = /usr/bin/powerpc-linux-gnu-ld
 BIN_PARSER = /usr/bin/powerpc-linux-gnu-objdump
 

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu.py
@@ -345,7 +345,7 @@ class Abstract_GNU_Toolchain(Toolchain, ABC):
         return self._parser.parse_relocations(readobj_output)
 
 
-class GNU_10_Toolchain(Abstract_GNU_Toolchain):
+class GNU_Toolchain(Abstract_GNU_Toolchain):
     def __init__(
         self,
         processor: ArchInfo,

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_aarch64.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_aarch64.py
@@ -1,5 +1,5 @@
 from ofrak_type.memory_permissions import MemoryPermissions
-from ofrak_patch_maker.toolchain.gnu import GNU_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu import GNU_Toolchain
 from ofrak_patch_maker.binary_parser.gnu import GNU_V10_ELF_Parser
 from ofrak_patch_maker.toolchain.model import ToolchainConfig
 from ofrak_type.architecture import InstructionSet, SubInstructionSet, ArchInfo
@@ -7,7 +7,7 @@ import logging
 from typing import Tuple
 
 
-class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
+class GNU_AARCH64_LINUX_12_Toolchain(GNU_Toolchain):
     binary_file_parsers = [GNU_V10_ELF_Parser()]
 
     def __init__(
@@ -24,7 +24,7 @@ class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
 
     @property
     def name(self) -> str:
-        return "GNU_AARCH64_LINUX_10"
+        return "GNU_AARCH64_LINUX_12"
 
     @property
     def segment_alignment(self) -> int:

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_arm.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_arm.py
@@ -1,11 +1,11 @@
 from ofrak_patch_maker.binary_parser.gnu import GNU_ELF_Parser
-from ofrak_patch_maker.toolchain.gnu import GNU_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu import GNU_Toolchain
 from ofrak_patch_maker.toolchain.model import ToolchainConfig, ToolchainException
 from ofrak_type.architecture import InstructionSet, SubInstructionSet, ArchInfo
 import logging
 
 
-class GNU_ARM_NONE_EABI_10_2_1_Toolchain(GNU_10_Toolchain):
+class GNU_ARM_NONE_EABI_10_2_1_Toolchain(GNU_Toolchain):
     binary_file_parsers = [GNU_ELF_Parser()]
 
     def __init__(

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_m68k.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_m68k.py
@@ -3,13 +3,13 @@ from typing import Tuple
 from ofrak_type.memory_permissions import MemoryPermissions
 
 from ofrak_type.architecture import InstructionSet, ArchInfo
-from ofrak_patch_maker.toolchain.gnu import GNU_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu import GNU_Toolchain
 from ofrak_patch_maker.binary_parser.gnu import GNU_ELF_Parser
 from ofrak_patch_maker.toolchain.model import ToolchainConfig
 import logging
 
 
-class GNU_M68K_LINUX_10_Toolchain(GNU_10_Toolchain):
+class GNU_M68K_LINUX_12_Toolchain(GNU_Toolchain):
     binary_file_parsers = [GNU_ELF_Parser()]
 
     def __init__(
@@ -26,7 +26,7 @@ class GNU_M68K_LINUX_10_Toolchain(GNU_10_Toolchain):
 
     @property
     def name(self) -> str:
-        return "GNU_M68K_LINUX_10"
+        return "GNU_M68K_LINUX_12"
 
     @property
     def segment_alignment(self) -> int:

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_ppc.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_ppc.py
@@ -2,12 +2,12 @@ import logging
 from typing import Optional
 
 from ofrak_patch_maker.binary_parser.gnu import GNU_V10_ELF_Parser
-from ofrak_patch_maker.toolchain.gnu import GNU_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu import GNU_Toolchain
 from ofrak_patch_maker.toolchain.model import ToolchainConfig
 from ofrak_type import ArchInfo, InstructionSet, MemoryPermissions
 
 
-class GNU_PPC_LINUX_10_Toolchain(GNU_10_Toolchain):
+class GNU_PPC_LINUX_12_Toolchain(GNU_Toolchain):
     binary_file_parsers = [GNU_V10_ELF_Parser()]
 
     def __init__(
@@ -28,7 +28,7 @@ class GNU_PPC_LINUX_10_Toolchain(GNU_10_Toolchain):
 
     @property
     def name(self) -> str:
-        return "GNU_PPC_LINUX_10"
+        return "GNU_PPC_LINUX_12"
 
     def _get_assembler_target(self, processor: ArchInfo) -> Optional[str]:
         if processor.isa != InstructionSet.PPC:

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_x64.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_x64.py
@@ -1,4 +1,4 @@
-from ofrak_patch_maker.toolchain.gnu import GNU_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu import GNU_Toolchain
 from ofrak_patch_maker.binary_parser.gnu import GNU_V10_ELF_Parser
 from ofrak_patch_maker.toolchain.model import ToolchainConfig
 import logging
@@ -6,7 +6,7 @@ import logging
 from ofrak_type.architecture import ArchInfo
 
 
-class GNU_X86_64_LINUX_EABI_10_3_0_Toolchain(GNU_10_Toolchain):
+class GNU_X86_64_LINUX_EABI_12_2_0_Toolchain(GNU_Toolchain):
     binary_file_parsers = [GNU_V10_ELF_Parser()]
 
     def __init__(
@@ -29,7 +29,7 @@ class GNU_X86_64_LINUX_EABI_10_3_0_Toolchain(GNU_10_Toolchain):
 
     @property
     def name(self) -> str:
-        return "GNU_X86_64_LINUX_EABI_10_3_0"
+        return "GNU_X86_64_LINUX_EABI_12_2_0"
 
     @property
     def segment_alignment(self) -> int:

--- a/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_x86.py
+++ b/ofrak_patch_maker/ofrak_patch_maker/toolchain/gnu_x86.py
@@ -1,8 +1,8 @@
-from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_10_3_0_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_12_2_0_Toolchain
 from ofrak_type import ArchInfo
 
 
-class GNU_X86_32_LINUX_EABI_10_3_0_Toolchain(GNU_X86_64_LINUX_EABI_10_3_0_Toolchain):
+class GNU_X86_32_LINUX_EABI_12_2_0_Toolchain(GNU_X86_64_LINUX_EABI_12_2_0_Toolchain):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -12,7 +12,7 @@ class GNU_X86_32_LINUX_EABI_10_3_0_Toolchain(GNU_X86_64_LINUX_EABI_10_3_0_Toolch
 
     @property
     def name(self) -> str:
-        return "GNU_X86_32_LINUX_EABI_10_3_0"
+        return "GNU_X86_32_LINUX_EABI_12_2_0"
 
     @property
     def segment_alignment(self) -> int:

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_aarch64_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_aarch64_toolchain.py
@@ -6,7 +6,7 @@ import pytest
 from ofrak_type import ArchInfo
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
-from ofrak_patch_maker.toolchain.gnu_aarch64 import GNU_AARCH64_LINUX_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu_aarch64 import GNU_AARCH64_LINUX_12_Toolchain
 from ofrak_patch_maker.toolchain.model import (
     Segment,
     CompilerOptimizationLevel,
@@ -34,7 +34,7 @@ AARCH64_EXTENSION = ".aarch64"
 @pytest.fixture(
     params=[
         ToolchainUnderTest(
-            GNU_AARCH64_LINUX_10_Toolchain,
+            GNU_AARCH64_LINUX_12_Toolchain,
             ArchInfo(
                 InstructionSet.AARCH64,
                 None,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_m68k_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_m68k_toolchain.py
@@ -6,7 +6,7 @@ import pytest
 from ofrak_type import ArchInfo
 from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
-from ofrak_patch_maker.toolchain.gnu_m68k import GNU_M68K_LINUX_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu_m68k import GNU_M68K_LINUX_12_Toolchain
 from ofrak_patch_maker.toolchain.gnu_vbcc_m68k import VBCC_0_9_GNU_Hybrid_Toolchain
 from ofrak_patch_maker.toolchain.model import (
     CompilerOptimizationLevel,
@@ -35,7 +35,7 @@ M68K_EXTENSION = ".m68k"
 @pytest.fixture(
     params=[
         ToolchainUnderTest(
-            GNU_M68K_LINUX_10_Toolchain,
+            GNU_M68K_LINUX_12_Toolchain,
             ArchInfo(
                 InstructionSet.M68K,
                 None,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_ppc_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_ppc_toolchain.py
@@ -2,7 +2,7 @@ import pytest
 
 from ofrak_patch_maker_test import ToolchainUnderTest
 
-from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_12_Toolchain
 from ofrak_type import ArchInfo, InstructionSet, BitWidth, Endianness
 
 from ofrak_patch_maker_test.toolchain_asm import (
@@ -20,7 +20,7 @@ PPC_EXTENSION = ".ppc"
 @pytest.fixture(
     params=[
         ToolchainUnderTest(
-            GNU_PPC_LINUX_10_Toolchain,
+            GNU_PPC_LINUX_12_Toolchain,
             ArchInfo(
                 InstructionSet.PPC,
                 None,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_symbol_parsing.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_symbol_parsing.py
@@ -6,11 +6,11 @@ import pytest
 
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.abstract import Toolchain
-from ofrak_patch_maker.toolchain.gnu_aarch64 import GNU_AARCH64_LINUX_10_Toolchain
+from ofrak_patch_maker.toolchain.gnu_aarch64 import GNU_AARCH64_LINUX_12_Toolchain
 from ofrak_patch_maker.toolchain.gnu_arm import GNU_ARM_NONE_EABI_10_2_1_Toolchain
 from ofrak_patch_maker.toolchain.gnu_avr import GNU_AVR_5_Toolchain
-from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_10_Toolchain
-from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_10_3_0_Toolchain
+from ofrak_patch_maker.toolchain.gnu_ppc import GNU_PPC_LINUX_12_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_12_2_0_Toolchain
 from ofrak_patch_maker.toolchain.llvm_12 import LLVM_12_0_1_Toolchain
 from ofrak_patch_maker.toolchain.model import (
     ToolchainConfig,
@@ -82,11 +82,11 @@ TOOLCHAINS_AND_TARGETS = [
     #     ArchInfo(InstructionSet.M68K, None, BitWidth.BIT_32, Endianness.LITTLE_ENDIAN, None)
     # ),
     (
-        GNU_X86_64_LINUX_EABI_10_3_0_Toolchain,
+        GNU_X86_64_LINUX_EABI_12_2_0_Toolchain,
         ArchInfo(InstructionSet.X86, None, BitWidth.BIT_64, Endianness.LITTLE_ENDIAN, None),
     ),
     (
-        GNU_PPC_LINUX_10_Toolchain,
+        GNU_PPC_LINUX_12_Toolchain,
         ArchInfo(InstructionSet.PPC, None, BitWidth.BIT_32, Endianness.BIG_ENDIAN, None),
     ),
     (
@@ -100,7 +100,7 @@ TOOLCHAINS_AND_TARGETS = [
         ),
     ),
     (
-        GNU_AARCH64_LINUX_10_Toolchain,
+        GNU_AARCH64_LINUX_12_Toolchain,
         ArchInfo(InstructionSet.AARCH64, None, BitWidth.BIT_64, Endianness.LITTLE_ENDIAN, None),
     ),
 ]

--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_x86_toolchain.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_x86_toolchain.py
@@ -2,8 +2,8 @@ import pytest
 
 from ofrak_type import ArchInfo
 
-from ofrak_patch_maker.toolchain.gnu_x86 import GNU_X86_32_LINUX_EABI_10_3_0_Toolchain
-from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_10_3_0_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x86 import GNU_X86_32_LINUX_EABI_12_2_0_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_12_2_0_Toolchain
 from ofrak_patch_maker_test import ToolchainUnderTest
 from ofrak_patch_maker_test.toolchain_c import run_hello_world_test, run_bounds_check_test
 from ofrak_type.architecture import (
@@ -19,7 +19,7 @@ X86_EXTENSION = ".x86"
 @pytest.fixture(
     params=[
         ToolchainUnderTest(
-            GNU_X86_64_LINUX_EABI_10_3_0_Toolchain,
+            GNU_X86_64_LINUX_EABI_12_2_0_Toolchain,
             ArchInfo(
                 InstructionSet.X86,
                 None,
@@ -30,7 +30,7 @@ X86_EXTENSION = ".x86"
             X86_EXTENSION,
         ),
         ToolchainUnderTest(
-            GNU_X86_32_LINUX_EABI_10_3_0_Toolchain,
+            GNU_X86_32_LINUX_EABI_12_2_0_Toolchain,
             ArchInfo(
                 InstructionSet.X86,
                 None,

--- a/ofrak_patch_maker/ofrak_patch_maker_test/toolchain_c.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/toolchain_c.py
@@ -6,7 +6,7 @@ from ofrak_patch_maker.model import PatchRegionConfig
 from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.gnu_avr import GNU_AVR_5_Toolchain
 from ofrak_patch_maker.toolchain.gnu_bcc_sparc import GNU_BCC_SPARC_Toolchain
-from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_10_3_0_Toolchain
+from ofrak_patch_maker.toolchain.gnu_x64 import GNU_X86_64_LINUX_EABI_12_2_0_Toolchain
 from ofrak_patch_maker.toolchain.model import (
     ToolchainConfig,
     BinFileType,
@@ -143,7 +143,7 @@ def run_hello_world_test(toolchain_under_test: ToolchainUnderTest):
             )
             current_vm_address += s.length
 
-            if toolchain_under_test.toolchain in [GNU_X86_64_LINUX_EABI_10_3_0_Toolchain]:
+            if toolchain_under_test.toolchain in [GNU_X86_64_LINUX_EABI_12_2_0_Toolchain]:
                 if current_vm_address % 16 > 0:
                     current_vm_address += 16 - current_vm_address % 16
             else:


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Changes the docker configuration to use Debian 12 Bookworm rather then Debian 11 Bullseye.

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Changes the docker configuration to use Debian 12 Bookworm rather then Debian 11 Bullseye. This requires switching gcc-10 to gcc-12 for gcc installed from apt, and openjdk from 11 to 17.

**Anyone you think should look at this, specifically?**
@whyitfor 