### PR TITLE
Add configuration option for base Python image for Docker files

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -9,6 +9,9 @@ import sys
 import pkg_resources
 import yaml
 
+DEFAULT_PYTHON_IMAGE = (
+    "python:3.8-bullseye@sha256:e1cd369204123e89646f8c001db830eddfe3e381bd5c837df00141be3bd754cb"
+)
 BASE_DOCKERFILE = "base.Dockerfile"
 FINISH_DOCKERFILE = "finish.Dockerfile"
 
@@ -33,6 +36,7 @@ class OfrakImageConfig:
     install_target: InstallTarget
     cache_from: List[str]
     entrypoint: Optional[str]
+    python_image: str
 
     def validate_serial_txt_existence(self):
         """
@@ -171,6 +175,7 @@ def parse_args() -> OfrakImageConfig:
         InstallTarget(args.target),
         args.cache_from,
         config_dict.get("entrypoint"),
+        config_dict.get("python_image", DEFAULT_PYTHON_IMAGE),
     )
     image_config.validate_serial_txt_existence()
     return image_config
@@ -207,7 +212,7 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
         dockerfile_base_parts += [f"### {dockerstage_path}", dockerstub]
 
     dockerfile_base_parts += [
-        "FROM python:3.8-bullseye@sha256:e1cd369204123e89646f8c001db830eddfe3e381bd5c837df00141be3bd754cb",
+        f"FROM {config.python_image}",
         "",
     ]
 

--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -61,8 +61,11 @@ RUN cd /tmp && \
 
 # Install Jefferson
 WORKDIR /tmp
-RUN wget https://bootstrap.pypa.io/pip/get-pip.py && python3.9 get-pip.py && python3.8 get-pip.py && rm get-pip.py
-RUN python3.9 -m pip install jefferson
+RUN wget https://bootstrap.pypa.io/pip/get-pip.py && \
+    /usr/bin/python3 get-pip.py && \
+    /usr/local/bin/python get-pip.py && \
+    rm get-pip.py
+RUN /usr/bin/python3 -m pip install jefferson
 WORKDIR /
 
 # Install UEFIExtract (build from source, pinned to releae A68)


### PR DESCRIPTION
[Python 3.8 is now officially EoL](https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983). I've been testing how OFRAK does with newer python versions in the [`maintenance/newer-python-test-fixes`](https://github.com/redballoonsecurity/ofrak/tree/maintenance/newer-python-test-fixes) branch. This change just lets us build Docker images off images of newer Python versions.

- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add configuration option for base Python image for Docker files.

**Link to Related Issue(s)**

**Please describe the changes in your request.**
- Adds a `python_image` configuration option to docker yaml files. Defaults to the current 3.8-bullseye image for now.

**Anyone you think should look at this, specifically?**
