### PR TITLE
Remove workflow caching steps

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -11,10 +11,6 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: 
     inputs:
-      flush_cache:
-        description: Flush the Docker image cache
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -54,43 +50,9 @@ jobs:
           cd frontend
           make check
 
-  build-base-image:
-    name: Build the common base OFRAK Docker image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: true
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.7'
-          cache: pip
-          cache-dependency-path: '**/setup.py'
-      - name: Cache base image
-        id: cache-image
-        uses: actions/cache@v3
-        with:
-          key: ofrak-core-dev
-          path: ofrak-base.tar.gz
-      - name: Build base image
-        # Always rebuild the base image when the scheduled workflow runs
-        if: inputs.flush_cache || steps.cache-image.outputs.cache-hit != 'true' || github.event_name == 'schedule'
-        run: |
-          python3 -m pip install PyYAML
-          DOCKER_BUILDKIT=1 python3 build_image.py --config ofrak-core-dev.yml --base 
-      - name: Export base image
-        if: inputs.flush_cache || steps.cache-image.outputs.cache-hit != 'true' || github.event_name == 'schedule'
-        run: |
-          sudo apt install pigz pv
-          docker save redballoonsecurity/ofrak/core-dev-base:latest \
-            | pigz -9 \
-            | pv --size 2400m --interval 5 --force \
-            > ofrak-base.tar.gz
-
   ofrak-ghidra:
     name: Test main OFRAK components
     runs-on: ubuntu-latest
-    needs: build-base-image
     steps:
       - uses: actions/checkout@v3
         with:
@@ -100,18 +62,6 @@ jobs:
           python-version: '3.7'
           cache: pip
           cache-dependency-path: '**/setup.py'
-      - name: Cache base image
-        id: cache-image
-        uses: actions/cache@v3
-        with:
-          key: ofrak-core-dev
-          path: ofrak-base.tar.gz
-      - name: Load base image
-        run: |
-          sudo apt install pv
-          pv --interval 5 --force ofrak-base.tar.gz \
-            | docker load 
-          docker images
       - name: Build Ghidra image
         run: |
           python3 -m pip install PyYAML
@@ -145,7 +95,6 @@ jobs:
   ofrak-angr:
     name: Test OFRAK angr and capstone components
     runs-on: ubuntu-latest
-    needs: build-base-image
     steps:
       - uses: actions/checkout@v3
         with:
@@ -155,18 +104,6 @@ jobs:
           python-version: '3.7'
           cache: pip
           cache-dependency-path: '**/setup.py'
-      - name: Cache base image
-        id: cache-image
-        uses: actions/cache@v3
-        with:
-          key: ofrak-core-dev
-          path: ofrak-base.tar.gz
-      - name: Load base image
-        run: |
-          sudo apt install pv
-          pv --interval 5 --force ofrak-base.tar.gz \
-            | docker load 
-          docker images
       - name: Build angr image
         run: |
           python3 -m pip install PyYAML
@@ -191,7 +128,6 @@ jobs:
   ofrak-tutorial:
     name: Test OFRAK examples and tutorial notebooks
     runs-on: ubuntu-latest
-    needs: build-base-image
     steps:
       - uses: actions/checkout@v3
         with:
@@ -201,18 +137,6 @@ jobs:
           python-version: '3.7'
           cache: pip
           cache-dependency-path: '**/setup.py'
-      - name: Cache base image
-        id: cache-image
-        uses: actions/cache@v3
-        with:
-          key: ofrak-core-dev
-          path: ofrak-base.tar.gz
-      - name: Load base image
-        run: |
-          sudo apt install pv
-          pv --interval 5 --force ofrak-base.tar.gz \
-            | docker load 
-          docker images
       - name: Build tutorial image
         run: |
           python3 -m pip install PyYAML


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Remove workflow caching steps to fix GitHub Actions CI running out of space. The cache isn't really useful anyway – since PR #67, the Docker caching hasn't actually been used in GitHub Actions.

**Anyone you think should look at this, specifically?**

@whyitfor 