### PR TITLE
Bugfix: Angr backend when BasicBlock doesn't have exit address

### DIFF
--- a/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
+++ b/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py
@@ -287,4 +287,8 @@ def _get_bb_exit_addr_info(
         # For example: basic block ends in unconditional one-way branch (not a call)
         # If there are somehow multiple successors and the fallthrough block is not one of them,
         # choosing the first succ as the exit addr is arbitrary, but better choice is unclear.
-        return False, successor_vaddrs[0]
+        if len(successor_vaddrs) > 0:
+            return False, successor_vaddrs[0]
+        else:
+            return False, None
+

--- a/disassemblers/ofrak_angr/ofrak_angr_test/test_unpackers.py
+++ b/disassemblers/ofrak_angr/ofrak_angr_test/test_unpackers.py
@@ -1,7 +1,12 @@
 from typing import Dict
 import pytest
+import tempfile
+import requests
+import os
 
 from ofrak.core.basic_block import BasicBlock
+from ofrak.core.complex_block import ComplexBlock
+from ofrak.core.code_region import CodeRegion
 
 from pytest_ofrak.patterns.code_region_unpacker import (
     CodeRegionUnpackAndVerifyPattern,
@@ -10,7 +15,11 @@ from pytest_ofrak.patterns.complex_block_unpacker import (
     ComplexBlockUnpackerTestCase,
     ComplexBlockUnpackerUnpackAndVerifyPattern,
 )
-
+from ofrak import OFRAKContext
+from ofrak import ResourceFilter, ResourceAttributeValueFilter
+from ofrak.model.viewable_tag_model import AttributesType
+from ofrak.core.addressable import Addressable
+from ofrak.core.elf.model import ElfSection
 
 class TestAngrCodeRegionUnpackAndVerify(CodeRegionUnpackAndVerifyPattern):
     pass
@@ -123,3 +132,43 @@ class TestAngrComplexBlockUnpackAndVerify(ComplexBlockUnpackerUnpackAndVerifyPat
 
         expected_results[cb_addr][idx] = bb_1
         expected_results[cb_addr].append(bb_2)
+
+async def test_basic_block_no_exit(ofrak_context: OFRAKContext):
+    # Regression test for https://github.com/redballoonsecurity/ofrak/issues/614
+    # Test unpacking a ComplexBlock that contains a BasicBlock which doesn't have an exit address
+    with tempfile.TemporaryDirectory() as temp_dir:
+        response = requests.get("https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox")
+        response.raise_for_status()
+
+        file_path = os.path.join(temp_dir, "busybox")
+        with open(file_path, 'wb') as f:
+            f.write(response.content)
+
+        root_resource = await ofrak_context.create_root_resource_from_file(file_path)
+
+        await root_resource.unpack()
+
+        # For some reason, I couldn't get the code_region through its virtual address, so I got it manually:
+        code_regions = await root_resource.get_descendants_as_view(
+            v_type=CodeRegion, r_filter=ResourceFilter(tags=[CodeRegion])
+        )
+        text_section = None
+        for code_region in code_regions:
+            if code_region.virtual_address == 0x400130:
+                text_section = code_region
+
+        await text_section.resource.unpack()
+
+        complexblock_0x4d8768 = await text_section.resource.get_only_child(
+            r_filter=ResourceFilter(
+                tags={ComplexBlock},
+                attribute_filters=[
+                    ResourceAttributeValueFilter(
+                        attribute=AttributesType[Addressable].VirtualAddress, value=0x4d8768
+                    )
+                ],
+            )
+        )
+
+        await complexblock_0x4d8768.unpack()
+        # In the past, unpacking that ComplexBlock would fail because it contains a BasicBlock that doens't have an exit address


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

When using the Angr backend, there is an exception when unpacking a ComplexBlock that contains a BasicBlock which doesn't have an exit address. In [unpackers.py](https://github.com/redballoonsecurity/ofrak/blob/master/disassemblers/ofrak_angr/ofrak_angr/components/blocks/unpackers.py) in _get_bb_exit_addr_info, successor_vaddrs[0] is returned even if successor_vaddrs is empty. This PR fixes that.

**Link to Related Issue(s)**

https://github.com/redballoonsecurity/ofrak/issues/614

**Please describe the changes in your request.**

- bugfix in `_get_bb_exit_addr_info`: as `_get_bb_exit_addr_info` returns `Tuple[bool, Optional[int]]`, the address is optional. So when `successor_vaddrs` is empty, simply return None for the address.
- regression test with public busybox binary

**Anyone you think should look at this, specifically?**

No