### PR TITLE
Include `node` and `npm` in Docker images with frontend (Fixes #497)

### DIFF
--- a/frontend/Dockerstage
+++ b/frontend/Dockerstage
@@ -1,4 +1,4 @@
-FROM node:latest AS svelte
+FROM node:lts-bullseye-slim AS svelte
 
 COPY --chown=node:node $PACKAGE_DIR /home/node/frontend
 

--- a/frontend/Dockerstub
+++ b/frontend/Dockerstub
@@ -1,6 +1,8 @@
 RUN apt-get update && apt-get install --yes nginx
 
 COPY --from=svelte --chown=root:root /home/node/frontend/dist /ofrak_gui
+COPY --from=svelte /usr/local/bin /usr/local/bin
+COPY --from=svelte /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 COPY $PACKAGE_PATH/nginx.conf /etc/nginx/sites-enabled/default
 


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Include `node` and `npm` in Docker images with frontend

**Link to Related Issue(s)**
#497 

**Please describe the changes in your request.**
- Uses `node:lts-bullseye-slim` to build frontend (can use a specific version pin as well)
- Copies `node`, `npm` and a couple of other tools into the resulting image for development

**Anyone you think should look at this, specifically?**
@rbs-jacob 