### PR TITLE
Do not try to get git revision when `image_version` tag exists in .yml

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -11,9 +11,15 @@ import yaml
 
 BASE_DOCKERFILE = "base.Dockerfile"
 FINISH_DOCKERFILE = "finish.Dockerfile"
-GIT_COMMIT_HASH = (
-    subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"]).decode("ascii").strip()
-)
+REVISION_FILE = "REVISION"
+
+if os.path.exists(REVISION_FILE):
+    with open(REVISION_FILE) as f:
+        GIT_COMMIT_HASH = f.read().strip()
+else:
+    GIT_COMMIT_HASH = (
+        subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"]).decode("ascii").strip()
+    )
 
 
 class InstallTarget(Enum):

--- a/build_image.py
+++ b/build_image.py
@@ -11,15 +11,6 @@ import yaml
 
 BASE_DOCKERFILE = "base.Dockerfile"
 FINISH_DOCKERFILE = "finish.Dockerfile"
-REVISION_FILE = "REVISION"
-
-if os.path.exists(REVISION_FILE):
-    with open(REVISION_FILE) as f:
-        GIT_COMMIT_HASH = f.read().strip()
-else:
-    GIT_COMMIT_HASH = (
-        subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"]).decode("ascii").strip()
-    )
 
 
 class InstallTarget(Enum):
@@ -32,6 +23,7 @@ class OfrakImageConfig:
     registry: str
     base_image_name: str
     image_name: str
+    image_revision: str
     packages_paths: List[str]
     build_base: bool
     build_finish: bool
@@ -96,7 +88,7 @@ def main():
             f"{full_base_image_name}:master",
             *cache_args,
             "-t",
-            f"{full_base_image_name}:{GIT_COMMIT_HASH}",
+            f"{full_base_image_name}:{config.image_revision}",
             "-t",
             f"{full_base_image_name}:latest",
             "-f",
@@ -121,7 +113,7 @@ def main():
             "docker",
             "build",
             "-t",
-            f"{full_image_name}:{GIT_COMMIT_HASH}",
+            f"{full_image_name}:{config.image_revision}",
             "-t",
             f"{full_image_name}:latest",
             "-f",
@@ -155,10 +147,19 @@ def parse_args() -> OfrakImageConfig:
     args = parser.parse_args()
     with open(args.config) as file_handle:
         config_dict = yaml.safe_load(file_handle)
+    if "image_revision" in config_dict:
+        image_revision = config_dict["image_revision"]
+    else:
+        image_revision = (
+            subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"])
+            .decode("ascii")
+            .strip()
+        )
     image_config = OfrakImageConfig(
         config_dict["registry"],
         config_dict["base_image_name"],
         config_dict["image_name"],
+        image_revision,
         config_dict["packages_paths"],
         args.base,
         args.finish,
@@ -245,7 +246,7 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
 def create_dockerfile_finish(config: OfrakImageConfig) -> str:
     full_base_image_name = "/".join((config.registry, config.base_image_name))
     dockerfile_finish_parts = [
-        f"FROM {full_base_image_name}:{GIT_COMMIT_HASH}\n\n",
+        f"FROM {full_base_image_name}:{config.image_revision}\n\n",
         f"ARG OFRAK_SRC_DIR=/\n",
     ]
     package_names = list()


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Adds an optional `--image-revision` argument to `ofrak.yml` to support image revision tagging
when building an OFRAK docker image from a source bundle without git.

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
See above

**Anyone you think should look at this, specifically?**
@whyitfor 