### PR TITLE
Draft: Introduce `get_data_memoryview()` for copy-free access to resource data 

### DIFF
--- a/ofrak_core/ofrak/core/binary.py
+++ b/ofrak_core/ofrak/core/binary.py
@@ -41,9 +41,8 @@ class BinaryExtendModifier(Modifier[BinaryExtendConfig]):
     async def modify(self, resource: Resource, config: BinaryExtendConfig):
         if len(config.content) == 0:
             raise ValueError("Content of the extended space not provided")
-        data = await resource.get_data()
-        data += config.content
-        resource.queue_patch(Range(0, await resource.get_data_length()), data)
+        orig_data_length = await resource.get_data_length()
+        resource.queue_patch(Range(orig_data_length, orig_data_length), config.content)
 
 
 @dataclass

--- a/ofrak_core/ofrak/core/bzip2.py
+++ b/ofrak_core/ofrak/core/bzip2.py
@@ -59,7 +59,7 @@ class Bzip2Packer(Packer[None]):
         :param config:
         """
         bzip2_child = await resource.get_only_child()
-        with bzip2_child.get_data_memoryview() as buffer:
+        with await bzip2_child.get_data_memoryview() as buffer:
             bzip2_compressed = bz2.compress(buffer)
         original_size = await resource.get_data_length()
         resource.queue_patch(Range(0, original_size), bzip2_compressed)

--- a/ofrak_core/ofrak/core/bzip2.py
+++ b/ofrak_core/ofrak/core/bzip2.py
@@ -36,8 +36,8 @@ class Bzip2Unpacker(Unpacker[None]):
         :param resource:
         :param config:
         """
-        resource_data = await resource.get_data()
-        decompressed_data = bz2.decompress(resource_data)
+        with await resource.get_data_memoryview() as resource_data:
+            decompressed_data = bz2.decompress(resource_data)
         await resource.create_child(
             tags=(GenericBinary,),
             data=decompressed_data,

--- a/ofrak_core/ofrak/core/bzip2.py
+++ b/ofrak_core/ofrak/core/bzip2.py
@@ -59,7 +59,8 @@ class Bzip2Packer(Packer[None]):
         :param config:
         """
         bzip2_child = await resource.get_only_child()
-        bzip2_compressed = bz2.compress(await bzip2_child.get_data())
+        with bzip2_child.get_data_memoryview() as buffer:
+            bzip2_compressed = bz2.compress(buffer)
         original_size = await resource.get_data_length()
         resource.queue_patch(Range(0, original_size), bzip2_compressed)
 

--- a/ofrak_core/ofrak/core/checksum.py
+++ b/ofrak_core/ofrak/core/checksum.py
@@ -43,7 +43,7 @@ class Md5Analyzer(Analyzer[None, Md5Attributes]):
     outputs = (Md5Attributes,)
 
     async def analyze(self, resource: Resource, config=None) -> Md5Attributes:
-        data = await resource.get_data()
         md5 = hashlib.md5()
-        md5.update(data)
+        with await resource.get_data_memoryview() as data:
+            md5.update(data)
         return Md5Attributes(md5.hexdigest())

--- a/ofrak_core/ofrak/core/checksum.py
+++ b/ofrak_core/ofrak/core/checksum.py
@@ -23,9 +23,9 @@ class Sha256Analyzer(Analyzer[None, Sha256Attributes]):
     outputs = (Sha256Attributes,)
 
     async def analyze(self, resource: Resource, config=None) -> Sha256Attributes:
-        data = await resource.get_data()
         sha256 = hashlib.sha256()
-        sha256.update(data)
+        with await resource.get_data_memoryview() as data:
+            sha256.update(data)
         return Sha256Attributes(sha256.hexdigest())
 
 

--- a/ofrak_core/ofrak/core/comments.py
+++ b/ofrak_core/ofrak/core/comments.py
@@ -34,7 +34,7 @@ class AddCommentModifier(Modifier[AddCommentModifierConfig]):
         # Verify that the given range is valid for the given resource.
         config_range = config.comment[0]
         if config_range is not None:
-            if config_range.start < 0 or config_range.end > len(await resource.get_data()):
+            if config_range.start < 0 or config_range.end > await resource.get_data_length():
                 raise ValueError(
                     f"Range {config_range} is outside the bounds of "
                     f"resource {resource.get_id().hex()}"

--- a/ofrak_core/ofrak/core/data.py
+++ b/ofrak_core/ofrak/core/data.py
@@ -23,12 +23,12 @@ class DataWord(MemoryRegion):
     xrefs_to: Tuple[int, ...]
 
     async def get_value_unsigned(self) -> int:
-        data = await self.resource.get_data()
-        return struct.unpack(self.format_string.upper(), data)[0]
+        with await self.resource.get_data_memoryview() as data:
+            return struct.unpack(self.format_string.upper(), data)[0]
 
     async def get_value_signed(self) -> int:
-        data = await self.resource.get_data()
-        return struct.unpack(self.format_string.lower(), data)[0]
+        with await self.resource.get_data_memoryview() as data:
+            return struct.unpack(self.format_string.lower(), data)[0]
 
 
 @dataclass(**ResourceAttributes.DATACLASS_PARAMS)

--- a/ofrak_core/ofrak/core/dtb.py
+++ b/ofrak_core/ofrak/core/dtb.py
@@ -102,30 +102,30 @@ class DtbHeaderAnalyzer(Analyzer[None, DtbHeader]):
     outputs = (DtbHeader,)
 
     async def analyze(self, resource: Resource, config: None) -> DtbHeader:
-        header_data = await resource.get_data()
-        (
-            dtb_magic,
-            totalsize,
-            off_dt_struct,
-            off_dt_strings,
-            off_mem_rsvmap,
-            version,
-            last_comp_version,
-        ) = struct.unpack(">IIIIIII", header_data[:28])
-        assert dtb_magic == DTB_MAGIC_SIGNATURE, (
-            f"DTB Magic bytes not matching."
-            f"Expected: {DTB_MAGIC_SIGNATURE} "
-            f"Unpacked: {dtb_magic}"
-        )
-        boot_cpuid_phys = 0
-        dtb_strings_size = 0
-        dtb_struct_size = 0
-        if version >= 2:
-            boot_cpuid_phys = struct.unpack(">I", header_data[28:32])[0]
-        if version >= 3:
-            dtb_strings_size = struct.unpack(">I", header_data[32:36])[0]
-        if version >= 17:
-            dtb_struct_size = struct.unpack(">I", header_data[36:40])[0]
+        with await resource.get_data_memoryview(Range(0, 40)) as header_data:
+            (
+                dtb_magic,
+                totalsize,
+                off_dt_struct,
+                off_dt_strings,
+                off_mem_rsvmap,
+                version,
+                last_comp_version,
+            ) = struct.unpack(">IIIIIII", header_data[:28])
+            assert dtb_magic == DTB_MAGIC_SIGNATURE, (
+                f"DTB Magic bytes not matching."
+                f"Expected: {DTB_MAGIC_SIGNATURE} "
+                f"Unpacked: {dtb_magic}"
+            )
+            boot_cpuid_phys = 0
+            dtb_strings_size = 0
+            dtb_struct_size = 0
+            if version >= 2:
+                boot_cpuid_phys = struct.unpack(">I", header_data[28:32])[0]
+            if version >= 3:
+                dtb_strings_size = struct.unpack(">I", header_data[32:36])[0]
+            if version >= 17:
+                dtb_struct_size = struct.unpack(">I", header_data[36:40])[0]
 
         return DtbHeader(
             dtb_magic,

--- a/ofrak_core/ofrak/core/elf/analyzer.py
+++ b/ofrak_core/ofrak/core/elf/analyzer.py
@@ -50,8 +50,8 @@ class ElfBasicHeaderAttributesAnalyzer(Analyzer[None, ElfBasicHeader]):
     outputs = (ElfBasicHeader,)
 
     async def analyze(self, resource: Resource, config=None) -> ElfBasicHeader:
-        tmp = await resource.get_data()
-        deserializer = BinaryDeserializer(io.BytesIO(tmp))
+        with await resource.get_data_memoryview() as tmp:
+            deserializer = BinaryDeserializer(io.BytesIO(tmp))
         (
             ei_magic,
             ei_class,

--- a/ofrak_core/ofrak/core/entropy/entropy.py
+++ b/ofrak_core/ofrak/core/entropy/entropy.py
@@ -76,7 +76,7 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummary]):
 
 
 def sample_entropy(
-    data: bytes, resource_id: bytes, window_size=256, max_samples=2**20
+    data: bytearray, resource_id: bytes, window_size=256, max_samples=2**20
 ) -> bytes:  # pragma: no cover
     """
     Return a list of entropy values where each value represents the Shannon entropy of the byte

--- a/ofrak_core/ofrak/core/entropy/entropy_c.py
+++ b/ofrak_core/ofrak/core/entropy/entropy_c.py
@@ -33,7 +33,8 @@ def entropy_c(
     if len(data) <= window_size:
         return b""
     entropy = ctypes.create_string_buffer(len(data) - window_size)
-    errval = C_ENTROPY_FUNC(data, len(data), entropy, window_size, C_LOG_TYPE(log_percent))
+    buffer = (ctypes.c_char * len(data)).from_buffer_copy(data)
+    errval = C_ENTROPY_FUNC(buffer, len(data), entropy, window_size, C_LOG_TYPE(log_percent))
     if errval != 0:
         raise ValueError("Bad input to entropy function.")
-    return bytes(entropy.raw)
+    return entropy.raw

--- a/ofrak_core/ofrak/core/entropy/entropy_py.py
+++ b/ofrak_core/ofrak/core/entropy/entropy_py.py
@@ -25,7 +25,7 @@ def entropy_py(
         histogram[b] += 1
 
     # Calculate the entropy using a sliding window
-    entropy = [0] * (len(data) - window_size)
+    entropy = bytearray(max(0, len(data) - window_size))
     last_percent_logged = 0
     for i in range(len(entropy)):
         entropy[i] = math.floor(255 * _shannon_entropy(histogram, window_size))
@@ -35,7 +35,7 @@ def entropy_py(
         if percent > last_percent_logged and percent % 10 == 0:
             log_percent(percent)
             last_percent_logged = percent
-    return bytes(entropy)
+    return entropy
 
 
 def _shannon_entropy(distribution: List[int], window_size: int) -> float:

--- a/ofrak_core/ofrak/core/filesystem.py
+++ b/ofrak_core/ofrak/core/filesystem.py
@@ -214,7 +214,7 @@ class FilesystemEntry(ResourceView):
         elif self.is_file():
             file_name = os.path.join(root_path, entry_path)
             with open(file_name, "wb") as f:
-                f.write(await self.resource.get_data())
+                await self.resource.write_to(f, pack=False)
             self.apply_stat_attrs(file_name)
         elif self.is_device():
             device_name = os.path.join(root_path, entry_path)

--- a/ofrak_core/ofrak/core/gzip.py
+++ b/ofrak_core/ofrak/core/gzip.py
@@ -53,7 +53,7 @@ class GzipUnpacker(Unpacker[None]):
 
     async def unpack(self, resource: Resource, config=None):
         with await resource.get_data_memoryview() as data:
-            unpacked_data = await self.unpack_with_zlib_module(data)
+            unpacked_data = self.unpack_with_zlib_module(data)
         return await resource.create_child(tags=(GenericBinary,), data=unpacked_data)
 
     @staticmethod

--- a/ofrak_core/ofrak/core/magic.py
+++ b/ofrak_core/ofrak/core/magic.py
@@ -68,7 +68,7 @@ class MagicAnalyzer(Analyzer[None, Magic]):
         if not MAGIC_INSTALLED:
             raise ComponentMissingDependencyError(self, LIBMAGIC_DEP)
         else:
-            with await resource.get_data_memoryview() as buffer:
+            with await resource.get_data_memoryview(force_readonly=False) as buffer:
                 c_char_array = c_char * len(buffer)
                 if buffer.readonly:
                     buffer_ctypes = c_char_array.from_buffer_copy(buffer)

--- a/ofrak_core/ofrak/core/magic.py
+++ b/ofrak_core/ofrak/core/magic.py
@@ -1,6 +1,7 @@
 import logging
 from dataclasses import dataclass
 from typing import Callable, Dict, Iterable, Union
+from ctypes import c_char
 
 from ofrak.component.abstract import ComponentMissingDependencyError
 
@@ -64,13 +65,18 @@ class MagicAnalyzer(Analyzer[None, Magic]):
     external_dependencies = (LIBMAGIC_DEP,)
 
     async def analyze(self, resource: Resource, config=None) -> Magic:
-        data = await resource.get_data()
         if not MAGIC_INSTALLED:
             raise ComponentMissingDependencyError(self, LIBMAGIC_DEP)
         else:
-            magic_mime = magic.from_buffer(data, mime=True)
-            magic_description = magic.from_buffer(data)
-            return Magic(magic_mime, magic_description)
+            with await resource.get_data_memoryview() as buffer:
+                c_char_array = c_char * len(buffer)
+                if buffer.readonly:
+                    buffer_ctypes = c_char_array.from_buffer_copy(buffer)
+                else:
+                    buffer_ctypes = c_char_array.from_buffer(buffer)
+                magic_mime = magic.from_buffer(buffer_ctypes, mime=True)
+                magic_description = magic.from_buffer(buffer_ctypes)
+                return Magic(magic_mime, magic_description)
 
 
 class MagicMimeIdentifier(Identifier[None]):

--- a/ofrak_core/ofrak/core/seven_zip.py
+++ b/ofrak_core/ofrak/core/seven_zip.py
@@ -38,7 +38,6 @@ class SevenZUnpacker(Unpacker[None]):
 
     async def unpack(self, resource: Resource, config=None):
         seven_zip_v = await resource.view_as(SevenZFilesystem)
-        resource_data = await seven_zip_v.resource.get_data()
         async with resource.temp_to_disk(suffix=".7z") as temp_path:
             with tempfile.TemporaryDirectory() as temp_flush_dir:
                 cmd = [

--- a/ofrak_core/ofrak/core/ubi.py
+++ b/ofrak_core/ofrak/core/ubi.py
@@ -188,9 +188,7 @@ class UbiUnpacker(Unpacker[None]):
         with tempfile.TemporaryDirectory() as temp_flush_dir:
             # flush to disk
             with open(f"{temp_flush_dir}/input.img", "wb") as temp_file:
-                resource_data = await resource.get_data()
-                temp_file.write(resource_data)
-                temp_file.flush()
+                await resource.write_to(temp_file, pack=False)
 
             # extract temp_file to temp_flush_dir
             cmd = [

--- a/ofrak_core/ofrak/core/ubifs.py
+++ b/ofrak_core/ofrak/core/ubifs.py
@@ -134,9 +134,7 @@ class UbifsUnpacker(Unpacker[None]):
         with tempfile.TemporaryDirectory() as temp_flush_dir:
             # flush to disk
             with open(f"{temp_flush_dir}/input.img", "wb") as temp_file:
-                resource_data = await resource.get_data()
-                temp_file.write(resource_data)
-                temp_file.flush()
+                await resource.write_to(temp_file, pack=False)
 
             cmd = [
                 "ubireader_extract_files",

--- a/ofrak_core/ofrak/core/zstd.py
+++ b/ofrak_core/ofrak/core/zstd.py
@@ -73,7 +73,7 @@ class ZstdPacker(Packer[ZstdPackerConfig]):
         proc = await asyncio.create_subprocess_exec(
             *command, stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE
         )
-        with await resource.get_data_memoryview() as data:
+        with await child_file.resource.get_data_memoryview() as data:
             result, _ = await proc.communicate(data)
         if proc.returncode:
             raise CalledProcessError(returncode=proc.returncode, cmd=command)

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -1572,7 +1572,7 @@ class Resource:
         with tempfile.NamedTemporaryFile(
             mode="wb", prefix=prefix, suffix=suffix, dir=dir, delete_on_close=False, delete=delete
         ) as temp:
-            temp.write(await self.get_data())
+            await self.write_to(temp, pack=False)
             temp.close()
             yield temp.name
 

--- a/ofrak_core/ofrak/service/data_service.py
+++ b/ofrak_core/ofrak/service/data_service.py
@@ -102,11 +102,14 @@ class DataService(DataServiceInterface):
     ) -> memoryview:
         model = self._get_by_id(data_id)
         root = self._get_root_by_id(model.root_id)
-        if data_range is not None:
-            translated_range = data_range.translate(model.range.start).intersect(root.model.range)
-            return memoryview(root.data)[translated_range.start : translated_range.end]
-        else:
-            return memoryview(root.data)[model.range.start : model.range.end]
+        with memoryview(root.data) as memview:
+            if data_range is not None:
+                translated_range = data_range.translate(model.range.start).intersect(
+                    root.model.range
+                )
+                return memview[translated_range.start : translated_range.end]
+            else:
+                return memview[model.range.start : model.range.end]
 
     async def get_data_memoryview(
         self, data_id: DataId, data_range: Optional[Range] = None

--- a/ofrak_core/ofrak/service/data_service.py
+++ b/ofrak_core/ofrak/service/data_service.py
@@ -97,14 +97,25 @@ class DataService(DataServiceInterface):
         else:
             return within_model.range.intersect(model.range).translate(-within_model.range.start)
 
-    async def get_data(self, data_id: DataId, data_range: Optional[Range] = None) -> bytes:
+    def _get_data_memoryview(
+        self, data_id: DataId, data_range: Optional[Range] = None
+    ) -> memoryview:
         model = self._get_by_id(data_id)
         root = self._get_root_by_id(model.root_id)
         if data_range is not None:
             translated_range = data_range.translate(model.range.start).intersect(root.model.range)
-            return root.data[translated_range.start : translated_range.end]
+            return memoryview(root.data)[translated_range.start : translated_range.end]
         else:
-            return root.data[model.range.start : model.range.end]
+            return memoryview(root.data)[model.range.start : model.range.end]
+
+    async def get_data_memoryview(
+        self, data_id: DataId, data_range: Optional[Range] = None
+    ) -> memoryview:
+        return self._get_data_memoryview(data_id, data_range)
+
+    async def get_data(self, data_id: DataId, data_range: Optional[Range] = None) -> bytes:
+        with self._get_data_memoryview(data_id, data_range) as buffer:
+            return buffer.tobytes()
 
     async def apply_patches(self, patches: List[DataPatch]) -> List[DataPatchesResult]:
         patches_by_root: Dict[DataId, List[DataPatch]] = defaultdict(list)
@@ -261,13 +272,11 @@ class DataService(DataServiceInterface):
         for affected_range in affected_ranges:
             results[root_data_id].append(affected_range)
 
-        new_root_data = bytearray(root.data)
         # Apply finalized patches to data and data models
         for patch_range, data, size_diff in finalized_ordered_patches:
-            new_root_data[patch_range.start : patch_range.end] = data
+            root.data[patch_range.start : patch_range.end] = data
             if size_diff != 0:
                 root.resize_range(patch_range, size_diff)
-        root.data = bytes(new_root_data)
 
         return [
             DataPatchesResult(data_id, results_for_id)
@@ -326,7 +335,7 @@ class _DataRoot:
 
     def __init__(self, model: DataModel, data: bytes):
         self.model: DataModel = model
-        self.data = data
+        self.data = bytearray(data)
         self._children: Dict[DataId, DataModel] = dict()
 
         # A pair of sorted 2D arrays, where each "point" in the grid is a set of children's data IDs

--- a/ofrak_core/ofrak/service/data_service_i.py
+++ b/ofrak_core/ofrak/service/data_service_i.py
@@ -138,6 +138,28 @@ class DataServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
+    async def get_data_memoryview(
+        self, data_id: bytes, data_range: Optional[Range] = None
+    ) -> memoryview:
+        """
+        Get the data (or section of data) of a model as a memoryview object. This method is provided
+        in order to reduce the number of copy operations in certain scenarios such as passing a buffer
+        to ctypes.
+
+        :param data_id: A unique ID for a data model
+        :param data_range: An optional range within the model's data to return
+
+        :return: memoryview of data from the model associated with `data_id` - all bytes by default, a
+        specific slice if `data_range` is provided, and empty bytes if `data_range` is provided but
+        is outside the modeled data. The returned memoryview will have itemsize=1 and may or may not
+        be readonly. The returned memoryview should be used as a context manager in order to release it
+        automatically and should NOT be written to.
+
+        :raises NotFoundError: if `data_id` is not associated with any known model
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     async def apply_patches(
         self,
         patches: List[DataPatch],

--- a/ofrak_core/test_ofrak/components/test_data.py
+++ b/ofrak_core/test_ofrak/components/test_data.py
@@ -18,6 +18,9 @@ class MockResource:
     async def get_data(self):
         return self.data
 
+    async def get_data_memoryview(self):
+        return memoryview(self.data)
+
 
 @dataclass
 class MockDataWord(DataWord):


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Introduce `get_data_memoryview()` for copy-free access to resource data 

**Link to Related Issue(s)**
#551 

**Please describe the changes in your request.**
- Adds `get_data_memoryview()` to data service and `Resource` to get a copy-free view of a resource's data
- Changes many built in components to use `get_data_memoryview()` instead of `get_data()`
- Changes magic component to pass memoryview as buffer directly

**Anyone you think should look at this, specifically?**
