### PR TITLE
Use temporary output directory for `test_function_replacement_modifier`

### DIFF
--- a/ofrak_core/test_ofrak/components/test_patch_maker_component.py
+++ b/ofrak_core/test_ofrak/components/test_patch_maker_component.py
@@ -230,7 +230,7 @@ async def test_function_replacement_modifier(ofrak_context: OFRAKContext, config
     )
 
     await target_program.resource.run(FunctionReplacementModifier, function_replacement_config)
-    new_program_path = f"{tmp_path}/replaced_{Path(config.program.path).name}"
+    new_program_path = str(tmp_path / f"replaced_{Path(config.program.path).name}")
 
     # When running tests in parallel, do this one at a time
     lock = filelock.FileLock(new_program_path + ".lock")

--- a/ofrak_core/test_ofrak/components/test_patch_maker_component.py
+++ b/ofrak_core/test_ofrak/components/test_patch_maker_component.py
@@ -184,7 +184,7 @@ TEST_CASE_CONFIGS = [
 
 
 @pytest.mark.parametrize("config", TEST_CASE_CONFIGS)
-async def test_function_replacement_modifier(ofrak_context: OFRAKContext, config):
+async def test_function_replacement_modifier(ofrak_context: OFRAKContext, config, tmp_path):
     root_resource = await ofrak_context.create_root_resource_from_file(config.program.path)
     await root_resource.unpack_recursively()
     target_program = await root_resource.view_as(Program)
@@ -230,7 +230,7 @@ async def test_function_replacement_modifier(ofrak_context: OFRAKContext, config
     )
 
     await target_program.resource.run(FunctionReplacementModifier, function_replacement_config)
-    new_program_path = f"replaced_{Path(config.program.path).name}"
+    new_program_path = f"{tmp_path}/replaced_{Path(config.program.path).name}"
 
     # When running tests in parallel, do this one at a time
     lock = filelock.FileLock(new_program_path + ".lock")


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

Currently running the test suite (specifically `test_function_replacement_modifier`) pollutes the current directory with these output files which the developer has to clean up to get a clean working tree. This changes it to use pytest's [`tmp_path`](https://docs.pytest.org/en/7.3.x/how-to/tmp_path.html) fixture.

The output files from subsequent runs are saved in pytest's temporary directories like so instead of being overwritten:

```
ofrakdev@e9d35e42d66b:/workspaces/rbs-ofrak/ofrak$ cd /tmp/pytest-of-ofrakdev/pytest-
pytest-0/       pytest-1/       pytest-current/ 
ofrakdev@e9d35e42d66b:/workspaces/rbs-ofrak/ofrak$ cd /tmp/pytest-of-ofrakdev/pytest-1/
ofrakdev@e9d35e42d66b:/tmp/pytest-of-ofrakdev/pytest-1$ ls
test_function_replacement_modi0  test_function_replacement_modi2  test_function_replacement_modi4  test_function_replacement_modi6  test_function_replacement_modicurrent
test_function_replacement_modi1  test_function_replacement_modi3  test_function_replacement_modi5  test_function_replacement_modi7
ofrakdev@e9d35e42d66b:/tmp/pytest-of-ofrakdev/pytest-1$ ls test_function_replacement_modi0
replaced_hello.out  replaced_hello.out.lock
```