### PR TITLE
Fix `KeyError` on resource save after calling `Resource.remove_tag` on parent and child tag class

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Set default fallback font to system default monospace, instead of variable-width sans-serif. ([#422](https://github.com/redballoonsecurity/ofrak/pull/422))
 - View resource attribute string values containing only digits primarily as strings, alternatively as hex numbers. ([#423](https://github.com/redballoonsecurity/ofrak/pull/423))
 - Fix bug where PJSON deserializer fails to deserialze `ComponentConfig` dataclasses have a field with a default value of `None`. ([#506](https://github.com/redballoonsecurity/ofrak/pull/506))
+- Fix bug where calling `Resource.remove_tag` on both a tag class and a class that inherits from that class causes a `KeyError` on resource save. ([#510](https://github.com/redballoonsecurity/ofrak/pull/510))
 
 ### Changed
 - By default, the ofrak log is now `ofrak-YYYYMMDDhhmmss.log` rather than just `ofrak.log` and the name can be specified on the command line ([#480](https://github.com/redballoonsecurity/ofrak/pull/480))

--- a/ofrak_core/ofrak/service/resource_service.py
+++ b/ofrak_core/ofrak/service/resource_service.py
@@ -688,7 +688,7 @@ class ResourceService(ResourceServiceInterface):
         for _tag in tag.tag_classes():
             if blacklist is not None and _tag in blacklist:
                 continue
-            self._tag_indexes[_tag].remove(resource)
+            self._tag_indexes[_tag].discard(resource)
 
     def _add_resource_attribute_to_index(
         self,


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix bug where calling `Resource.remove_tag` on both a tag class and a class that inherits from that class causes a `KeyError` on resource save.

**Link to Related Issue(s)**
#507 

Does not fully fix that issue, since calling `remove_tag` on _only_ the parent tag will not properly remove it.

**Please describe the changes in your request.**
Changes a call to `.remove` to `.discard` instead, since its possible the resource was already removed from the index in the same update cycle

**Anyone you think should look at this, specifically?**
