### PR TITLE
Change GitHub workflow so commits affecting exclusively `CHANGELOG.md` files do not trigger workflow runs.

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**/CHANGELOG.md'
   push:
     branches:
       - master
+    paths-ignore:
+      - '**/CHANGELOG.md'
   schedule: 
     - cron: '0 0 * * *'
   workflow_dispatch: 

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to `ofrak` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+THIS CHANGE SHOULD NOT RESULT IN A WORKFLOW RUN.
+
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
 - Add license check command to prompt users about community or pro licenses. ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Change GitHub workflow so commits affecting exclusively `CHANGELOG.md` files do not trigger workflow runs.

**Link to Related Issue(s)**
#534 

**Anyone you think should look at this, specifically?**
@whyitfor 