### PR TITLE
Data.Offset refers to offset in data root

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Made some changes to OFRAK test suite to improve test coverage on Windows ([#487](https://github.com/redballoonsecurity/ofrak/pull/487))
 - Fix usage of `NamedTemporaryFile` with external tools on Windows ([#486](https://github.com/redballoonsecurity/ofrak/pull/486))
 - Fix unintentional ignoring of cpio errors introduced in [#486](https://github.com/redballoonsecurity/ofrak/pull/486) ([#555](https://github.com/redballoonsecurity/ofrak/pull/555]))
+- `Data` resource attribute always corresponds to value of `Resource.get_data_range_within_root` ([#559](https://github.com/redballoonsecurity/ofrak/pull/559))
 
 ### Changed
 - By default, the ofrak log is now `ofrak-YYYYMMDDhhmmss.log` rather than just `ofrak.log` and the name can be specified on the command line ([#480](https://github.com/redballoonsecurity/ofrak/pull/480))

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -918,7 +918,7 @@ class Data(ResourceAttributes):
     will screw up sorting/filtering.
     """
 
-    _offset: int  # Offset of the resource in the data root.
+    _offset: int  # Offset of the resource in the root binary blob it is mapped into.
     _length: int
 
     @index

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -918,7 +918,7 @@ class Data(ResourceAttributes):
     will screw up sorting/filtering.
     """
 
-    _offset: int
+    _offset: int  # Offset of the resource in the data root.
     _length: int
 
     @index

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -918,7 +918,7 @@ class Data(ResourceAttributes):
     will screw up sorting/filtering.
     """
 
-    _offset: int  # Offset of the resource in the root binary blob it is mapped into.
+    _offset: int  # Offset of the resource in the binary blob it is mapped into.
     _length: int
 
     @index

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -683,11 +683,7 @@ class Resource:
                 self._resource.data_id,
                 data_range,
             )
-            if data_model.root_id != self._resource.data_id:
-                # If the root id is not the parent, we need to translate the data range
-                #  by the root id range start
-                data_range = data_range.translate(data_model.range.start)
-            data_attrs = Data(data_range.start, data_range.length())
+            data_attrs = Data(data_model.range.start, data_model.range.length())
             attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         elif data is not None:
             if self._resource.data_id is None:

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -683,8 +683,11 @@ class Resource:
                 self._resource.data_id,
                 data_range,
             )
-            translated_range = data_range.translate(data_model.range.start)
-            data_attrs = Data(translated_range.start, translated_range.length())
+            if data_model.root_id != self._resource.data_id:
+                # If the root id is not the parent, we need to translate the data range
+                #  by the root id range start
+                data_range = data_range.translate(data_model.range.start)
+            data_attrs = Data(data_range.start, data_range.length())
             attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         elif data is not None:
             if self._resource.data_id is None:

--- a/ofrak_core/ofrak/resource.py
+++ b/ofrak_core/ofrak/resource.py
@@ -678,12 +678,13 @@ class Resource:
                     "Cannot create a child with mapped data from a parent that doesn't have data"
                 )
             data_model_id = resource_id
-            await self._data_service.create_mapped(
+            data_model = await self._data_service.create_mapped(
                 data_model_id,
                 self._resource.data_id,
                 data_range,
             )
-            data_attrs = Data(data_range.start, data_range.length())
+            translated_range = data_range.translate(data_model.range.start)
+            data_attrs = Data(translated_range.start, translated_range.length())
             attributes = [data_attrs, *attributes] if attributes else [data_attrs]
         elif data is not None:
             if self._resource.data_id is None:

--- a/ofrak_core/test_ofrak/unit/test_data_attributes.py
+++ b/ofrak_core/test_ofrak/unit/test_data_attributes.py
@@ -79,7 +79,7 @@ class TestGrandchildrenDataAttributes:
     @staticmethod
     async def assert_child_and_sorted_grandchildren_are_equivalent(b_child):
         """
-        Assort that child bytes equals values of sorted grandchildren.
+        Assert that child bytes equals the values of sorted grandchildren.
 
         When this test was created, it failed with:
         b'CBBB' != b'BBBC'

--- a/ofrak_core/test_ofrak/unit/test_data_attributes.py
+++ b/ofrak_core/test_ofrak/unit/test_data_attributes.py
@@ -54,15 +54,16 @@ async def test_data_attributes_update(ofrak_context: OFRAKContext, elf_object_fi
 
 
 class TestGrandchildrenDataAttributes:
-    async def test_grandchildren_data_attributes(self, ofrak_context: OFRAKContext):
+    async def test_grandchildren_data_attributes_update(self, ofrak_context: OFRAKContext):
         """
         Test that grandchildren data attributes update correctly.
         """
-        b_child = await self._get_child_resource(ofrak_context)
+        b_child = await self._create_resource_get_child(ofrak_context)
         await b_child.run(BinaryPatchModifier, BinaryPatchConfig(0, b"C"))
         await self.assert_child_and_sorted_grandchildren_are_equivalent(b_child)
 
-    async def _get_child_resource(self, ofrak_context):
+    @staticmethod
+    async def _create_resource_get_child(ofrak_context):
         """
         Create a resource with contents b"AAAABBBB".
         Unpack the BBBB as one child, and create byte-size grandchildren for each byte
@@ -86,6 +87,9 @@ class TestGrandchildrenDataAttributes:
 
         Expected :b'BBBC'
         Actual   :b'CBBB'
+
+        See https://github.com/redballoonsecurity/ofrak/pull/559 for the bugfix corresponding
+        to this test.
         """
         sorted_children = await b_child.get_children(r_sort=ResourceSort(Data.Offset))
         assert await b_child.get_data() == b"".join(

--- a/ofrak_core/test_ofrak/unit/test_data_attributes.py
+++ b/ofrak_core/test_ofrak/unit/test_data_attributes.py
@@ -1,4 +1,5 @@
 from ofrak import OFRAKContext, ResourceSort
+from ofrak.core import BinaryPatchModifier, BinaryPatchConfig
 from ofrak.model.resource_model import Data
 from ofrak_type import Range
 
@@ -50,3 +51,43 @@ async def test_data_attributes_update(ofrak_context: OFRAKContext, elf_object_fi
         elif child == arbitrary_child2:
             assert arbitrary_child1_found
             break
+
+
+class TestGrandchildrenDataAttributes:
+    async def test_grandchildren_data_attributes(self, ofrak_context: OFRAKContext):
+        """
+        Test that grandchildren data attributes update correctly.
+        """
+        b_child = await self._get_child_resource(ofrak_context)
+        await b_child.run(BinaryPatchModifier, BinaryPatchConfig(0, b"C"))
+        await self.assert_child_and_sorted_grandchildren_are_equivalent(b_child)
+
+    async def _get_child_resource(self, ofrak_context):
+        """
+        Create a resource with contents b"AAAABBBB".
+        Unpack the BBBB as one child, and create byte-size grandchildren for each byte
+        of that child.
+
+        Returns b_child.
+        """
+        resource = await ofrak_context.create_root_resource(name="test-resource", data=b"AAAABBBB")
+        b_child = await resource.create_child(data_range=Range(4, 8))
+        for i in range(await b_child.get_data_length()):
+            await b_child.create_child(data_range=Range(i, i + 1))
+        return b_child
+
+    @staticmethod
+    async def assert_child_and_sorted_grandchildren_are_equivalent(b_child):
+        """
+        Assort that child bytes equals values of sorted grandchildren.
+
+        When this test was created, it failed with:
+        b'CBBB' != b'BBBC'
+
+        Expected :b'BBBC'
+        Actual   :b'CBBB'
+        """
+        sorted_children = await b_child.get_children(r_sort=ResourceSort(Data.Offset))
+        assert await b_child.get_data() == b"".join(
+            [await child.get_data() for child in sorted_children]
+        )


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Update `Data.Offset` such that its value is always the equivalent to a resource's start offset in the data root:

```
Range.from_size(Data.Offset, Data.Length) == await resource.get_data_range_within_root()
```

**Link to Related Issue(s)**

**Please describe the changes in your request.**
Before this change, the `Data` attribute was created with the data range of a parent resource, which was not always equal to the data root range.

During patching, however, the value of `Data` were updated to correspond to the root data range. This created inconsistencies when sorting by `Data`--for example, in the OFRAK GUI tree. 

`TestGrandchildrenDataAttributes` asserts that the behavior is correct.

**Anyone you think should look at this, specifically?**
@rbs-jacob.
@dannyp303 could review for general awareness.