### PR TITLE
Pin Ubuntu version

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Pin GitHub Actions CI Ubuntu version instead of using `ubuntu-latest`.

**Link to Related Issue(s)**

- <https://github.com/actions/runner-images/issues/10636>

**Please describe the changes in your request.**

According to the issue linked above, the `ubuntu-latest` GitHub Actions images are being bumped from Ubuntu 22.04 to 24.04. They are rolling out the change, so some repos are seeing it before others. On [my fork of OFRAK](https://github.com/rbs-jacob/ofrak/actions/runs/12217517784) the GitHub Actions workflows are failing due to this version change, since they use Python 3.7 to run `build_image.py`.

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/e9bb8f54-a416-477c-b64d-fe828b00a521" />

To preemptively fix this in OFRAK, I have pinned the CI Ubuntu version to the current 22.04. We can also bump the Python version to 3.8 and continue using `ubuntu-latest`, but I have not tested that that will work. Or we can bump to Python 3.8 and pin the Ubuntu version.

**Anyone you think should look at this, specifically?**

@whyitfor 