### PR TITLE
Fix bug with resource data offset in `FreeSpaceModifier` introduced in #505

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `PatchFromSourceModifier` bundles src and header files into same temporary directory with BOM and FEM ([#517](https://github.com/redballoonsecurity/ofrak/pull/517))
 - Add support for running on Windows to the `Filesystem` component. ([#521](https://github.com/redballoonsecurity/ofrak/pull/521))
 - Add `JavaArchive` resource tag ([#492](https://github.com/redballoonsecurity/ofrak/pull/492))
-- Add new method for allocating `.bss` sections using free space ranges that aren't mapped to data ranges. ([#505](https://github.com/redballoonsecurity/ofrak/pull/505))
+- Add new method for allocating `.bss` sections using free space ranges that aren't mapped to data ranges. ([#505](https://github.com/redballoonsecurity/ofrak/pull/505), [#569](https://github.com/redballoonsecurity/ofrak/pull/569))
 - Add `JavaArchive` resource tag ([#492](https://github.com/redballoonsecurity/ofrak/pull/492))
 
 ### Fixed

--- a/ofrak_core/ofrak/core/free_space.py
+++ b/ofrak_core/ofrak/core/free_space.py
@@ -606,7 +606,7 @@ class FreeSpaceModifier(Modifier[FreeSpaceModifierConfig]):
             FreeSpaceTag = RuntimeFreeSpace
         else:
             patch_data = _get_patch(freed_range, config.stub, config.fill)
-            patch_offset = (await parent.get_data_range_within_parent()).start
+            patch_offset = (await resource.get_data_range_within_parent()).start
             patch_range = freed_range.translate(patch_offset - freed_range.start)
 
             # Patch in the patch_data


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fix bug with resource data offset in free_space.py introduced in #505. (No changelog necessary, fixes a bug recently introduced)

**Link to Related Issue(s)**

**Please describe the changes in your request.**
- Fix a typo where `(await resource.get_data_range_within_parent()).start` was accidentally replaced with `(await parent.get_data_range_within_parent()).start` in `FreeSpaceModifier`
 - Change the free space modifier tests to use a child memoryregion with non-zero offset to catch this bug in the future.
 
**Anyone you think should look at this, specifically?**
