### PR TITLE
Bugfix/cpio libarchive

### DIFF
--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -10,6 +10,7 @@ importlib-metadata>=4.13
 intervaltree==3.1.0
 keystone-engine==0.9.2
 jefferson==0.4.5;python_version>="3.8"
+libarchive-c>=4.0.0
 lief==0.16.1
 orjson==3.10.16
 pefile==2023.2.7

--- a/ofrak_core/src/ofrak/core/cpio.py
+++ b/ofrak_core/src/ofrak/core/cpio.py
@@ -1,30 +1,54 @@
 import asyncio
 import logging
-import tempfile312 as tempfile
+import os
+import stat
 from dataclasses import dataclass
 from enum import Enum
-from subprocess import CalledProcessError
 
 from ofrak.component.analyzer import Analyzer
 from ofrak.component.packer import Packer
 from ofrak.component.unpacker import Unpacker
 from ofrak.core.binary import GenericBinary
-from ofrak.core.filesystem import File, Folder, FilesystemRoot, SpecialFileType
+from ofrak.core.filesystem import (
+    File,
+    Folder,
+    FilesystemRoot,
+    SpecialFileType,
+    SymbolicLink,
+    CharacterDevice,
+    BlockDevice,
+    FIFOPipe,
+)
 from ofrak.core.magic import MagicMimePattern, MagicDescriptionPattern, Magic
 from ofrak.model.component_model import ComponentExternalTool
 from ofrak.resource import Resource
+from ofrak.service.resource_service_i import ResourceFilter
 from ofrak_type.range import Range
+from ofrak.core.filesystem import FilesystemEntry
+
+try:
+    import libarchive
+    LIBARCHIVE_INSTALLED = True
+except OSError:
+    LIBARCHIVE_INSTALLED = False
+
+class LibarchiveTool(ComponentExternalTool):
+    def __init__(self):
+        super().__init__(
+            "libarchive",
+            "https://www.libarchive.org/",
+            install_check_arg="",
+            apt_package="libarchive-dev",
+            brew_package="libarchive",
+            choco_package="libarchive",
+        )
+
+    async def is_tool_installed(self) -> bool:
+        return LIBARCHIVE_INSTALLED
+
+LIBARCHIVE_TOOL: LibarchiveTool = LibarchiveTool()
 
 LOGGER = logging.getLogger(__name__)
-
-CPIO_TOOL = ComponentExternalTool(
-    "cpio",
-    "https://www.gnu.org/software/cpio/",
-    install_check_arg="--help",
-    apt_package="cpio",
-    brew_package="cpio",
-    choco_package="cpio",
-)
 
 
 class CpioArchiveType(Enum):
@@ -76,79 +100,213 @@ class CpioFilesystemAnalyzer(Analyzer[None, CpioFilesystem]):
         return CpioFilesystem(archive_type)
 
 
+def _libarchive_entry_to_stat_result(entry) -> os.stat_result:
+    import ipdb; ipdb.set_trace()
+    return os.stat_result((
+        entry.mode,           # st_mode (complete mode: file type + permission bits)
+        0,                    # st_ino (not preserved in CPIO)
+        0,                    # st_dev (not preserved)
+        1,                    # st_nlink (default, it looks like we can't get this from libarchive)
+        entry.uid,            # st_uid
+        entry.gid,            # st_gid
+        entry.size,           # st_size
+        int(entry.atime) if entry.atime else 0,     # st_atime
+        int(entry.mtime) if entry.mtime else 0,     # st_mtime
+        int(entry.ctime) if entry.ctime else 0,     # st_ctime
+    ))
+
+
 class CpioUnpacker(Unpacker[None]):
     """
-    Unpack a CPIO archive.
+    Unpack a CPIO archive using libarchive.
     """
 
     targets = (CpioFilesystem,)
     children = (File, Folder, SpecialFileType)
-    external_dependencies = (CPIO_TOOL,)
+    external_dependencies = (LIBARCHIVE_TOOL,)
 
     async def unpack(self, resource: Resource, config=None):
         cpio_v = await resource.view_as(CpioFilesystem)
         resource_data = await cpio_v.resource.get_data()
-        with tempfile.TemporaryDirectory() as temp_flush_dir:
-            cmd = [
-                "cpio",
-                "-id",
-            ]
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=temp_flush_dir,
-            )
-            await proc.communicate(input=resource_data)
-            if proc.returncode:
-                raise CalledProcessError(returncode=proc.returncode, cmd=cmd)
-            await cpio_v.initialize_from_disk(temp_flush_dir)
+
+        with libarchive.memory_reader(resource_data) as archive:
+            for entry in archive:
+                if entry.pathname in (".", "./"):
+                    continue
+
+                # remove leading ./
+                path = entry.pathname.lstrip("./")
+                if not path:
+                    continue
+
+                entry_stat = _libarchive_entry_to_stat_result(entry)
+
+                xattrs = {}
+                if hasattr(entry, 'xattr'):
+                    for xattr_name in entry.xattr.keys():
+                        xattrs[xattr_name] = entry.xattr.get(xattr_name)
+
+                filetype = entry.filetype
+
+                if stat.S_ISREG(filetype):
+                    data = b''.join(entry.get_blocks())
+                    await cpio_v.add_file(path, data, entry_stat, xattrs or None)
+                elif stat.S_ISDIR(filetype):
+                    await cpio_v.add_folder(path, entry_stat, xattrs or None)
+                elif stat.S_ISLNK(filetype):
+                    linkpath = entry.linkpath or ""
+                    symlink = SymbolicLink(
+                        name=path,
+                        stat=entry_stat,
+                        xattrs=xattrs or None,
+                        source_path=linkpath
+                    )
+                    await cpio_v.add_special_file_entry(path, symlink)
+                elif stat.S_ISCHR(filetype):
+                    chardev = CharacterDevice(
+                        name=path,
+                        stat=entry_stat,
+                        xattrs=xattrs or None
+                    )
+                    await cpio_v.add_special_file_entry(path, chardev)
+                elif stat.S_ISBLK(filetype):
+                    blockdev = BlockDevice(
+                        name=path,
+                        stat=entry_stat,
+                        xattrs=xattrs or None
+                    )
+                    await cpio_v.add_special_file_entry(path, blockdev)
+                elif stat.S_ISFIFO(filetype):
+                    fifo = FIFOPipe(
+                        name=path,
+                        stat=entry_stat,
+                        xattrs=xattrs or None
+                    )
+                    await cpio_v.add_special_file_entry(path, fifo)
+                else:
+                    raise NotImplementedError(f"Unsupported file type: {oct(filetype)}")
+
+
+def _ofrak_tags_to_filetype(resource) -> int:
+    if resource.has_tag(File):
+        return stat.S_IFREG
+    elif resource.has_tag(Folder):
+        return stat.S_IFDIR
+    elif resource.has_tag(SymbolicLink):
+        return stat.S_IFLNK
+    elif resource.has_tag(CharacterDevice):
+        return stat.S_IFCHR
+    elif resource.has_tag(BlockDevice):
+        return stat.S_IFBLK
+    elif resource.has_tag(FIFOPipe):
+        return stat.S_IFIFO
+    else:
+        raise ValueError("Unknown file type")
+
+
+def _get_libarchive_format(archive_type: CpioArchiveType) -> str:
+    """
+    Note: libarchive supports reading many CPIO variants but only supports
+    writing a subset. We map to the closest supported write format.
+    Available write formats: 'cpio' (generic), 'cpio_newc' (SVR4 newc)
+    """
+    format_map = {
+        CpioArchiveType.NEW_ASCII: "cpio_newc",
+        CpioArchiveType.OLD_ASCII: "cpio",
+        CpioArchiveType.CRC_ASCII: "cpio_newc",
+        CpioArchiveType.BINARY: "cpio",
+        CpioArchiveType.TAR: "cpio",
+        CpioArchiveType.USTAR: "ustar",
+        CpioArchiveType.HPBIN: "cpio",
+        CpioArchiveType.HPODC: "cpio",
+    }
+    return format_map.get(archive_type, "cpio_newc")
 
 
 class CpioPacker(Packer[None]):
     """
-    Pack files into a CPIO archive.
+    Pack files into a CPIO archive using libarchive.
     """
 
     targets = (CpioFilesystem,)
-    external_dependencies = (CPIO_TOOL,)
+    external_dependencies = (LIBARCHIVE_TOOL,)
 
     async def pack(self, resource: Resource, config=None):
         cpio_v: CpioFilesystem = await resource.view_as(CpioFilesystem)
-        temp_flush_dir = await cpio_v.flush_to_disk()
-        cpio_format = cpio_v.archive_type.value
-        list_files_cmd = [
-            "find",
-            "-print",
-        ]
-        list_files_proc = await asyncio.create_subprocess_exec(
-            *list_files_cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=temp_flush_dir,
-        )
-        list_files_list, stderr = await list_files_proc.communicate()
-        if list_files_proc.returncode:
-            raise CalledProcessError(returncode=list_files_proc.returncode, cmd=list_files_cmd)
 
-        cpio_pack_cmd = [
-            "cpio",
-            "-o",
-            f"--format={cpio_format}",
-        ]
-        cpio_pack_proc = await asyncio.create_subprocess_exec(
-            *cpio_pack_cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=temp_flush_dir,
+        format_str = _get_libarchive_format(cpio_v.archive_type)
+
+        entries = await resource.get_descendants(
+            r_filter=ResourceFilter(tags=(FilesystemEntry,))
         )
-        cpio_pack_output, stderr = await cpio_pack_proc.communicate(input=list_files_list)
-        if cpio_pack_proc.returncode:
-            raise CalledProcessError(returncode=cpio_pack_proc.returncode, cmd=cpio_pack_cmd)
-        # Passing in the original range effectively replaces the original data with the new data
-        resource.queue_patch(Range(0, await resource.get_data_length()), cpio_pack_output)
+
+        # Sort entries by path (parents before children)
+        entry_list = []
+        for entry_resource in entries:
+            entry = await entry_resource.view_as(FilesystemEntry)
+            path = await entry.get_path()
+            entry_list.append((path, entry, entry_resource))
+
+        entry_list.sort(key=lambda x: x[0])
+
+        # custom_writer calls our write_func with chunks of data
+        packed_chunks = []
+
+        def write_func(data):
+            packed_chunks.append(bytes(data))
+            return len(data)
+
+        with libarchive.custom_writer(write_func, format_str) as archive:
+            for path, entry, entry_resource in entry_list:
+                entry_stat = entry.stat
+                if not entry_stat:
+                    # Create default stat if missing
+                    entry_stat = os.stat_result((0o644, 0, 0, 1, 0, 0, 0, 0, 0, 0))
+
+                xattrs = entry.xattrs or {}
+
+                filetype = _ofrak_tags_to_filetype(entry_resource)
+
+                linkpath = None
+                is_symlink = entry_resource.has_tag(SymbolicLink)
+                if is_symlink:
+                    symlink_view = await entry_resource.view_as(SymbolicLink)
+                    linkpath = symlink_view.source_path
+
+                # Get data only for regular files (not symlinks, directories, or special files)
+                data = b''
+                entry_size = 0
+                if entry_resource.has_tag(File) and not is_symlink:
+                    data = await entry_resource.get_data()
+                    entry_size = len(data)
+                elif is_symlink and linkpath:
+                    # For symlinks, the size is the length of the link target path
+                    entry_size = len(linkpath)
+
+                # Extract permission bits including setuid/setgid/sticky (not file type bits)
+                permission_bits = entry_stat.st_mode & 0o7777
+
+                # Build parameters dict - include linkpath for symlinks
+                add_params = {
+                    'entry_path': path,
+                    'entry_size': entry_size,
+                    'entry_data': data,
+                    'filetype': filetype,
+                    'permission': permission_bits,
+                    'uid': entry_stat.st_uid,
+                    'gid': entry_stat.st_gid,
+                    'atime': entry_stat.st_atime,
+                    'mtime': entry_stat.st_mtime,
+                    'ctime': entry_stat.st_ctime,
+                }
+                if linkpath is not None:
+                    add_params['linkpath'] = linkpath
+
+                archive.add_file_from_memory(**add_params)
+
+        # Combine all chunks into final bytes
+        packed_bytes = b''.join(packed_chunks)
+        resource.queue_patch(Range(0, await resource.get_data_length()), packed_bytes)
 
 
 MagicMimePattern.register(CpioFilesystem, "application/x-cpio")

--- a/ofrak_core/src/ofrak/core/cpio.py
+++ b/ofrak_core/src/ofrak/core/cpio.py
@@ -101,7 +101,6 @@ class CpioFilesystemAnalyzer(Analyzer[None, CpioFilesystem]):
 
 
 def _libarchive_entry_to_stat_result(entry) -> os.stat_result:
-    import ipdb; ipdb.set_trace()
     return os.stat_result((
         entry.mode,           # st_mode (complete mode: file type + permission bits)
         0,                    # st_ino (not preserved in CPIO)

--- a/ofrak_core/tests/components/assets/tinycore.cpio
+++ b/ofrak_core/tests/components/assets/tinycore.cpio
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b078e8c4490c4529780cce7dd4a72f877da98526fe999aff4f615451f61fc01
+size 19231232


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Reimplement the CPIO components using `libarchive`.

**Link to Related Issue(s)**

Addresses https://github.com/redballoonsecurity/ofrak/issues/616

**Please describe the changes in your request.**

Updated the CPIO components to use `libarchive` instead of the `cpio` command. The advantage is that unpacking is done in memory, files aren't actually created on disk. This fixes the 2 issues documented in https://github.com/redballoonsecurity/ofrak/issues/616. I added regression tests for the 2 aforementioned issues, plus a full unpack-pack-unpack test to make sure all metadata is preserved.

**Anyone you think should look at this, specifically?**

No