### PR TITLE
Use slim docker image

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -9,9 +9,7 @@ import sys
 import pkg_resources
 import yaml
 
-DEFAULT_PYTHON_IMAGE = (
-    "python:3.9-bookworm@sha256:a23efa04a7f7a881151fe5d473770588ef639c08fd5f0dcc6987dbe13705c829"
-)
+DEFAULT_PYTHON_IMAGE = "python:3.9-slim-bookworm@sha256:ac457d45a4cafd54f0d72966592bdbbfa83e2ec3f5f95b28f6e68bbd490f8bc3"
 BASE_DOCKERFILE = "base.Dockerfile"
 FINISH_DOCKERFILE = "finish.Dockerfile"
 

--- a/frontend/Dockerstub
+++ b/frontend/Dockerstub
@@ -1,4 +1,4 @@
-RUN apt-get update && apt-get install --yes nginx
+RUN apt-get update && apt-get install --yes nginx && rm -rf /var/lib/apt/lists/*
 
 COPY --from=svelte --chown=root:root /home/node/frontend/dist /ofrak_gui
 

--- a/ofrak_core/Dockerstub
+++ b/ofrak_core/Dockerstub
@@ -1,5 +1,6 @@
 ARG TARGETARCH
 # - u-boot-tools: for mkimage, to test the UImage packer/unpacker
+# - zlib1g-dev, liblzma-dev: development headers needed for squashfs-tools compilation
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
       build-essential \
@@ -10,20 +11,25 @@ RUN apt-get -y update && \
       liblz4-dev \
       liblzo2-dev \
       libzstd-dev \
+      zlib1g-dev \
+      liblzma-dev \
       lzop \
       mtd-utils \
       pigz \
       zip \
       qemu-user-static \
+      wget \
       u-boot-tools \
       unar \
-      zstd
+      unzip \
+      zstd \
+    && rm -rf /var/lib/apt/lists/*
 
 # python-lzo needed by ubireader
 RUN python3 -m pip install python-lzo
 
 # Install apktool and uber-apk-signer
-RUN apt-get -y update && apt-get -y install openjdk-17-jdk
+RUN apt-get -y update && apt-get -y install openjdk-17-jdk && rm -rf /var/lib/apt/lists/*
 RUN wget https://raw.githubusercontent.com/iBotPeaches/Apktool/v2.3.3/scripts/linux/apktool -O /usr/local/bin/apktool && \
   wget https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.3.3.jar -O /usr/local/bin/apktool.jar && \
   wget https://github.com/patrickfav/uber-apk-signer/releases/download/v1.0.0/uber-apk-signer-1.0.0.jar -O /usr/local/bin/uber-apk-signer.jar && \

--- a/ofrak_patch_maker/Dockerstub
+++ b/ofrak_patch_maker/Dockerstub
@@ -1,5 +1,14 @@
 ARG TARGETARCH
 
+# Install all compression tools and dependencies needed for toolchain downloads
+RUN apt-get update && apt-get install -y \
+    xz-utils \
+    bzip2 \
+    lbzip2 \
+    unzip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /opt/rbs/toolchain
 
 COPY ${PACKAGE_PATH}/src/ofrak_patch_maker/config/docker/${TARGETARCH}_platform_toolchain.conf /etc/ofrak/toolchain.conf
@@ -12,7 +21,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     rm -rf clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \
     mv /opt/rbs/toolchain/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu- /opt/rbs/toolchain/llvm_12.0.1; \
 elif [ "$TARGETARCH" = "arm64" ]; then \
-    apt-get update && apt-get install -y libtinfo5 && \
+    apt-get update && apt-get install -y libtinfo5 && rm -rf /var/lib/apt/lists/* && \
     cd /tmp/ && \
     wget https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz --show-progress --progress=bar:force:noscroll && \
     tar xf clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz -C /opt/rbs/toolchain && \
@@ -48,7 +57,7 @@ fi;
 
 #M68k GNU 10 Linux
 RUN cd /tmp && \
-    apt-get update && apt-get install -y gcc g++ gperf bison flex texinfo help2man make libncurses5-dev python3-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip patch libstdc++6 rsync && \
+    apt-get update && apt-get install -y gcc g++ git gperf bison flex texinfo help2man make libncurses5-dev python3-dev autoconf automake libtool libtool-bin gawk patch libstdc++6 rsync && rm -rf /var/lib/apt/lists/* && \
     git clone https://github.com/crosstool-ng/crosstool-ng.git && \
     cd crosstool-ng/ && \
     git reset --hard 6d1d61cbcacc7ce4622ef024490e0cb56881614b && \


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Use `python:3.9-slim-bookworm` image.

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Update Dockerstubs to use base slim image (python:3.9-slim-bookworm) and install what tools are needed when they are needed.

**Anyone you think should look at this, specifically?**
