### PR TITLE
Auto-enable Docker buildkit

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Build Ghidra image
         run: |
           python3 -m pip install PyYAML
-          DOCKER_BUILDKIT=1 \
           python3 build_image.py \
             --config ofrak-ghidra.yml \
             --base \
@@ -107,7 +106,6 @@ jobs:
       - name: Build angr image
         run: |
           python3 -m pip install PyYAML
-          DOCKER_BUILDKIT=1 \
           python3 build_image.py \
             --config ofrak-angr.yml \
             --base \
@@ -140,7 +138,6 @@ jobs:
       - name: Build tutorial image
         run: |
           python3 -m pip install PyYAML
-          DOCKER_BUILDKIT=1 \
           python3 build_image.py \
             --config ofrak-tutorial.yml \
             --base \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ image:
 	python3 build_image.py --config ofrak-core-dev.yml --base --finish
 
 tutorial-image:
-	DOCKER_BUILDKIT=1 python3 build_image.py --config ofrak-tutorial.yml --base --finish
+	python3 build_image.py --config ofrak-tutorial.yml --base --finish
 
 tutorial-run:
 	make -C ofrak_tutorial run

--- a/build_image.py
+++ b/build_image.py
@@ -73,7 +73,7 @@ def main():
         f.write(dockerfile_finish)
     print(f"{FINISH_DOCKERFILE} built.")
 
-    env = {k: v for k, v in os.environ.items()}
+    env = os.environ.copy()
     if not config.no_forced_buildkit:
         env["DOCKER_BUILDKIT"] = "1"
 

--- a/build_image.py
+++ b/build_image.py
@@ -33,7 +33,6 @@ class OfrakImageConfig:
     install_target: InstallTarget
     cache_from: List[str]
     entrypoint: Optional[str]
-    no_forced_buildkit: bool
 
     def validate_serial_txt_existence(self):
         """
@@ -74,8 +73,7 @@ def main():
     print(f"{FINISH_DOCKERFILE} built.")
 
     env = os.environ.copy()
-    if not config.no_forced_buildkit:
-        env["DOCKER_BUILDKIT"] = "1"
+    env["DOCKER_BUILDKIT"] = "1"
 
     if config.build_base:
         full_base_image_name = "/".join((config.registry, config.base_image_name))
@@ -149,7 +147,6 @@ def parse_args() -> OfrakImageConfig:
         default=InstallTarget.DEVELOP.value,
     )
     parser.add_argument("--cache-from", action="append")
-    parser.add_argument("--no-forced-buildkit", action="store_true")
     args = parser.parse_args()
     with open(args.config) as file_handle:
         config_dict = yaml.safe_load(file_handle)

--- a/build_image.py
+++ b/build_image.py
@@ -171,7 +171,6 @@ def parse_args() -> OfrakImageConfig:
         InstallTarget(args.target),
         args.cache_from,
         config_dict.get("entrypoint"),
-        args.no_forced_buildkit,
     )
     image_config.validate_serial_txt_existence()
     return image_config

--- a/docs/user-guide/disassembler-backends/binary_ninja.md
+++ b/docs/user-guide/disassembler-backends/binary_ninja.md
@@ -35,7 +35,7 @@ The recommended Binary Ninja version to use with OFRAK is 3.2.3814. If you are r
       > serial.txt
     ```
 
-    The command `DOCKER_BUILDKIT=1 python3 build_image.py --config ofrak-binary-ninja.yml --base --finish` will build an image using Docker BuildKit secrets so that neither the license nor serial number are exposed in the built Docker image. BuildKit is required for the build to succeed!
+    The command `python3 build_image.py --config ofrak-binary-ninja.yml --base --finish` will build an image using Docker BuildKit secrets so that neither the license nor serial number are exposed in the built Docker image. BuildKit is required for the build to succeed!
 
     The Docker container should be run with the same license file from the installation step. The license can then be mounted into the Docker container at location `/root/.binaryninja/license.dat` by adding the following arguments to the `docker run` command:
 


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Default to forcing Docker buildkit to be enabled.

**Link to Related Issue(s)**
N/A; supersedes #392 

**Please describe the changes in your request.**
Per @EdwardLarson:
> Some features in the build require Docker buildkit to be enabled, and we say as much in the docs to build the image. However, this is a point of failure (for some reason I could not get the buildkit to be enabled in my machine) and a "gotcha" that can be removed entirely by just setting the Docker buildkit enabled in the subprocess we spin up to do the Docker build. In case there is a desire to specifically NOT use the buildkit, an option is added to not alter the subprocess environment at all (buildkit may or may not be enabled depending on user's environment).

**Anyone you think should look at this, specifically?**
@whyitfor 
