### PR TITLE
Fix an issue with parallel tests potentially clashing

### DIFF
--- a/ofrak_core/requirements-test.txt
+++ b/ofrak_core/requirements-test.txt
@@ -1,6 +1,7 @@
 autoflake==1.4
 # pytest-lazy-fixture does not work with pytest 8.0.0 - https://github.com/TvoroG/pytest-lazy-fixture/issues/65
 pytest<8.0
+filelock
 hypothesis~=6.39.3
 hypothesis-trio
 trio-asyncio

--- a/ofrak_core/test_ofrak/components/test_patch_maker_component.py
+++ b/ofrak_core/test_ofrak/components/test_patch_maker_component.py
@@ -231,7 +231,7 @@ async def test_function_replacement_modifier(ofrak_context: OFRAKContext, config
 
     await target_program.resource.run(FunctionReplacementModifier, function_replacement_config)
     new_program_path = f"replaced_{Path(config.program.path).name}"
-    
+
     # When running tests in parallel, do this one at a time
     lock = filelock.FileLock(new_program_path + ".lock")
     with lock:


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix an issue with parallel tests potentially clashing

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
The `test_function_replacement_modifier` in `ofrak/ofrak_core/test_ofrak/components/test_patch_maker_component.py` is configured to run several times, sometimes writing the same `replaced_hello.out` program. When running tests in parallel, this can create spurious failures if two tests try to write the output binary at the same time. This change introduces an inter-process file lock to avoid this.

**Anyone you think should look at this, specifically?**
Not sure