### PR TITLE
Add SHELL instruction to avoid JSONArgsRecommended warning

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -274,6 +274,7 @@ def create_dockerfile_finish(config: OfrakImageConfig) -> str:
     )
     dockerfile_finish_parts.append(f'RUN printf "{finish_makefile}" >> Makefile\n')
     if config.entrypoint is not None:
+        dockerfile_finish_parts.append('SHELL ["/bin/bash", "-c"]\n')
         dockerfile_finish_parts.append(f"ENTRYPOINT {config.entrypoint}")
     return "".join(dockerfile_finish_parts)
 


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Added `SHELL` instruction to image building script to ensure consistent OS signal behavior
**Link to Related Issue(s)**
N/A
**Please describe the changes in your request.**
As `build_image.py` stands now, building images with `ENTRYPOINT`s including `&`, `&&`, etc leads to the following warning in the build log for `finish.Dockerfile`:
`WARN: JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals`

Eg, when running `make tutorial-image`:
```
...
 > importing cache manifest from redballoonsecurity/ofrak/tutorial-base:master:
------
[+] Building 0.5s (17/17) FINISHED                                                                                                                                                                  docker:default
 => [internal] load build definition from finish.Dockerfile                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.88kB                                                                                                                                                                        0.0s
 => WARN: JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 46)                                                                       0.0s
...
```
Or when building `ofrak-ghidra.yml` (as it currently stands in master):
```
...
 > importing cache manifest from redballoonsecurity/ofrak/ghidra-base:master:
------
[+] Building 0.5s (15/15) FINISHED                                                                                                                                                                  docker:default
 => [internal] load build definition from finish.Dockerfile                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.46kB                                                                                                                                                                        0.0s
 => WARN: JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 38)                                                                       0.0s
...
```

As per [the docs](https://docs.docker.com/reference/build-checks/json-args-recommended/) for this warning, one way to fix it is to pass the `ENTRYPOINT` arguments in exec form, but this wouldn't work for our `ofrak-ghidra`, for example, because exec form would not allow `&`. The simpler way of fixing this warning be to explicitly define the shell to be `/bin/bash`, which this PR does by adding `SHELL ["/bin/bash", "-c"]` before the `ENTRYPOINT`.
**Anyone you think should look at this, specifically?**
N/A