### PR TITLE
Do not run Ghidra auto-analysis on import

### DIFF
--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `ofrak-ghidra` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Fixed
+- Do not run Ghidra auto-analysis upon importing a program
 
 ## 0.1.1 - 2024-02-15
 ### Added

--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Fixed
-- Do not run Ghidra auto-analysis upon importing a program
+- Do not run Ghidra auto-analysis upon importing a program. ([#473](https://github.com/redballoonsecurity/ofrak/pull/473))
 
 ## 0.1.1 - 2024-02-15
 ### Added

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_analyzer.py
@@ -183,6 +183,7 @@ class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
             "-p",
             "-import",
             full_fname,
+            "-noanalysis",
         ]
 
         if not use_existing:


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
* Do not run Ghidra auto-analysis upon importing a program

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
This change adds `-noanalysis` to the import command in `_do_ghidra_import` in the `GhidraProjectAnalyzer`. Without this change, Ghidra analysis runs every time the `GhidraProjectAnalyzer` runs. This consumes a significant amount of time that is not necessary if using a pre-analyzed Ghidra project. By adding `-noanalysis` to the import command, the Ghidra analysis will run conditionally in `_do_ghidra_analyze_and_serve`, depending on if a pre-analyzed Ghidra project has been passed into the analyzer config.

**Anyone you think should look at this, specifically?**
@whyitfor @SamL98 