### PR TITLE
Fix component configs default field=None bug

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix bug in OFRAK GUI server which causes an error when parsing a default config value of bytes. ([#409](https://github.com/redballoonsecurity/ofrak/pull/409))
 - Set default fallback font to system default monospace, instead of variable-width sans-serif. ([#422](https://github.com/redballoonsecurity/ofrak/pull/422))
 - View resource attribute string values containing only digits primarily as strings, alternatively as hex numbers. ([#423](https://github.com/redballoonsecurity/ofrak/pull/423))
+- Fix bug where PJSON deserializer fails to deserialze `ComponentConfig` dataclasses have a field with a default value of `None`. ([#506](https://github.com/redballoonsecurity/ofrak/pull/506))
 
 ### Changed
 - By default, the ofrak log is now `ofrak-YYYYMMDDhhmmss.log` rather than just `ofrak.log` and the name can be specified on the command line ([#480](https://github.com/redballoonsecurity/ofrak/pull/480))

--- a/ofrak_core/ofrak/service/serialization/serializers/class_instance_serializer.py
+++ b/ofrak_core/ofrak/service/serialization/serializers/class_instance_serializer.py
@@ -87,7 +87,7 @@ class ClassInstanceSerializer(SerializerInterface):
             cls, as_dataclass=is_dataclass(cls)
         )
         deserialized_fields = {
-            field_name: self._service.from_pjson(cls_fields_pjson[field_name], field_type)
+            field_name: self._service.from_pjson(cls_fields_pjson.get(field_name), field_type)
             for field_name, field_type in expected_fields_and_types.items()
         }
         if is_dataclass(cls) and getattr(cls, dataclasses._PARAMS).init:  # type: ignore


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

When `ComponentConfig` dataclasses have a field with a default value of `None`, the PJSON deserializer fails to deserialze the values. This fixes that bug.

**Anyone you think should look at this, specifically?**

@dannyp303 