### PR TITLE
Update PatchFromSourceModifier to place src and header files in same temporary directory as BOM/FEM artifacts

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add UEFI binary unpacker. ([#399](https://github.com/redballoonsecurity/ofrak/pull/399))
 - Add recursive identify functionality in the GUI. ([#435](https://github.com/redballoonsecurity/ofrak/pull/435))
 - Add generic DecompilationAnalysis classes. ([#453](https://github.com/redballoonsecurity/ofrak/pull/453))
+- `PatchFromSourceModifier` bundles src and header files into same temporary directory with BOM and FEM ([#517](https://github.com/redballoonsecurity/ofrak/pull/517))
 
 ### Fixed
 - Improved flushing of filesystem entries (including symbolic links and other types) to disk. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373))

--- a/ofrak_core/ofrak/core/patch_maker/modifiers.py
+++ b/ofrak_core/ofrak/core/patch_maker/modifiers.py
@@ -5,21 +5,21 @@ import tempfile
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Type, Union, cast
 
+from ofrak_patch_maker.model import PatchRegionConfig, FEM
+from ofrak_patch_maker.patch_maker import PatchMaker
 from ofrak_patch_maker.toolchain.abstract import Toolchain
+from ofrak_patch_maker.toolchain.model import Segment, ToolchainConfig
+
 from ofrak.component.modifier import Modifier
 from ofrak.core.architecture import ProgramAttributes
 from ofrak.core.complex_block import ComplexBlock
 from ofrak.core.injector import BinaryInjectorModifier, BinaryInjectorModifierConfig
 from ofrak.core.memory_region import MemoryRegion
+from ofrak.core.patch_maker.linkable_binary import LinkableBinary
 from ofrak.core.program import Program
 from ofrak.model.component_model import ComponentConfig
 from ofrak.resource import Resource
 from ofrak.service.resource_service_i import ResourceFilter, ResourceSort, ResourceSortDirection
-from ofrak.core.patch_maker.linkable_binary import LinkableBinary
-from ofrak_patch_maker.model import PatchRegionConfig, FEM
-from ofrak_patch_maker.patch_maker import PatchMaker
-from ofrak_patch_maker.toolchain.abstract import Toolchain
-from ofrak_patch_maker.toolchain.model import Segment, ToolchainConfig
 from ofrak_type.memory_permissions import MemoryPermissions
 
 LOGGER = logging.getLogger(__file__)
@@ -110,13 +110,14 @@ class PatchFromSourceModifier(Modifier):
             patch_name = config.patch_name
 
         build_tmp_dir = tempfile.mkdtemp()
-
-        source_tmp_dir = tempfile.mkdtemp()
+        source_tmp_dir = os.path.join(build_tmp_dir, "src")
+        os.makedirs(source_tmp_dir)
         config.source_code.dump(source_tmp_dir)
 
         header_dirs = []
         for header_directory in config.header_directories:
-            header_tmp_dir = tempfile.mkdtemp()
+            header_tmp_dir = os.path.join(build_tmp_dir, "include")
+            os.makedirs(build_tmp_dir)
             header_directory.dump(header_tmp_dir)
             header_dirs.append(header_tmp_dir)
 
@@ -128,7 +129,6 @@ class PatchFromSourceModifier(Modifier):
             toolchain=config.toolchain(program_attributes, config.toolchain_config),
             build_dir=build_tmp_dir,
         )
-
         patch_bom = patch_maker.make_bom(
             name=patch_name,
             source_list=absolute_source_list,
@@ -162,7 +162,6 @@ class PatchFromSourceModifier(Modifier):
             [(patch_bom, p), target_linkable_bom_info],
             exec_path,
         )
-
         await resource.run(
             SegmentInjectorModifier,
             SegmentInjectorModifierConfig.from_fem(fem),


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
The src and header files that serve as input to `PatchFromSourceModifier` are now written to the same temporary
directory that PatchMaker uses for its output.

**Link to Related Issue(s)**

**Please describe the changes in your request.**
The src and header files that serve as input to `PatchFromSourceModifier` are now written to the same temporary
directory that PatchMaker uses for its output.

This will make it easier to compare BOM/FEM files to the source code that generated them

I've tested this change with an example from https://github.com/whyitfor/ofrak-u-boot, the temporary build directory now helpfully includes the source files:

```
# tree /tmp/tmpbf6xisdn
/tmp/tmpbf6xisdn
├── do_version_patch_bom_files
│   ├── do_help.c.o
│   └── do_version.c.o
├── do_version_patch_vqkt3hd6.ld
├── output_exec
├── output_exec.map
├── src
│   ├── do_help.S
│   ├── do_help.c
│   └── do_version.c
├── stub_printf.as
└── stubs_bom_files
    └── stub_printf.as.o
```

Future work might consider only copying source files that are actually given segments in `PatchFromSourceModifier` (in this example, `do_help.S` and `do_help.c` are separate implementations, only one is used).

**Anyone you think should look at this, specifically?**
@alchzh, @rbs-jacob 