### PR TITLE
Remove remaing sibling APIs from Resource

### DIFF
--- a/frontend/src/ofrak/resource.js
+++ b/frontend/src/ofrak/resource.js
@@ -317,22 +317,6 @@ export class Resource {
     throw new NotImplementedError("get_only_descendant");
   }
 
-  async get_siblings_as_view(v_type, r_filter, r_sort) {
-    throw new NotImplementedError("get_siblings_as_view");
-  }
-
-  async get_siblings(r_filter, r_sort) {
-    throw new NotImplementedError("get_siblings");
-  }
-
-  async get_only_sibling_as_view(v_type, r_filter) {
-    throw new NotImplementedError("get_only_sibling_as_view");
-  }
-
-  async get_only_sibling(r_filter) {
-    throw new NotImplementedError("get_only_sibling");
-  }
-
   async get_children_as_view(v_type, r_filter, r_sort) {
     throw new NotImplementedError("get_children_as_view");
   }

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -93,7 +93,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Resource.flush_to_disk` deprecated in favor of `Resource.flush_data_to_disk`. ([#373](https://github.com/redballoonsecurity/ofrak/pull/373), [#567](https://github.com/redballoonsecurity/ofrak/pull/568))
 
 ### Removed
-- Removed `Instruction.disassembly` from `Instruction` class: use `Instruction.get_assembly()` instead ([#539](https://github.com/redballoonsecurity/ofrak/issues/539))
+- Remove `Instruction.disassembly` from `Instruction` class: use `Instruction.get_assembly()` instead ([#539](https://github.com/redballoonsecurity/ofrak/issues/539))
+- Remove `Resource.get_only_sibling`, `Resource.get_only_sibling_as_view` API from Resource ([#641](https://github.com/redballoonsecurity/ofrak/pull/641))
 
 ### Security
 - Update aiohttp to 3.10.11 ([#522](https://github.com/redballoonsecurity/ofrak/pull/522))

--- a/ofrak_core/src/ofrak/core/elf/model.py
+++ b/ofrak_core/src/ofrak/core/elf/model.py
@@ -232,7 +232,8 @@ class ElfSegmentStructure(ResourceView):
         return self.segment_index
 
     async def get_header(self) -> "ElfProgramHeader":
-        return await self.resource.get_only_sibling_as_view(
+        parent = await self.resource.get_parent()
+        return await parent.get_only_child_as_view(
             ElfProgramHeader,
             ResourceFilter(
                 tags=(ElfProgramHeader,),
@@ -333,7 +334,8 @@ class ElfSectionStructure(ResourceView):
         return await self.resource.get_parent_as_view(Elf)
 
     async def get_header(self) -> "ElfSectionHeader":
-        return await self.resource.get_only_sibling_as_view(
+        parent = await self.resource.get_parent()
+        return await parent.get_only_child_as_view(
             ElfSectionHeader,
             ResourceFilter(
                 tags=(ElfSectionHeader,),

--- a/ofrak_core/src/ofrak/core/pe/model.py
+++ b/ofrak_core/src/ofrak/core/pe/model.py
@@ -154,7 +154,8 @@ class PeSection(PeSectionStructure, NamedProgramSection):
     """PE section"""
 
     async def get_header(self) -> "PeSectionHeader":
-        return await self.resource.get_only_sibling_as_view(
+        parent = await self.resource.get_parent()
+        return await parent.get_only_child_as_view(
             PeSectionHeader,
             ResourceFilter(
                 tags=(PeSectionHeader,),
@@ -242,7 +243,8 @@ class PeSectionHeader(PeSectionStructure):
 
     async def get_body(self) -> PeSection:
         """Get the PeSection associated with this section header."""
-        return await self.resource.get_only_sibling_as_view(
+        parent = await self.resource.get_parent()
+        return await parent.get_only_child_as_view(
             PeSection,
             ResourceFilter(
                 tags=(PeSection,),

--- a/ofrak_core/src/ofrak/resource.py
+++ b/ofrak_core/src/ofrak/resource.py
@@ -1294,60 +1294,6 @@ class Resource:
             )
         return await self._create_resource(models[0])
 
-    async def get_only_sibling_as_view(
-        self,
-        v_type: Type[RV],
-        r_filter: ResourceFilter = None,
-    ) -> RV:
-        """
-        If a filter is provided, get the only sibling of this resource which matches the given
-        filter. If a filter is not provided, gets the only sibling of this resource. The sibling
-        will be returned as an instance of the given
-        [viewable tag][ofrak.model.viewable_tag_model.ViewableResourceTag].
-        :param v_type: The type of [view][ofrak.resource] to get the sibling as
-        :param r_filter: Contains parameters which resources must match to be returned, including
-        any tags it must have and/or values of indexable attributes
-        :return:
-
-        :raises NotFoundError: If a filter is provided and more or fewer than one sibling matches
-        ``r_filter``
-        :raises NotFoundError: If a filter is not provided and this resource has multiple siblings
-        """
-        sibling_r = await self.get_only_sibling(r_filter)
-        return await sibling_r.view_as(v_type)
-
-    async def get_only_sibling(self, r_filter: ResourceFilter = None) -> "Resource":
-        """
-        If a filter is provided, get the only sibling of this resource which matches the given
-        filter. If a filter is not provided, gets the only sibling of this resource.
-
-        :param r_filter: Contains parameters which resources must match to be returned, including
-        any tags it must have and/or values of indexable attributes
-        :return:
-
-        :raises NotFoundError: If a filter is provided and more or fewer than one sibling matches
-        ``r_filter``
-        :raises NotFoundError: If a filter is not provided and this resource has multiple siblings
-        """
-        models = list(
-            await self._resource_service.get_siblings_by_id(
-                self._resource.id,
-                max_count=2,
-                r_filter=r_filter,
-            )
-        )
-        if len(models) == 0:
-            raise NotFoundError(
-                f"There is no sibling for resource {self._resource.id.hex()} matching "
-                f"the provided filter"
-            )
-        if len(models) > 1:
-            raise MultipleResourcesFoundError(
-                f"There are multiple siblings for resource {self._resource.id.hex()} "
-                f"matching the provided filter"
-            )
-        return await self._create_resource(models[0])
-
     async def get_children(
         self,
         r_filter: ResourceFilter = None,

--- a/ofrak_core/src/ofrak/service/resource_service.py
+++ b/ofrak_core/src/ofrak/service/resource_service.py
@@ -875,25 +875,6 @@ class ResourceService(ResourceServiceInterface):
             resources = itertools.islice(resources, 0, max_count)
         return resources
 
-    async def get_siblings_by_id(
-        self,
-        resource_id: bytes,
-        max_count: int = -1,
-        r_filter: Optional[ResourceFilter] = None,
-        r_sort: Optional[ResourceSort] = None,
-    ) -> Iterable[ResourceModel]:
-        resource_node = self._resource_store.get(resource_id)
-        if resource_node is None:
-            raise NotFoundError(f"The resource {resource_id.hex()} does not exist")
-        if resource_node.parent is None:
-            raise NotFoundError(
-                f"The resource {resource_id.hex()} does not have siblings as it is a root "
-                f"resource."
-            )
-        return await self.get_descendants_by_id(
-            resource_node.parent.model.id, max_count, 1, r_filter, r_sort
-        )
-
     async def update(self, resource_diff: ResourceModelDiff) -> ResourceModel:
         return self._update(resource_diff)
 

--- a/ofrak_core/src/ofrak/service/resource_service_i.py
+++ b/ofrak_core/src/ofrak/service/resource_service_i.py
@@ -237,40 +237,6 @@ class ResourceServiceInterface(AbstractOfrakService, metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    async def get_siblings_by_id(
-        self,
-        resource_id: bytes,
-        max_count: int = -1,
-        r_filter: Optional[ResourceFilter] = None,
-        r_sort: Optional[ResourceSort] = None,
-    ) -> Iterable[ResourceModel]:
-        """
-        Get the resource models of the siblings of a resource with a given ID. These siblings
-        may be filtered by an optional filter argument. A maximum count of siblings may also be
-        given, to cap the number of (filtered or unfiltered) siblings returned.
-
-        :param resource_id: ID of resource to get siblings of
-        :param max_count: Optional argument to cap the number of models returned; if set to -1
-        (default) then any number of siblings may be returned
-        :param r_filter: Optional resource filter for the resource models returned; if set to
-        None all siblings may be returned (the model for `resource_id` is excluded),
-        otherwise all siblings matching the filter may be returned (possibly including the model
-        for `resource_id`), up to the maximum allowed by `max_count`
-        :param r_sort: Optional logic to order the returned siblings by the value of a
-        specific attribute of each sibling
-
-        :raises NotFoundError: If there is not a resource with resource ID `resource_id`
-        :raises NotFoundError: If the resource with ID `resource_id` does not have siblings
-        because it is a root
-
-
-        :return: As many siblings of `resource_id` matching `r_filter` as `max_count`
-        allows, in order specified by `r_sort`. If `r_sort` is None, no specific ordering is
-        guaranteed.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
     async def update(self, resource_diff: ResourceModelDiff) -> ResourceModel:
         """
         Modify a stored resource model according to the differences in the given diff object.

--- a/ofrak_core/src/version.py
+++ b/ofrak_core/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.3.0rc17"
+VERSION = "3.3.0rc18"
 
 if __name__ == "__main__":
     print(VERSION)

--- a/ofrak_core/tests/service/resource_service/test_resource_service.py
+++ b/ofrak_core/tests/service/resource_service/test_resource_service.py
@@ -645,12 +645,6 @@ class TestResourceService:
         )
         test_case.check_results(results)
 
-    @pytest.mark.skip
-    async def test_get_siblings_by_id(self, resource_service):
-        # TODO: Implement test
-        # Not done with the others because it is a special case of get_descendants_by_id
-        pass
-
     async def test_update(self, populated_resource_service: ResourceServiceInterface):
         # Update nonexistant resource
         with pytest.raises(NotFoundError):


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Remove `Resource.get_only_sibling`, `Resource.get_only_sibling_as_view` from Resource API

**Link to Related Issue(s)**
N/A.

**Please describe the changes in your request.**
See above.

**Anyone you think should look at this, specifically?**
@rbs-jacob 