### PR TITLE
Make the log file name configurable and include timestamp by default

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - View resource attribute string values containing only digits primarily as strings, alternatively as hex numbers. ([#423](https://github.com/redballoonsecurity/ofrak/pull/423))
 
 ### Changed
+- By default, the ofrak log is now `ofrak-YYYYMMDDhhmmss.log` rather than just `ofrak.log` and the name can be specified on the command line ([#480](https://github.com/redballoonsecurity/ofrak/pull/480))
 - In `GripUnpacker`, use `gzip.GzipFile` python unpacker for speed, fall back on `pigz` if needed ([#472](https://github.com/redballoonsecurity/ofrak/pull/472))
 - Change `FreeSpaceModifier` & `PartialFreeSpaceModifier` behavior: an optional stub that isn't free space can be provided and fill-bytes for free space can be specified. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 - `Resource.flush_to_disk` method renamed to `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -14,7 +14,7 @@ from importlib_metadata import entry_points
 
 from ofrak.component.interface import ComponentInterface
 from ofrak.model.component_model import ComponentExternalTool
-from ofrak.ofrak_context import OFRAKContext, OFRAK
+from ofrak.ofrak_context import DEFAULT_LOG_FILE, OFRAKContext, OFRAK
 from synthol.injector import DependencyInjector
 
 BACKEND_PACKAGES: Dict[Optional[str], Set[str]] = {
@@ -128,6 +128,11 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
             default=OFRAK.DEFAULT_LOG_LEVEL,
         )
         command_subparser.add_argument(
+            "--log-file",
+            help="Log file to use; defaults to ofrak<YYYYMMDDhhmmss.log in a temp directory",
+            default=DEFAULT_LOG_FILE,
+        )
+        command_subparser.add_argument(
             "--exclude-components-missing-dependencies",
             "-x",
             help="When initializing OFRAK, check each component's dependency and do not use any "
@@ -163,6 +168,7 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
             logging_level = getattr(logging, args.logging_level.upper())
         ofrak = OFRAK(
             logging_level=logging_level,
+            log_file=args.log_file,
             exclude_components_missing_dependencies=args.exclude_components_missing_dependencies,
         )
 

--- a/ofrak_core/ofrak/cli/ofrak_cli.py
+++ b/ofrak_core/ofrak/cli/ofrak_cli.py
@@ -129,7 +129,7 @@ class OfrakCommandRunsScript(OfrakCommand, ABC):
         )
         command_subparser.add_argument(
             "--log-file",
-            help="Log file to use; defaults to ofrak<YYYYMMDDhhmmss.log in a temp directory",
+            help="Log file to use; defaults to ofrak<YYYYMMDDhhmmss>.log in a temp directory",
             default=DEFAULT_LOG_FILE,
         )
         command_subparser.add_argument(

--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -30,7 +30,7 @@ from ofrak.service.job_service_i import JobServiceInterface
 from ofrak.service.resource_service_i import ResourceServiceInterface
 
 LOGGER = logging.getLogger("ofrak")
-DEFAULT_OFRAK_LOG_FILE = os.path.join(tempfile.gettempdir(), "ofrak.log")
+DEFAULT_LOG_FILE = os.path.join(tempfile.gettempdir(), f"ofrak_{time.strftime('%Y%m%d%H%M%S')}.log")
 
 
 class OFRAKContext:
@@ -122,6 +122,7 @@ class OFRAK:
     def __init__(
         self,
         logging_level: int = DEFAULT_LOG_LEVEL,
+        log_file: Optional[str] = None,
         exclude_components_missing_dependencies: bool = False,
     ):
         """
@@ -132,7 +133,9 @@ class OFRAK:
         not use any components missing some dependencies
         """
         logging.basicConfig(level=logging_level, format="[%(filename)15s:%(lineno)5s] %(message)s")
-        logging.getLogger().addHandler(logging.FileHandler(DEFAULT_OFRAK_LOG_FILE))
+        if log_file is None:
+            log_file = DEFAULT_LOG_FILE
+        logging.getLogger().addHandler(logging.FileHandler(log_file))
         logging.getLogger().setLevel(logging_level)
         logging.captureWarnings(True)
         self.injector = DependencyInjector()


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
By default, the ofrak log is now `ofrak-YYYYMMDDhhmmss.log` rather than just `ofrak.log` and the name can be specified on the command line.

**Link to Related Issue(s)**
#311 

**Please describe the changes in your request.**
See summary

**Anyone you think should look at this, specifically?**
@whyitfor maybe?