### PR TITLE
Update pycryptography to 43.0.3

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -42,7 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Minor update to OFRAK Community License, add OFRAK Pro License ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
 
 ### Security
-- Update pycryptogrpahy to version 43.0.3
+- Update aiohttp to 3.10.11 ([#522](https://github.com/redballoonsecurity/ofrak/pull/522))
+- Update pycryptogrpahy to version 43.0.3. ([#525](https://github.com/redballoonsecurity/ofrak/pull/525))
 
 ## [3.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.1.0...ofrak-v3.2.0)
 ### Added

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -41,6 +41,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Partially reverted [#150](https://github.com/redballoonsecurity/ofrak/pull/150) so entropy C code is called with `ctypes` again, but maintaining the current API and automatic compilation by `setup.py`. ([#482](https://github.com/redballoonsecurity/ofrak/pull/482))
 - Minor update to OFRAK Community License, add OFRAK Pro License ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
 
+### Security
+- Update pycryptogrpahy to version 43.0.3
+
 ## [3.2.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.1.0...ofrak-v3.2.0)
 ### Added
 - Add a JFFS2 packer and unpacker. ([#326](https://github.com/redballoonsecurity/ofrak/pull/326))

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -2,7 +2,7 @@ aiohttp~=3.10.11
 aiohttp-cors~=0.7.0
 beartype~=0.12.0
 black==23.3.0
-cryptography==42.0.8
+cryptography==43.0.3
 fdt==0.3.3
 GitPython==3.1.41
 importlib-metadata>=4.13


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Update pycryptography to 43.0.3.

**Link to Related Issue(s)**
https://github.com/redballoonsecurity/ofrak/security/dependabot/24

**Please describe the changes in your request.**
- Update pycryptography to 43.0.3.
- Update changelog to account for #522.

**Anyone you think should look at this, specifically?**
@rbs-jacob