### PR TITLE
Support `application/vnd.android.package-archive` mime type for APKs

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
+- Support `application/vnd.android.package-archive` mime type for APKs, which is returned by newer versions of libmagic ([#470](https://github.com/redballoonsecurity/ofrak/pull/470))
 - Add links to other resources and locations in comments with an autocomplete feature in the comment view. ([#447](https://github.com/redballoonsecurity/ofrak/pull/447)) 
 - Add modifier to add and remove sections using lief. ([#443](https://github.com/redballoonsecurity/ofrak/pull/443))
 - Add tabbed content views and a decompilation view to the OFRAK GUI. ([#436](https://github.com/redballoonsecurity/ofrak/pull/436/))

--- a/ofrak_core/ofrak/core/apk.py
+++ b/ofrak_core/ofrak/core/apk.py
@@ -215,7 +215,9 @@ class ApkIdentifier(Identifier):
     async def identify(self, resource: Resource, config=None) -> None:
         await resource.run(MagicMimeIdentifier)
         magic = resource.get_attributes(Magic)
-        if magic is not None and magic.mime in ["application/java-archive", "application/zip"]:
+        if magic.mime == "application/vnd.android.package-archive":
+            resource.add_tag(Apk)
+        elif magic is not None and magic.mime in ["application/java-archive", "application/zip"]:
             with tempfile.NamedTemporaryFile(suffix=".zip") as temp_file:
                 temp_file.write(await resource.get_data())
                 temp_file.flush()


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Support `application/vnd.android.package-archive` mime type for APKs, which is returned by newer versions of libmagic

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
In Debian 12 Bookworm with libmagic 5.44-3, `ofrak_core/test_ofrak/components/test_apk.py` currently fails, as the `ApkIdentifier` does not recognize the test apk file as such. The issue is that currently `ApkIdentifier` expects apks to be recognized by libmime as `application/java-archive` or `application/zip` but in fact it is recognized as `application/vnd.android.package-archive`. This change adds `application/vnd.android.package-archive` to `ApkIdentifier` - for that mime type, the `Apk` tag is immediately added without checking the archive contents. 

Note that for newer libmagic the old code is not actually needed (and would only cause the identifier to take too long to reject the non-APK zip archives), but I kept it as we obviously want to support older versions of libmagic as well for time being.

**Anyone you think should look at this, specifically?**
Not sure.