### PR TITLE
Handle escape character in json

### DIFF
--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Speedup: do not run Ghidra auto-analysis upon importing a program. ([#473](https://github.com/redballoonsecurity/ofrak/pull/473))
 - Ensure large 64-bit addresses are interpreted as unsigned. ([#474](https://github.com/redballoonsecurity/ofrak/pull/474))
 - Update `GhidraDecompilationAnalyzer` to match API in ofrak 0.3.0rc10 ([#600](https://github.com/redballoonsecurity/ofrak/pull/600))
+- Handle escape (\) character in the JSON going from Java (Ghidra) to Python ([#604](https://github.com/redballoonsecurity/ofrak/pull/604))
 
 ## 0.1.1 - 2024-02-15
 ### Added

--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to `ofrak-ghidra` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased 0.2.0rc1](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased 0.2.0rc2](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Changed
 - Minor update to OFRAK Community License, add OFRAK Pro License ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_decompilation_analyzer.py
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/components/ghidra_decompilation_analyzer.py
@@ -77,6 +77,7 @@ class GhidraDecompilationAnalyzer(DecompilationAnalyzer, OfrakGhidraMixin):
                     .replace("<cr>", "\r")
                     .replace("<tab>", "\t")
                     .replace("<zero>", "\\0")
+                    .replace("<escape>", "\\")
                 )
             else:
                 decomp = "No Decompilation available"

--- a/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/GetDecompilation.java
+++ b/disassemblers/ofrak_ghidra/ofrak_ghidra/ghidra_scripts/GetDecompilation.java
@@ -69,7 +69,8 @@ public class GetDecompilation extends HeadlessScript {
                                           .replace("\n", "<nl>")
                                           .replace("\0", "<zero>")
                                           .replace("\t", "<tab>")
-                                          .replace("\r", "<cr>");
+                                          .replace("\r", "<cr>")
+                                          .replace("\\", "<escape>");
             return String.format("{\"decomp\": \"%s\"}", escaped_decomp);
         }
     }

--- a/disassemblers/ofrak_ghidra/setup.py
+++ b/disassemblers/ofrak_ghidra/setup.py
@@ -31,7 +31,7 @@ def read_requirements(requirements_path):
 
 setuptools.setup(
     name="ofrak_ghidra",
-    version="0.2.0rc1",
+    version="0.2.0rc2",
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",
     description="OFRAK Ghidra Components",


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Handle escape (`\`) character in the JSON going from Java (Ghidra) to Python.

**Link to Related Issue(s)**

None

**Please describe the changes in your request.**

I noticed that when the decompilation output from Ghidra contained something like `printf("This is bob\'s key.")`, then the Python side would raise an exception: `json.decoder.JSONDecodeError: Invalid \escape: line ... column ... (char ...)` because of the `\` character. I added a case in the list of special chars we replace on both ends.

**Anyone you think should look at this, specifically?**

No