### PR TITLE
Cache ResourceAttributes.get_indexable_attributes

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to `ofrak` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased: 3.3.0rc3](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased: 3.3.0rc5](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Added
 - Add license check command to prompt users about community or pro licenses. ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
 - Support `application/vnd.android.package-archive` mime type for APKs, which is returned by newer versions of libmagic ([#470](https://github.com/redballoonsecurity/ofrak/pull/470))
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix broken link in docs ([#574](https://github.com/redballoonsecurity/ofrak/pull/574))
 - Fix ValueError after analyzing ELF with invalid MemoryPermissions ([#581](https://github.com/redballoonsecurity/ofrak/pull/581))
 - Fix build pipeline failures by pinning `orjson`, a recent minor version of which breaks the PJSON tests. ([#584](https://github.com/redballoonsecurity/ofrak/pull/584))
+- Improve performance of ResourceAttributes.get_indexable_attributes()
 
 ### Changed
 - By default, the ofrak log is now `ofrak-YYYYMMDDhhmmss.log` rather than just `ofrak.log` and the name can be specified on the command line ([#480](https://github.com/redballoonsecurity/ofrak/pull/480))

--- a/ofrak_core/ofrak/model/resource_model.py
+++ b/ofrak_core/ofrak/model/resource_model.py
@@ -1,6 +1,7 @@
 import dataclasses
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from functools import lru_cache
 from typing import (
     TypeVar,
     Set,
@@ -229,6 +230,7 @@ class ResourceAttributes:
         return f"{self.__class__.__name__}({fields_str})"
 
     @classmethod
+    @lru_cache(maxsize=None)
     def get_indexable_attributes(cls) -> List[ResourceIndexedAttribute]:
         indexable_attributes = []
         for name, attr in cls.__dict__.items():

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -69,7 +69,7 @@ def read_requirements(requirements_path):
 
 setuptools.setup(
     name="ofrak",
-    version="3.3.0rc4",
+    version="3.3.0rc5",
     description="A binary analysis and modification platform",
     packages=setuptools.find_packages(exclude=["test_ofrak", "test_ofrak.*"]),
     package_data={


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add an lru_cache to `ResourceAttributes.get_indexable_attributes`.

**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
`ResourceAttributes.get_indexable_attributes` is called every time a resource is created.

By applying this lru_cache, we ensure that the work behind this function is done once per type of `ResourceAttribute`.

**Anyone you think should look at this, specifically?**
