### PR TITLE
Filter excessive crosstool-ng output

### DIFF
--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -80,7 +80,8 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       'CT_ZLIB_PATCH_GLOBAL=y' \
       'CT_ZSTD_PATCH_GLOBAL=y' \
       >> .config && \
-    ./ct-ng build CT_JOBS=`nproc` && \
+    ./ct-ng build CT_JOBS=`nproc` \
+      | sed 's/.*\r//g' && \
     cd /tmp && rm -rf crosstool-ng; \
 fi;
 


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Remove crosstool-ng loading spinner output during docker build.

**Please describe the changes in your request.**

`crosstool-ng` is used to cross-compile the m68k toolchain in the patch maker Docker build. Unfortunately, there is no argument or flag (that I could find) to tell `ct-ng` to run without a loading spinner. Since the builds can take a long time, and since the spinner is output regardless of whether `ct-ng` runs in a TTY or not, the Docker logs (on GitHub Actions and locally) are polluted by thousands upon thousands of lines of loading spinner slashes. For an example [check out this insane test run output](https://github.com/redballoonsecurity/ofrak/actions/runs/12658836028/job/35276633644?pr=562). 

To solve this, I pipe the `ct-ng` output to `sed`, and remove all lines ending in a carriage return. This has the added benefit of giving us regular compilation output, without the spinner, instead of condemning us to entirely silent compilation. 

**Anyone you think should look at this, specifically?**

@alchzh @paulnoalhyt 