### PR TITLE
Remove DecompilationIdentifier, it is not needed!

### DIFF
--- a/disassemblers/ofrak_angr/CHANGELOG.md
+++ b/disassemblers/ofrak_angr/CHANGELOG.md
@@ -3,11 +3,11 @@ All notable changes to `ofrak-angr` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased 1.1.0rc0](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Changed
 - Update to latest angr==9.2.93, which also necessitates Python >= 3.8.
-- Refactored AngrDecompilationAnalysis/Analyzer to use generic components in ofrak core. ([#453](https://github.com/redballoonsecurity/ofrak/pull/453))
+- Add decompilation using angr backend ([#453](https://github.com/redballoonsecurity/ofrak/pull/453), [#600](https://github.com/redballoonsecurity/ofrak/pull/600))
 - Minor update to OFRAK Community License, add OFRAK Pro License ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
 
 ### Fixed

--- a/disassemblers/ofrak_angr/ofrak_angr/components/angr_decompilation_analyzer.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/angr_decompilation_analyzer.py
@@ -1,20 +1,18 @@
 import angr
 from angr.analyses.decompiler import Decompiler
-from ofrak.component.analyzer import Analyzer
 
 from ofrak.resource import Resource
 from ofrak.core.complex_block import ComplexBlock
 from ofrak.service.resource_service_i import ResourceFilter
 from ofrak_angr.model import AngrAnalysis, AngrAnalysisResource
-from ofrak.core.decompilation import DecompilationAnalysis
+from ofrak.core.decompilation import DecompilationAnalysis, DecompilationAnalyzer
 
 
-class AngrDecompilatonAnalyzer(Analyzer[None, DecompilationAnalysis]):
-    id = b"AngrDecompilationAnalyzer"
+class AngrDecompilatonAnalyzer(DecompilationAnalyzer):
     targets = (ComplexBlock,)
     outputs = (DecompilationAnalysis,)
 
-    async def analyze(self, resource: Resource, config: None) -> DecompilationAnalysis:
+    async def analyze(self, resource: Resource, config=None) -> DecompilationAnalysis:
         # Run / fetch angr analyzer
         try:
             root_resource = await resource.get_only_ancestor(
@@ -51,6 +49,7 @@ class AngrDecompilatonAnalyzer(Analyzer[None, DecompilationAnalysis]):
                 decomp = dec.codegen.text
             else:
                 decomp = "No Decompilation available"
+            resource.add_tag(DecompilationAnalysis)
             return DecompilationAnalysis(decomp)
         except Exception as e:
             return DecompilationAnalysis(

--- a/disassemblers/ofrak_angr/ofrak_angr_test/test_decompilation.py
+++ b/disassemblers/ofrak_angr/ofrak_angr_test/test_decompilation.py
@@ -1,6 +1,6 @@
 from typing import List
 import os
-from ofrak.core.decompilation import DecompilationAnalysis
+from ofrak.core.decompilation import DecompilationAnalysis, DecompilationAnalyzer
 from ofrak.ofrak_context import OFRAKContext
 from ofrak.core.complex_block import ComplexBlock
 from ofrak.service.resource_service_i import ResourceFilter
@@ -25,7 +25,7 @@ async def test_angr_decompilation(ofrak_context: OFRAKContext):
     )
     decomps = []
     for complex_block in complex_blocks:
-        await complex_block.resource.identify()
+        await complex_block.resource.run(DecompilationAnalyzer)
         angr_resource: DecompilationAnalysis = await complex_block.resource.view_as(
             DecompilationAnalysis
         )

--- a/disassemblers/ofrak_angr/setup.py
+++ b/disassemblers/ofrak_angr/setup.py
@@ -31,12 +31,12 @@ def read_requirements(requirements_path):
 
 setuptools.setup(
     name="ofrak_angr",
-    version="1.0.1",
+    version="1.1.0rc0",
     description="OFRAK angr Components",
     packages=setuptools.find_packages(exclude=["ofrak_angr_test", "ofrak_angr_test.*"]),
     package_data={"ofrak_angr": ["py.typed"]},
     install_requires=[
-        "ofrak",
+        "ofrak>=3.3.0rc10",
     ]
     + read_requirements("requirements.txt"),
     extras_require={

--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -3,16 +3,16 @@ All notable changes to `ofrak-ghidra` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased: 0.2.0rc0](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased 0.2.0rc1](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Changed
 - Minor update to OFRAK Community License, add OFRAK Pro License ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
 - Move to OpenJDK version 17 with the docker container move to Debian 12 ([#502](https://github.com/redballoonsecurity/ofrak/pull/502))
-- Upgrade Ghidra from 10.1.2 to 11.3.2 with native PyGhidra support ([#594](https://github.com/redballoonsecurity/ofrak/pull/594))
 
 ### Fixed
 - Speedup: do not run Ghidra auto-analysis upon importing a program. ([#473](https://github.com/redballoonsecurity/ofrak/pull/473))
 - Ensure large 64-bit addresses are interpreted as unsigned. ([#474](https://github.com/redballoonsecurity/ofrak/pull/474))
+- Update `GhidraDecompilationAnalyzer` to match API in ofrak 0.3.0rc10 ([#600](https://github.com/redballoonsecurity/ofrak/pull/600))
 
 ## 0.1.1 - 2024-02-15
 ### Added

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_decompilation_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_decompilation_analyzer.py
@@ -66,20 +66,21 @@ class GhidraDecompilationAnalyzer(DecompilationAnalyzer, OfrakGhidraMixin):
                 resource, complex_block.virtual_address
             )
         except JSONDecodeError as e:
-            return DecompilationAnalysis(str(e))
+            result = str(e)
+        finally:
+            if "decomp" in result:
+                decomp = (
+                    result["decomp"]
+                    .replace("<quote>", "'")
+                    .replace("<dquote>", '"')
+                    .replace("<nl>", "\n")
+                    .replace("<cr>", "\r")
+                    .replace("<tab>", "\t")
+                    .replace("<zero>", "\\0")
+                )
+            else:
+                decomp = "No Decompilation available"
 
-        if "decomp" in result:
-            decomp = (
-                result["decomp"]
-                .replace("<quote>", "'")
-                .replace("<dquote>", '"')
-                .replace("<nl>", "\n")
-                .replace("<cr>", "\r")
-                .replace("<tab>", "\t")
-                .replace("<zero>", "\\0")
-            )
-        else:
-            decomp = "No Decompilation available"
-
-        decomp_escaped = escape_strings(decomp)
-        return DecompilationAnalysis(decomp_escaped)
+            decomp_escaped = escape_strings(decomp)
+            resource.add_tag(DecompilationAnalysis)
+            return DecompilationAnalysis(decomp_escaped)

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_decompilation.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra_test/test_decompilation.py
@@ -1,6 +1,6 @@
 from typing import List
 import os
-from ofrak.core.decompilation import DecompilationAnalysis
+from ofrak.core.decompilation import DecompilationAnalysis, DecompilationAnalyzer
 from ofrak.ofrak_context import OFRAKContext
 from ofrak.core.complex_block import ComplexBlock
 from ofrak.service.resource_service_i import ResourceFilter
@@ -25,7 +25,7 @@ async def test_ghidra_decompilation(ofrak_context: OFRAKContext):
     )
     decomps = []
     for complex_block in complex_blocks:
-        await complex_block.resource.identify()
+        await complex_block.resource.run(DecompilationAnalyzer)
         ghidra_resource: DecompilationAnalysis = await complex_block.resource.view_as(
             DecompilationAnalysis
         )

--- a/disassemblers/ofrak_ghidra/setup.py
+++ b/disassemblers/ofrak_ghidra/setup.py
@@ -31,7 +31,7 @@ def read_requirements(requirements_path):
 
 setuptools.setup(
     name="ofrak_ghidra",
-    version="0.2.0rc0",
+    version="0.2.0rc1",
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",
     description="OFRAK Ghidra Components",
@@ -42,7 +42,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    install_requires=read_requirements("requirements.txt"),
+    install_requires=["ofrak>=3.3.0rc10"] + read_requirements("requirements.txt"),
     extras_require={
         "test": [
             "fun-coverage==0.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ofrak-app",
-  "version": "3.3.0rc9",
+  "version": "3.3.0rc10",
   "description": "The graphical front-end for OFRAK.",
   "homepage": "https://ofrak.com",
   "private": true,

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -227,6 +227,6 @@ Answer by running riddle.answer('your answer here') from the console.`);
 
 <div class="bottomright">
   <p>
-    <a href="https://ofrak.com" target="_blank" rel="noreferrer">v3.3.0rc9</a>
+    <a href="https://ofrak.com" target="_blank" rel="noreferrer">v3.3.0rc10</a>
   </p>
 </div>

--- a/frontend/src/views/ContentView.svelte
+++ b/frontend/src/views/ContentView.svelte
@@ -70,8 +70,8 @@
       "ofrak.core.instruction.Instruction",
       "ofrak.core.data.DataWord",
     ].some((tag) => $selectedResource.has_tag(tag));
-    hasDecompView = ["ofrak.core.decompilation.DecompilationAnalysis"].some(
-      (tag) => $selectedResource.has_tag(tag)
+    hasDecompView = ["ofrak.core.complex_block.ComplexBlock"].some((tag) =>
+      $selectedResource.has_tag(tag)
     );
     if (hasTextView) {
       tabs.push(textTab);

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -3,14 +3,14 @@ All notable changes to `ofrak` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased: 3.3.0rc9](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased: 3.3.0rc10](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
 - Add license check command to prompt users about community or pro licenses. ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
 - Support `application/vnd.android.package-archive` mime type for APKs, which is returned by newer versions of libmagic ([#470](https://github.com/redballoonsecurity/ofrak/pull/470))
 - Add links to other resources and locations in comments with an autocomplete feature in the comment view. ([#447](https://github.com/redballoonsecurity/ofrak/pull/447)) 
 - Add modifier to add and remove sections using lief. ([#443](https://github.com/redballoonsecurity/ofrak/pull/443))
-- Add tabbed content views and a decompilation view to the OFRAK GUI. ([#436](https://github.com/redballoonsecurity/ofrak/pull/436/))
+- Add tabbed content views and a decompilation view to the OFRAK GUI. ([#436](https://github.com/redballoonsecurity/ofrak/pull/436/), [#600](https://github.com/redballoonsecurity/ofrak/pull/600))
 - Refactor HexView and related components to use mousewheel instead of scroll and compartmentalize all comonents to src/hex. ([#427](https://github.com/redballoonsecurity/ofrak/pull/427))
 - Add an improved ISO9660 packer that leverages `mkisofs` instead of PyCdLib. ([#393](https://github.com/redballoonsecurity/ofrak/pull/393))
 - Add UEFI binary unpacker. ([#399](https://github.com/redballoonsecurity/ofrak/pull/399))
@@ -20,7 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add support for running on Windows to the `Filesystem` component. ([#521](https://github.com/redballoonsecurity/ofrak/pull/521))
 - Add `JavaArchive` resource tag ([#492](https://github.com/redballoonsecurity/ofrak/pull/492))
 - Add new method for allocating `.bss` sections using free space ranges that aren't mapped to data ranges. ([#505](https://github.com/redballoonsecurity/ofrak/pull/505), [#569](https://github.com/redballoonsecurity/ofrak/pull/569))
-- Add `JavaArchive` resource tag ([#492](https://github.com/redballoonsecurity/ofrak/pull/492))
 - Pulled `Allocatable._align_range` out to standalone function `allocate_range_start` ([#575](https://github.com/redballoonsecurity/ofrak/pull/575))
 
 ### Fixed

--- a/ofrak_core/ofrak/core/decompilation.py
+++ b/ofrak_core/ofrak/core/decompilation.py
@@ -5,21 +5,12 @@ from ofrak.resource import Resource
 from ofrak.resource_view import ResourceView
 
 from ofrak.component.analyzer import Analyzer
-from ofrak.component.identifier import Identifier
 from ofrak.core.complex_block import ComplexBlock
 
 
 @dataclass
 class DecompilationAnalysis(ResourceView):
     decompilation: str
-
-
-class DecompilationAnalysisIdentifier(Identifier):
-    id = b"DecompilationAnalysisIdentifier"
-    targets = (ComplexBlock,)
-
-    async def identify(self, resource: Resource, config=None):
-        resource.add_tag(DecompilationAnalysis)
 
 
 class DecompilationAnalyzer(Analyzer[None, DecompilationAnalysis], ABC):

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -69,7 +69,7 @@ def read_requirements(requirements_path):
 
 setuptools.setup(
     name="ofrak",
-    version="3.3.0rc9",
+    version="3.3.0rc10",
     description="A binary analysis and modification platform",
     packages=setuptools.find_packages(exclude=["test_ofrak", "test_ofrak.*"]),
     package_data={


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Remove the `DecompilationIdentifier`.

**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
OFRAK identifiers are [expensive](https://github.com/redballoonsecurity/ofrak/pull/492). This changeset removes the `DecompilationAnalyzer`, and updates the frontend code to display the decompilation tab for any ComplexBlock.

This functionally is the same as it was before.

**Anyone you think should look at this, specifically?**
@dannyp303 and @rbs-jacob 