### PR TITLE
Use mirror for BCC toolchain

### DIFF
--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - X86_64 toolchain now installs on Docker image builds for AARCH64 hosts. ([#405](https://github.com/redballoonsecurity/ofrak/pull/405))
 - Toolchain now drops the .altinstrs_replacement as well as the .altinstructions section in our generated linker scripts ([#414](https://github.com/redballoonsecurity/ofrak/pull/414))
+- Update patchmaker dockerstub to use mirror server for downloading the BCC toolchain ([#541](https://github.com/redballoonsecurity/ofrak/pull/541))
 
 ### Changed
 - Removed `SUBALIGN(0)` for `.bss` sections

--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -14,12 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - X86_64 toolchain now installs on Docker image builds for AARCH64 hosts. ([#405](https://github.com/redballoonsecurity/ofrak/pull/405))
 - Toolchain now drops the .altinstrs_replacement as well as the .altinstructions section in our generated linker scripts ([#414](https://github.com/redballoonsecurity/ofrak/pull/414))
-- Update patchmaker dockerstub to use mirror server for downloading the BCC toolchain ([#541](https://github.com/redballoonsecurity/ofrak/pull/541))
 
 ### Changed
 - Removed `SUBALIGN(0)` for `.bss` sections
 - Minor update to OFRAK Community License, add OFRAK Pro License ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
-- Install toolchains from source or tarball instead of relying on the Debian package manager ([#502](https://github.com/redballoonsecurity/ofrak/pull/502))
+- Install toolchains from source or tarball instead of relying on the Debian package manager ([#502](https://github.com/redballoonsecurity/ofrak/pull/502), [#541](https://github.com/redballoonsecurity/ofrak/pull/541))
 
 ## [4.0.2](https://github.com/redballoonsecurity/ofrak/compare/ofrak-patch-maker-v.4.0.1...ofrak-patch-maker-v.4.0.2)
 ### Fixed

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -129,7 +129,7 @@ fi;
 #BCC (GCC) SPARC v8
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
     cd /tmp/ \
-      && wget https://www.gaisler.com/anonftp/bcc2/bin/bcc-2.0.7-gcc-linux64.tar.xz --show-progress --progress=bar:force:noscroll \
+      && wget http://mirror.tensorflow.org/www.gaisler.com/anonftp/bcc2/bin/bcc-2.0.7-gcc-linux64.tar.xz --show-progress --progress=bar:force:noscroll \
       && mkdir -p /opt/rbs/toolchain/ \
       && tar -C /opt/rbs/toolchain/ -xJf bcc-2.0.7-gcc-linux64.tar.xz \
       && rm bcc-2.0.7-gcc-linux64.tar.xz; \


### PR DESCRIPTION
Update patchmaker dockerstub to use mirror server for downloading the BCC toolchain.

- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Update patchmaker dockerstub to use mirror server for downloading the BCC toolchain.

**Link to Related Issue(s)**

**Please describe the changes in your request.**
Use a mirror server for the download of the BCC toolchain, because the original server sometimes bans our IP.

**Anyone you think should look at this, specifically?**
@whyitfor 