### PR TITLE
Ghidra instruction decode fails if the VLE register is available but the value is null.

### DIFF
--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/GetInstructions.java
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/GetInstructions.java
@@ -118,7 +118,9 @@ public class GetInstructions extends HeadlessScript {
             Register vle_register = instruction.getRegister("vle");
             if (vle_register != null) {
                 BigInteger vle_val = instruction.getValue(vle_register, false);
-                this.instruction_mode = vle_val.equals(BigInteger.ONE) ? "VLE" : this.instruction_mode ;
+                if (vle_val != null){
+                    this.instruction_mode = vle_val.equals(BigInteger.ONE) ? "VLE" : this.instruction_mode ;
+                }
             }
 
             for (int i = 0; i < instruction.getNumOperands(); i++) {


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fall back to PPC instruction encoding when the VLE register is available but the value is null. 
**Link to Related Issue(s)**

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
