### PR TITLE
Fix failing tests, including in ofrak-core-dev docker with Python3.11

### DIFF
--- a/ofrak_core/ofrak/ofrak_context.py
+++ b/ofrak_core/ofrak/ofrak_context.py
@@ -203,7 +203,10 @@ class OFRAK:
 
     # TODO: Typehints here do not properly accept functions with variable args
     def run(self, func: Callable[["OFRAKContext", Any], Awaitable[None]], *args):
-        asyncio.get_event_loop().run_until_complete(self.run_async(func, *args))
+        # If we run this function multiple time and try using the default loop,
+        # the first test will delete the loop at the end of the run,
+        # and the 2nd call, unless we create a new asyncio loop.
+        asyncio.new_event_loop().run_until_complete(self.run_async(func, *args))
 
     def _setup(self):
         """Discover common OFRAK services and components."""

--- a/ofrak_io/ofrak_io/batch_manager.py
+++ b/ofrak_io/ofrak_io/batch_manager.py
@@ -91,7 +91,7 @@ class _BatchManagerImplementation(BatchManagerInterface[Request, Result]):
         current_batch.add_request(request)
         # Gives self._handler_loop_task a chance to raise its errors
         done, _ = await asyncio.wait(
-            (current_batch.result(request), self._handler_loop_task),
+            (asyncio.ensure_future(current_batch.result(request)), self._handler_loop_task),
             return_when=asyncio.FIRST_COMPLETED,
         )
         return next(iter(done)).result()


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Fixed two tests - one was failing starting with Python 3.11 and another is probably an intermittent failure that existed for a while.

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
- `ofrak_io/ofrak_io/batch_manager.py` - starting with Python3.11, coroutines cannot be passed to asyncio.wait directly, and have to be wrapped in a future or a task. This wraps it using `asyncio.ensure_future`
- ofrak_core/ofrak/ofrak_context.py: `OFRAK.run` used `asyncio.new_event_loop().run_until_complete` which meant that the first time it was executed, it will delete the loop at the end of the run, and will then fail with a RuntimeException on any further calls. This means that during testing, if two tests using this function happened to be assigned to the same runner process, then the 2nd test would fail. Changed it by creating a separate asyncio loop for each call, so that it does not mess with the default loop.

**Anyone you think should look at this, specifically?**
@whyitfor 
