### PR TITLE
Update GUI to generate decompilation when tab is selected

### DIFF
--- a/frontend/src/views/DecompilationView.svelte
+++ b/frontend/src/views/DecompilationView.svelte
@@ -38,13 +38,13 @@
       return html;
     } else {
       decompilation = "Decompiling...";
-     await $selectedResource.analyze();
-     return hljs.highlight(
-       $selectedResource.attributes[
-         "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
-       ]["decompilation"],
-       { language: "c" },
-     ).value;
+      await $selectedResource.analyze();
+      return hljs.highlight(
+        $selectedResource.attributes[
+          "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
+        ]["decompilation"],
+        { language: "c" }
+      ).value;
     }
   }
 

--- a/frontend/src/views/DecompilationView.svelte
+++ b/frontend/src/views/DecompilationView.svelte
@@ -14,11 +14,17 @@
 <script>
   import hljs from "highlight.js";
   import c from "highlight.js/lib/languages/c";
-  import { selectedResource } from "../stores.js";
+  import {
+    selectedResource,
+    resourceNodeDataMap,
+    selected,
+    settings,
+  } from "../stores.js";
+
   let decompilation;
   hljs.registerLanguage("c", c);
 
-  function get_decompilation() {
+  async function get_decompilation() {
     if (
       "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]" in
       $selectedResource.attributes
@@ -27,15 +33,26 @@
         $selectedResource.attributes[
           "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
         ]["decompilation"],
-        { language: "c" }
+        { language: "c" },
       ).value;
       return html;
     } else {
-      return 'To see decompilation, click "Analyze" on the left toolbar';
+      decompilation = "Decompiling...";
+      return await $selectedResource.analyze().then(() => {
+        var html = hljs.highlight(
+          $selectedResource.attributes[
+            "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
+          ]["decompilation"],
+          { language: "c" },
+        ).value;
+        return html;
+      });
     }
   }
 
-  $: decompilation = get_decompilation($selectedResource);
+  $: (async () => {
+    decompilation = await get_decompilation($selectedResource);
+  })();
 </script>
 
 <link rel="stylesheet" href="./code.css" />

--- a/frontend/src/views/DecompilationView.svelte
+++ b/frontend/src/views/DecompilationView.svelte
@@ -33,7 +33,7 @@
         $selectedResource.attributes[
           "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
         ]["decompilation"],
-        { language: "c" },
+        { language: "c" }
       ).value;
       return html;
     } else {
@@ -43,7 +43,7 @@
           $selectedResource.attributes[
             "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
           ]["decompilation"],
-          { language: "c" },
+          { language: "c" }
         ).value;
         return html;
       });

--- a/frontend/src/views/DecompilationView.svelte
+++ b/frontend/src/views/DecompilationView.svelte
@@ -50,9 +50,9 @@
     }
   }
 
-  $: (async () => {
-    decompilation = await get_decompilation($selectedResource);
-  })();
+  $: get_decompilation($selectedResource).then((result) => {
+    decompilation = result;
+  });
 </script>
 
 <link rel="stylesheet" href="./code.css" />

--- a/frontend/src/views/DecompilationView.svelte
+++ b/frontend/src/views/DecompilationView.svelte
@@ -38,15 +38,13 @@
       return html;
     } else {
       decompilation = "Decompiling...";
-      return await $selectedResource.analyze().then(() => {
-        var html = hljs.highlight(
-          $selectedResource.attributes[
-            "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
-          ]["decompilation"],
-          { language: "c" }
-        ).value;
-        return html;
-      });
+     await $selectedResource.analyze();
+     return hljs.highlight(
+       $selectedResource.attributes[
+         "ofrak.model._auto_attributes.AttributesType[DecompilationAnalysis]"
+       ]["decompilation"],
+       { language: "c" },
+     ).value;
     }
   }
 

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to `ofrak` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased: 3.3.0rc15](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased: 3.3.0rc16](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
 - Add license check command to prompt users about community or pro licenses. ([#478](https://github.com/redballoonsecurity/ofrak/pull/478))
@@ -85,6 +85,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Update `DataSummary` handling so that it is no longer stored in `ResourceModel`, but rather retrievable via `DataSummaryAnalyzer.get_data_summary` ([#598](https://github.com/redballoonsecurity/ofrak/pull/598))
 - Update dependencies: aiohttp>=3.12.14, beartype~=0.20.0, ubi-reader==0.8.12 ([#613](https://github.com/redballoonsecurity/ofrak/pull/613))
 - Add `ofrak_pyghidra` to OFRAK GUI script builder ([#631](https://github.com/redballoonsecurity/ofrak/pull/631))
+- When the user selects the "Decompilation" tab in the GUI, the pane is updated with the decompiled code automatically, without having to click "Analyze" first. ([#639](https://github.com/redballoonsecurity/ofrak/pull/639))
 
 ### Deprecated
 - `Resource.flush_to_disk` deprecated in favor of `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373), [#567](https://github.com/redballoonsecurity/ofrak/pull/568))


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
When the user selects the "Decompilation" tab in the GUI, the pane is updated with the decompiled code automatically, without having to click "Analyze" first.

**Link to Related Issue(s)**
#636 
**Please describe the changes in your request.**
I updated the `DecompilationView` to analyze the selected resource if the `DecompilationAnalysis` is not yet available ([link](https://github.com/NicolaasWeideman/ofrak/blob/9b627060ac79682486851d7ddc6c02f96d0e3901/frontend/src/views/DecompilationView.svelte#L40)).

**Anyone you think should look at this, specifically?**
@rbs-jacob 
