### PR TITLE
Use PyPI version of bincopy, bump to 20.0.0

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - View resource attribute string values containing only digits primarily as strings, alternatively as hex numbers. ([#423](https://github.com/redballoonsecurity/ofrak/pull/423))
 - Fix bug where PJSON deserializer fails to deserialze `ComponentConfig` dataclasses have a field with a default value of `None`. ([#506](https://github.com/redballoonsecurity/ofrak/pull/506))
 - Fix bug where calling `Resource.remove_tag` on both a tag class and a class that inherits from that class causes a `KeyError` on resource save. ([#510](https://github.com/redballoonsecurity/ofrak/pull/510))
+- Use PyPI version of `bincopy`, upgrade to version 20.0.0 ([#528](https://github.com/redballoonsecurity/ofrak/pull/528))
 
 ### Changed
 - By default, the ofrak log is now `ofrak-YYYYMMDDhhmmss.log` rather than just `ofrak.log` and the name can be specified on the command line ([#480](https://github.com/redballoonsecurity/ofrak/pull/480))

--- a/ofrak_core/ofrak/core/ihex.py
+++ b/ofrak_core/ofrak/core/ihex.py
@@ -4,14 +4,7 @@ import sys
 from dataclasses import dataclass
 from typing import List, Union, Tuple, Any
 
-from ofrak.component.abstract import ComponentMissingDependencyError
-
-try:
-    from bincopy import BinFile
-
-    BINCOPY_INSTALLED = True
-except ImportError:
-    BINCOPY_INSTALLED = False
+from bincopy import BinFile
 
 from ofrak.component.analyzer import Analyzer
 from ofrak.component.identifier import Identifier
@@ -20,7 +13,6 @@ from ofrak.component.unpacker import Unpacker
 from ofrak.core.binary import GenericBinary, GenericText
 from ofrak.core.program_section import ProgramSection
 from ofrak.core.program import Program
-from ofrak.model.component_model import ComponentExternalTool
 from ofrak.resource import Resource
 from ofrak.service.resource_service_i import ResourceFilter
 from ofrak_type.range import Range
@@ -48,13 +40,6 @@ class IhexProgram(Program):
     segments: List[Range]
 
 
-_BINCOPY_TOOL = ComponentExternalTool(
-    "bincopy",
-    "https://github.com/eerimoq/bincopy",
-    "--help",
-)
-
-
 class IhexAnalyzer(Analyzer[None, IhexProgram]):
     """
     Extract Intel HEX parameters
@@ -62,8 +47,6 @@ class IhexAnalyzer(Analyzer[None, IhexProgram]):
 
     targets = (IhexProgram,)
     outputs = (IhexProgram,)
-
-    external_dependencies = (_BINCOPY_TOOL,)
 
     async def analyze(self, resource: Resource, config: None = None) -> IhexProgram:
         raw_ihex = await resource.get_parent()
@@ -80,8 +63,6 @@ class IhexUnpacker(Unpacker[None]):
 
     targets = (Ihex,)
     children = (IhexProgram,)
-
-    external_dependencies = (_BINCOPY_TOOL,)
 
     async def unpack(self, resource: Resource, config=None):
         ihex_program, binfile = _binfile_analysis(await resource.get_data(), self)
@@ -142,12 +123,7 @@ class IhexPacker(Packer[None]):
 
     targets = (Ihex,)
 
-    external_dependencies = (_BINCOPY_TOOL,)
-
     async def pack(self, resource: Resource, config=None) -> None:
-        if not BINCOPY_INSTALLED:
-            raise ComponentMissingDependencyError(self, _BINCOPY_TOOL)
-
         program_child = await resource.get_only_child_as_view(IhexProgram)
         vaddr_offset = -program_child.address_limits.start
         binfile = BinFile()
@@ -186,8 +162,6 @@ class IhexIdentifier(Identifier):
 
 
 def _binfile_analysis(raw_ihex: bytes, component) -> Tuple[IhexProgram, Any]:
-    if not BINCOPY_INSTALLED:
-        raise ComponentMissingDependencyError(component, _BINCOPY_TOOL)
     binfile = BinFile()
     binfile.add_ihex(raw_ihex.decode("utf-8"))
 

--- a/ofrak_core/requirements-non-pypi.txt
+++ b/ofrak_core/requirements-non-pypi.txt
@@ -1,2 +1,1 @@
-bincopy @ git+https://github.com/eerimoq/bincopy.git@17.14.5
 binwalk @ git+https://github.com/ReFirmLabs/binwalk.git@v2.3.4

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp~=3.10.11
 aiohttp-cors~=0.7.0
 beartype~=0.12.0
+bincopy==20.0.0
 black==23.3.0
 cryptography==43.0.3
 fdt==0.3.3


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Use PyPI version of bincopy, bump to 20.0.0

**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
Use PyPI version of bincopy, bump to 20.0.0

**Anyone you think should look at this, specifically?**
