### PR TITLE
Revert "Fix circular dependencies by making `ofrak_angr` and `ofrak_capstone` optional for `ofrak_core` tests"

### DIFF
--- a/ofrak_core/requirements-test.txt
+++ b/ofrak_core/requirements-test.txt
@@ -15,4 +15,3 @@ pytest-cov
 pytest-xdist
 requests
 fun-coverage==0.2.0
-importlib-resources  # Needed because of https://github.com/redballoonsecurity/ofrak/issues/398

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -83,7 +83,12 @@ setuptools.setup(
     + read_requirements("requirements.txt"),
     extras_require={
         "docs": read_requirements("requirements-docs.txt"),
-        "test": read_requirements("requirements-test.txt"),
+        "test": [
+            "importlib-resources",  # Needed because of https://github.com/redballoonsecurity/ofrak/issues/398
+            "ofrak_angr~=1.0",
+            "ofrak_capstone~=1.0",
+        ]
+        + read_requirements("requirements-test.txt"),
         "non-pypi": read_requirements("requirements-non-pypi.txt"),
     },
     author="Red Balloon Security",

--- a/ofrak_core/test_ofrak/components/test_patch_from_source.py
+++ b/ofrak_core/test_ofrak/components/test_patch_from_source.py
@@ -4,8 +4,8 @@ import subprocess
 
 from ofrak_patch_maker.toolchain.llvm_12 import LLVM_12_0_1_Toolchain
 
-ofrak_angr = pytest.importorskip("ofrak_angr")
-ofrak_capstone = pytest.importorskip("ofrak_capstone")
+import ofrak_angr
+import ofrak_capstone
 from ofrak import OFRAKContext, Resource, ResourceAttributeValueFilter, ResourceFilter
 from ofrak.core import (
     Allocatable,

--- a/ofrak_core/test_ofrak/components/test_symbolic_analysis.py
+++ b/ofrak_core/test_ofrak/components/test_symbolic_analysis.py
@@ -3,7 +3,7 @@ from typing import Tuple, Dict
 
 import pytest
 
-ofrak_angr = pytest.importorskip("ofrak_angr")
+import ofrak_angr
 from ofrak import OFRAKContext, Resource, ResourceFilter
 from ofrak.core import (
     ElfSymbolType,


### PR DESCRIPTION
Reverts redballoonsecurity/ofrak#420
