### PR TITLE
Add `--config-settings editable_mode=compat` to `make develop` pip command lines

### DIFF
--- a/disassemblers/ofrak_angr/Makefile
+++ b/disassemblers/ofrak_angr/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test]
+	$(PIP) install -e .[test] --config-settings editable_mode=legacy
 
 .PHONY: inspect
 inspect:

--- a/disassemblers/ofrak_angr/Makefile
+++ b/disassemblers/ofrak_angr/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[test] --config-settings editable_mode=compat
 
 .PHONY: inspect
 inspect:

--- a/disassemblers/ofrak_binary_ninja/Makefile
+++ b/disassemblers/ofrak_binary_ninja/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test]
+	$(PIP) install -e .[test] --config-settings editable_mode=legacy
 
 .PHONY: inspect
 inspect:

--- a/disassemblers/ofrak_binary_ninja/Makefile
+++ b/disassemblers/ofrak_binary_ninja/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[test] --config-settings editable_mode=compat
 
 .PHONY: inspect
 inspect:

--- a/disassemblers/ofrak_capstone/Makefile
+++ b/disassemblers/ofrak_capstone/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test]
+	$(PIP) install -e .[test] --config-settings editable_mode=legacy
 
 .PHONY: inspect
 inspect:

--- a/disassemblers/ofrak_capstone/Makefile
+++ b/disassemblers/ofrak_capstone/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[test] --config-settings editable_mode=compat
 
 .PHONY: inspect
 inspect:

--- a/disassemblers/ofrak_ghidra/Makefile
+++ b/disassemblers/ofrak_ghidra/Makefile
@@ -5,7 +5,7 @@ install:
 	$(PIP) install .
 
 develop:
-	$(PIP) install -e .[test]
+	$(PIP) install -e .[test] --config-settings editable_mode=legacy
 
 test:
 	$(PYTHON) -m pytest --cov=ofrak_ghidra --cov-report=term-missing ofrak_ghidra_test

--- a/disassemblers/ofrak_ghidra/Makefile
+++ b/disassemblers/ofrak_ghidra/Makefile
@@ -5,7 +5,7 @@ install:
 	$(PIP) install .
 
 develop:
-	$(PIP) install -e .[test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[test] --config-settings editable_mode=compat
 
 test:
 	$(PYTHON) -m pytest --cov=ofrak_ghidra --cov-report=term-missing ofrak_ghidra_test

--- a/ofrak-core-dev.yml
+++ b/ofrak-core-dev.yml
@@ -9,3 +9,4 @@ packages_paths:
     "ofrak_core",
     "frontend",
   ]
+python_image: "python:3.11.11-bookworm@sha256:b337e1fd27dbacda505219f713789bf82766694095876769ea10c2d34b4f470b"

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -7,7 +7,7 @@ install: ofrak/gui/public
 
 .PHONY: develop
 develop: ofrak/gui/public
-	$(PIP) install -e .[docs,test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[docs,test] --config-settings editable_mode=compat
 
 .PHONY: inspect
 inspect:

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -7,7 +7,7 @@ install: ofrak/gui/public
 
 .PHONY: develop
 develop: ofrak/gui/public
-	$(PIP) install -e .[docs,test]
+	$(PIP) install -e .[docs,test] --config-settings editable_mode=legacy
 
 .PHONY: inspect
 inspect:

--- a/ofrak_io/Makefile
+++ b/ofrak_io/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test]
+	$(PIP) install -e .[test] --config-settings editable_mode=legacy
 
 .PHONY: inspect
 inspect:

--- a/ofrak_io/Makefile
+++ b/ofrak_io/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[test] --config-settings editable_mode=compat
 
 .PHONY: inspect
 inspect:

--- a/ofrak_patch_maker/Makefile
+++ b/ofrak_patch_maker/Makefile
@@ -8,7 +8,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[test] --config-settings editable_mode=compat
 
 .PHONY: inspect
 inspect:

--- a/ofrak_patch_maker/Makefile
+++ b/ofrak_patch_maker/Makefile
@@ -8,7 +8,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test]
+	$(PIP) install -e .[test] --config-settings editable_mode=legacy
 
 .PHONY: inspect
 inspect:

--- a/ofrak_tutorial/Makefile
+++ b/ofrak_tutorial/Makefile
@@ -29,7 +29,7 @@ run:
 
 .PHONY: develop
 develop:
-	${PIP} install -e .[test]
+	${PIP} install -e .[test] --config-settings editable_mode=legacy
 	make generate_stripped_notebooks
 
 .PHONY: install

--- a/ofrak_tutorial/Makefile
+++ b/ofrak_tutorial/Makefile
@@ -29,7 +29,7 @@ run:
 
 .PHONY: develop
 develop:
-	${PIP} install -e .[test] --config-settings editable_mode=legacy
+	${PIP} install -e .[test] --config-settings editable_mode=compat
 	make generate_stripped_notebooks
 
 .PHONY: install

--- a/ofrak_type/Makefile
+++ b/ofrak_type/Makefile
@@ -1,13 +1,13 @@
 PYTHON=python3
 PIP=pip3
 
-.PHONY: develop
+.PHONY: install
 install:
 	$(PIP) install .
 
-.PHONY: install
+.PHONY: develop
 develop:
-	$(PIP) install -e .[test]
+	$(PIP) install -e .[test] --config-settings editable_mode=legacy
 
 .PHONY: inspect
 inspect:

--- a/ofrak_type/Makefile
+++ b/ofrak_type/Makefile
@@ -7,7 +7,7 @@ install:
 
 .PHONY: develop
 develop:
-	$(PIP) install -e .[test] --config-settings editable_mode=legacy
+	$(PIP) install -e .[test] --config-settings editable_mode=compat
 
 .PHONY: inspect
 inspect:


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

`setuptools` changes the way editable packages are installed in newer versions. See https://setuptools.pypa.io/en/latest/userguide/development_mode.html for information.

The default format for newer packages causes issues such as directories in the current working directory being imported unintentionally over editable packages with the same name. See https://github.com/pypa/setuptools/issues/3557#issuecomment-1226027571 for discussion about this issue.

For now, I believe it makes sense to use the "legacy" editable install mode to avoid issues until the newer editable hooks format is mature and bug-free.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add `--config-settings editable_mode=compat` to `make develop` pip command lines.

**Link to Related Issue(s)**
#552 

**Anyone you think should look at this, specifically?**
@rbs-jacob 