### PR TITLE
Add install step for gui

### DIFF
--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -23,6 +23,7 @@ ofrak/gui/public:
 		cp -r /ofrak_gui ofrak/gui/public ; \
 	elif [ -d ../frontend ]; then \
 		cd ../frontend && \
+		npm install && \
 		npm run build && \
 		cd ../ofrak_core && \
 		cp -r ../frontend/dist ofrak/gui/public ; \


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**Please describe the changes in your request.**
`make develop` inside ofrak_core does not work without first running `npm install`. This adds `npm install` as a step.

**Anyone you think should look at this, specifically?**
@rbs-jacob 