### PR TITLE
Address potential path injection issues in OFRAK server

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - `build_image.py` uses `OFRAK_DIR` from `extra_build_args` to identify `pytest_ofrak` location for develop builds ([#657](https://github.com/redballoonsecurity/ofrak/pull/657/))
 
+### Security
+- Adding path validation and sanitization using `werkzeug.secure_filename` and path normalization to OFRAK Server ([#664](https://github.com/redballoonsecurity/ofrak/pull/664))
+
 ## [3.3.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.2.0...ofrak-v3.3.0) - 2025-10-03
 
 ### Added

--- a/ofrak_core/requirements.txt
+++ b/ofrak_core/requirements.txt
@@ -22,4 +22,5 @@ synthol~=0.1.1
 tempfile312~=1.0.1
 typeguard~=2.13.3
 ubi-reader==0.8.12
+werkzeug==3.1.3
 xattr==0.10.1;platform_system!="Windows"

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -96,6 +96,7 @@ setuptools.setup(
         "tempfile312~=1.0.1",
         "typeguard~=2.13.3",
         "ubi-reader>=0.8.12",
+        "werkzeug>=3.0.0",
         "xattr>=0.10.1;platform_system!='Windows'",
     ],
     author="Red Balloon Security",

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,1 +1,1 @@
-VERSION = "3.4.0rc1"
+VERSION = "3.4.0rc2"


### PR DESCRIPTION
- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Adding path validation and sanitization using werkzeug.secure_filename and path normalization to OFRAK server.

**Link to Related Issue(s)**
Resolves 6 CodeQL path injection alerts from GitHub Code Scanning:
  - https://github.com/redballoonsecurity/ofrak/security/code-scanning/57 - Path injection in clone_project_from_git at line 1240
  - https://github.com/redballoonsecurity/ofrak/security/code-scanning/58 - Path injection in set_projects_path at line 1322
  - https://github.com/redballoonsecurity/ofrak/security/code-scanning/59 - Path injection in set_projects_path at line 1323
  - https://github.com/redballoonsecurity/ofrak/security/code-scanning/60 - Path injection in _slurp_projects_from_dir at line 1389
  - https://github.com/redballoonsecurity/ofrak/security/code-scanning/61 - Path injection in _slurp_projects_from_dir at line 1390
  - https://github.com/redballoonsecurity/ofrak/security/code-scanning/62 - Path injection in _slurp_projects_from_dir at line 1391
**Please describe the changes in your request.**

Implementation:
- Add `validate_safe_directory_path` to validate that user-provided paths are within base directory
- Add `sanitize_repo_name` to extract and sanitize provided Git URLs
- Update OFRAK Server's `clone_project_from_git`, `set_projects_path`, `_slurp_projects_from_dir` to use these methods

Testing:
 - Added 14 unit tests to test_ofrak_server.py to test functional correctness of these methods

**Anyone you think should look at this, specifically?**
