### PR TITLE
Fix pjson tests on newer Python versions

### DIFF
--- a/ofrak_core/test_ofrak/service/serialization_service/test_pjson.py
+++ b/ofrak_core/test_ofrak/service/serialization_service/test_pjson.py
@@ -77,10 +77,9 @@ def iterable_strategy(draw, type_hint):
 @composite
 def os_stat_result_strategy(draw, _type_hint):
     """
-    os.stat_result instances can be generated as tuples of size 10. They most likely won't be valid
-    but it doesn't matter here.
+    os.stat_result instances can be generated as tuples of size 10.
     """
-    return draw(tuples(*[integer_strategy()] * 10))
+    return os.stat_result(draw(tuples(*[integer_strategy()] * 10)))
 
 
 @composite

--- a/ofrak_core/test_ofrak/service/serialization_service/test_pjson.py
+++ b/ofrak_core/test_ofrak/service/serialization_service/test_pjson.py
@@ -269,7 +269,7 @@ def test_interval_tree_serialization(obj: IntervalTree, _test_serialize_deserial
     "json_obj,type_hint",
     [
         ([1, 2], List),
-        ({1: 2}, Dict),
+        ([(1, 2)], Dict),
     ],
 )
 def test_from_pjson_ambiguous_type_hints(


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix pjson tests on newer python versions (>3.8)

**Link to Related Issue(s)**
#543 

**Please describe the changes in your request.**
- Fix draw strategy for `os.stat_result` so it returns an actual `stat_result` instead of a bare tuple. Fixes test failure on Python 3.9+
- Second minor bug: fix the ambiguous type hint test input to use the correct list-of-tuples serialization for `Dict`, so that the error is actually from the type hint being ambiguous and not from the improper serialization. 

**Anyone you think should look at this, specifically?**
