### PR TITLE
Run `ofrak_patch_maker_test/test_symbol_parsing.py`

### DIFF
--- a/ofrak_patch_maker/ofrak_patch_maker_test/test_symbol_parsing.py
+++ b/ofrak_patch_maker/ofrak_patch_maker_test/test_symbol_parsing.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 
 @dataclass
-class TestCase:
+class SymbolParsingTestCase:
     base_label: str
     symbol_source_code: str
     expected_to_be_resolved: bool
@@ -107,14 +107,14 @@ TOOLCHAINS_AND_TARGETS = [
 
 
 FULL_TEST_CASES = [
-    TestCase(case_name, symbol_source, expected_resolved, toolchain, arch)
+    SymbolParsingTestCase(case_name, symbol_source, expected_resolved, toolchain, arch)
     for (case_name, symbol_source, expected_resolved) in SYMBOL_SOURCES
     for (toolchain, arch) in TOOLCHAINS_AND_TARGETS
 ]
 
 
 @pytest.mark.parametrize("tc", FULL_TEST_CASES, ids=lambda case: case.full_label)
-async def test_symbol_parsing(tc: TestCase, tmpdir):
+def test_symbol_parsing(tc: SymbolParsingTestCase, tmpdir):
     logging.getLogger().addHandler(logging.FileHandler("/tmp/ofrak.log"))
     logging.getLogger().setLevel(logging.INFO)
 


### PR DESCRIPTION
This test was incorrectly marked as `async def` so it never actually run in CI or locally in my experience.

See example logs here: https://github.com/redballoonsecurity/ofrak/actions/runs/11921517683/job/33225804260#step:6:380

- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Maintenance only change

**Please describe the changes in your request.**
- Removes a spurious `async def` preventing this test case from running
- Renames the `TestCase` class so pytest doesn't think it's a class with tests

**Anyone you think should look at this, specifically?**
@whyitfor @rbs-jacob 