### PR TITLE
Use GzipFile python unpacker for speed, fall back on pigz if needed

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - View resource attribute string values containing only digits primarily as strings, alternatively as hex numbers. ([#423](https://github.com/redballoonsecurity/ofrak/pull/423))
 
 ### Changed
+- In `GripUnpacker`, use `gzip.GzipFile` python unpacker for speed, fall back on `pigz` if needed ([#472](https://github.com/redballoonsecurity/ofrak/pull/472))
 - Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 - `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))
 - `build_image.py` supports building Docker images with OFRAK packages from any ancestor directory. ([#425](https://github.com/redballoonsecurity/ofrak/pull/425))


### PR DESCRIPTION
- [X ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Use GzipFile python unpacker for speed, fall back on pigz if needed

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Back before OFRAK became public we switched to using external gzip, and then later in #79 we switched to pigz. The reason the initial switch to gzip was made is because unlike python gzip, gzip and pigz binaries are willing to accept gzipped data with extra junk at the end as a "warning" (exit code 2, as opposed to exit code 1 for errors). Unfortunately, spawning external processes has nontrivial overhead, and asyncio is not enough to mitigate it. This commit tries a compromise - try `gzip.GzipFile` in python first, then fall back to pigz if BadGzipFile is raise.

**Anyone you think should look at this, specifically?**
@whyitfor 