### PR TITLE
Add a PyGhidraCustomLoadAnalyzer

### DIFF
--- a/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
+++ b/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from typing import List, Optional
 from dataclasses import dataclass
 
@@ -31,6 +32,8 @@ from ofrak.resource import Resource
 from ofrak.component.unpacker import Unpacker
 from ofrak.core.program import Program
 from ofrak_type.architecture import InstructionSetMode
+
+LOGGER = logging.getLogger(__name__)
 
 _GHIDRA_AUTO_LOADABLE_FORMATS = [Elf, Ihex, Pe]
 
@@ -249,7 +252,10 @@ class CachedCodeRegionUnpacker(CodeRegionUnpacker):
                 size=complex_block["size"],
                 name=complex_block["name"],
             )
-            await code_region_view.create_child_region(cb)
+            if cb.virtual_address > code_region_view.virtual_address and cb.EndVaddr < code_region_view.EndVaddr:
+                await code_region_view.create_child_region(cb)
+            else:
+                LOGGER.warning(f"{cb} not in {code_region_view}, skip creating it.")
 
 
 class CachedComplexBlockUnpacker(ComplexBlockUnpacker):

--- a/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
+++ b/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
@@ -1,5 +1,4 @@
 import hashlib
-import logging
 from typing import List, Optional
 from dataclasses import dataclass
 
@@ -32,8 +31,6 @@ from ofrak.resource import Resource
 from ofrak.component.unpacker import Unpacker
 from ofrak.core.program import Program
 from ofrak_type.architecture import InstructionSetMode
-
-LOGGER = logging.getLogger(__name__)
 
 _GHIDRA_AUTO_LOADABLE_FORMATS = [Elf, Ihex, Pe]
 
@@ -252,13 +249,7 @@ class CachedCodeRegionUnpacker(CodeRegionUnpacker):
                 size=complex_block["size"],
                 name=complex_block["name"],
             )
-            if (
-                cb.virtual_address >= code_region_view.virtual_address
-                and cb.EndVaddr <= code_region_view.EndVaddr
-            ):
-                await code_region_view.create_child_region(cb)
-            else:
-                LOGGER.warning(f"{cb} not in {code_region_view}, skip creating it.")
+            await code_region_view.create_child_region(cb)
 
 
 class CachedComplexBlockUnpacker(ComplexBlockUnpacker):

--- a/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
+++ b/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
@@ -253,8 +253,8 @@ class CachedCodeRegionUnpacker(CodeRegionUnpacker):
                 name=complex_block["name"],
             )
             if (
-                cb.virtual_address > code_region_view.virtual_address
-                and cb.EndVaddr < code_region_view.EndVaddr
+                cb.virtual_address >= code_region_view.virtual_address
+                and cb.EndVaddr <= code_region_view.EndVaddr
             ):
                 await code_region_view.create_child_region(cb)
             else:

--- a/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
+++ b/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
@@ -252,7 +252,10 @@ class CachedCodeRegionUnpacker(CodeRegionUnpacker):
                 size=complex_block["size"],
                 name=complex_block["name"],
             )
-            if cb.virtual_address > code_region_view.virtual_address and cb.EndVaddr < code_region_view.EndVaddr:
+            if (
+                cb.virtual_address > code_region_view.virtual_address
+                and cb.EndVaddr < code_region_view.EndVaddr
+            ):
                 await code_region_view.create_child_region(cb)
             else:
                 LOGGER.warning(f"{cb} not in {code_region_view}, skip creating it.")

--- a/disassemblers/ofrak_pyghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_pyghidra/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased 0.2.0rc4](https://github.com/redballoonsecurity/ofrak/tree/master)
 
+### Added
+- Add a PyGhidra custom load analyzer to allow for loading programs with a custom layout ([#677](https://github.com/redballoonsecurity/ofrak/pull/677))
+
 ### Fixed
 - Fix Ghidra and pyghidra CodeRegion unpacker to take into account the base address that ghidra sets for PIE executables.([#627](https://github.com/redballoonsecurity/ofrak/pull/627))
 - Fix auto discovery of `PyGhidraDecompilationAnalyzer` ([#650](https://github.com/redballoonsecurity/ofrak/pull/650))

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
@@ -201,12 +201,12 @@ class PyGhidraCustomLoadAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
         self.analysis_store = analysis_store
 
     async def analyze(self, resource: Resource, config: PyGhidraCustomLoadAnalyzerConfig):
-        try:
-            program_attrs = resource.get_attributes(ProgramAttributes)
-            language = _arch_info_to_processor_id(program_attrs)
-        except NotFoundError:
-            language = None
         if config is None:
+            try:
+                program_attrs = resource.get_attributes(ProgramAttributes)
+                language = _arch_info_to_processor_id(program_attrs)
+            except NotFoundError:
+                language = None
             decomp = False
         else:
             decomp = config.decomp

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
@@ -98,7 +98,7 @@ class CachedGhidraCodeRegionModifier(CachedGhidraCodeRegionModifier):
 
 
 @dataclass
-class PyGhidraAutoAnalyzerConfig(ComponentConfig):
+class PyGhidraAnalyzerConfig(ComponentConfig):
     decomp: bool
     language: str
 
@@ -129,7 +129,7 @@ class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraAutoLoadProject]):
         super().__init__(resource_factory, data_service, resource_service)
         self.analysis_store = analysis_store
 
-    async def analyze(self, resource: Resource, config: PyGhidraAutoAnalyzerConfig = None):
+    async def analyze(self, resource: Resource, config: PyGhidraAnalyzerConfig = None):
         tempdir = mkdtemp(prefix="rbs-pyghidra-bin")
         await resource.identify()  # useful for checking tags later
         try:
@@ -170,12 +170,6 @@ class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraAutoLoadProject]):
         return PyGhidraAutoLoadProject()
 
 
-@dataclass
-class PyGhidraCustomLoadAnalyzerConfig(ComponentConfig):
-    decomp: bool
-    language: str
-
-
 class PyGhidraCustomLoadAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
     """
     Runs Ghidra's automated analysis on binaries with custom memory region setup. This analyzer
@@ -200,7 +194,7 @@ class PyGhidraCustomLoadAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
         super().__init__(resource_factory, data_service, resource_service)
         self.analysis_store = analysis_store
 
-    async def analyze(self, resource: Resource, config: PyGhidraCustomLoadAnalyzerConfig):
+    async def analyze(self, resource: Resource, config: PyGhidraAnalyzerConfig):
         if config is None:
             try:
                 program_attrs = resource.get_attributes(ProgramAttributes)
@@ -255,14 +249,25 @@ class PyGhidraCodeRegionUnpacker(CachedCodeRegionUnpacker):
         program_r = await resource.get_only_ancestor(ResourceFilter.with_tags(PyGhidraProject))
         if not self.analysis_store.id_exists(program_r.get_id()):
             if config is not None:
-                await program_r.run(
-                    PyGhidraAutoAnalyzer,
-                    config=PyGhidraAutoAnalyzerConfig(
-                        decomp=config.decomp, language=config.language
-                    ),
+                analyzer_config = PyGhidraAnalyzerConfig(
+                    decomp=config.decomp, language=config.language
                 )
             else:
-                await program_r.run(PyGhidraAutoAnalyzer)
+                analyzer_config = None
+            if program_r.has_tag(PyGhidraAutoLoadProject):
+                await program_r.run(
+                    PyGhidraAutoAnalyzer,
+                    config=analyzer_config,
+                )
+            elif program_r.has_tag(PyGhidraCustomLoadProject):
+                await program_r.run(
+                    PyGhidraCustomLoadAnalyzer,
+                    config=analyzer_config,
+                )
+            else:
+                raise ValueError(
+                    f"resource {resource} does not have any tag that allow analysis with the PyGhidra backend."
+                )
         return await super().unpack(resource, config)
 
 

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
@@ -174,12 +174,12 @@ class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraAutoLoadProject]):
 
 
 @dataclass
-class PyGhidraCustomAutoAnalyzerConfig(ComponentConfig):
+class PyGhidraCustomLoadAnalyzerConfig(ComponentConfig):
     decomp: bool
     language: str
 
 
-class PyGhidraCustomAutoAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
+class PyGhidraCustomLoadAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
     """
     Runs Ghidra's automated analysis on binaries with custom memory region setup. This analyzer
     explicitly creates all memory regions from the OFRAK Program's MemoryRegion children in Ghidra
@@ -188,7 +188,7 @@ class PyGhidraCustomAutoAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
     created and analyzed, which is critical for firmware with multiple discontinuous memory segments.
     """
 
-    id = b"PyGhidraCustomAutoAnalyzer"
+    id = b"PyGhidraCustomLoadAnalyzer"
 
     targets = (PyGhidraCustomLoadProject,)
     outputs = (PyGhidraCustomLoadProject,)
@@ -203,7 +203,7 @@ class PyGhidraCustomAutoAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
         super().__init__(resource_factory, data_service, resource_service)
         self.analysis_store = analysis_store
 
-    async def analyze(self, resource: Resource, config: PyGhidraCustomAutoAnalyzerConfig):
+    async def analyze(self, resource: Resource, config: PyGhidraCustomLoadAnalyzerConfig):
         try:
             program_attrs = resource.get_attributes(ProgramAttributes)
             language = _arch_info_to_processor_id(program_attrs)

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
@@ -39,20 +39,45 @@ _GHIDRA_AUTO_LOADABLE_FORMATS = [Elf, Ihex, Pe]
 
 @dataclass
 class PyGhidraProject(CachedAnalysis):
+    """
+    A resource which may be loaded into PyGhidra and analyzed.
+    """
+    pass
+
+
+@dataclass
+class PyGhidraAutoLoadProject(PyGhidraProject):
+    """
+    A resource which PyGhidra can automatically load with one of its existing Loaders (e.g. ELF).
+    """
+    pass
+
+
+@dataclass
+class PyGhidraCustomLoadProject(PyGhidraProject):
+    """
+    A resource which PyGhidra does not have an existing loader for and cannot load automatically.
+    Before analysis, we need to inform PyGhidra of correct processor and segments.
+    """
     pass
 
 
 class PyGhidraAnalysisIdentifier(Identifier):
     """
-    Component to identify resources to analyze with Ghidra. If this component is discovered,
-    it will tag all [Program][ofrak.core.program.Program]s as GhidraProjects
+    Tags Program resources for PyGhidra analysis. Auto-loadable formats (ELF, PE, Ihex) get PyGhidraAutoLoadProject tag,
+    others get PyGhidraCustomLoadProject. Enables PyGhidra-based components to run on the resource.
     """
 
-    id = b"GhidraAnalysisIdentifier"
-    targets = (Program, Ihex)
+    id = b"PyGhidraAnalysisIdentifier"
+    targets = (Program,)
 
     async def identify(self, resource: Resource, config=None):
-        resource.add_tag(PyGhidraProject)
+        for tag in _GHIDRA_AUTO_LOADABLE_FORMATS:
+            if resource.has_tag(tag):
+                resource.add_tag(PyGhidraAutoLoadProject)
+                return
+
+        resource.add_tag(PyGhidraCustomLoadProject)
 
 
 @dataclass
@@ -81,7 +106,7 @@ class PyGhidraAutoAnalyzerConfig(ComponentConfig):
     language: str
 
 
-class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraProject]):
+class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraAutoLoadProject]):
     """
     Runs Ghidra's comprehensive automated analysis on binaries including disassembly, function
     boundary detection, control flow analysis, data type propagation, symbol discovery,
@@ -94,8 +119,8 @@ class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraProject]):
 
     id = b"PyGhidraAutoAnalyzer"
 
-    targets = (PyGhidraProject,)
-    outputs = (PyGhidraProject,)
+    targets = (PyGhidraAutoLoadProject,)
+    outputs = (PyGhidraAutoLoadProject,)
 
     def __init__(
         self,
@@ -127,7 +152,7 @@ class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraProject]):
                 self.analysis_store.store_analysis(
                     resource.get_id(), unpack(program_file, decomp, language)
                 )
-                return PyGhidraProject()
+                return PyGhidraAutoLoadProject()
 
         program_attrs = resource.get_attributes(ProgramAttributes)
         # Guess that the base address is the min start address of any memory region
@@ -145,7 +170,75 @@ class PyGhidraAutoAnalyzer(Analyzer[None, PyGhidraProject]):
                 base_address=base_address,
             ),
         )
-        return PyGhidraProject()
+        return PyGhidraAutoLoadProject()
+
+
+@dataclass
+class PyGhidraCustomAutoAnalyzerConfig(ComponentConfig):
+    decomp: bool
+    language: str
+
+
+class PyGhidraCustomAutoAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
+    """
+    Runs Ghidra's automated analysis on binaries with custom memory region setup. This analyzer
+    explicitly creates all memory regions from the OFRAK Program's MemoryRegion children in Ghidra
+    before running analysis. Use when analyzing raw firmware or binaries with non-standard memory
+    layouts that Ghidra doesn't automatically detect. This ensures all memory regions are properly
+    created and analyzed, which is critical for firmware with multiple discontinuous memory segments.
+    """
+
+    id = b"PyGhidraCustomAutoAnalyzer"
+
+    targets = (PyGhidraCustomLoadProject,)
+    outputs = (PyGhidraCustomLoadProject,)
+
+    def __init__(
+        self,
+        resource_factory: ResourceFactory,
+        data_service: DataServiceInterface,
+        resource_service: ResourceServiceInterface,
+        analysis_store: PyGhidraAnalysisStore,
+    ):
+        super().__init__(resource_factory, data_service, resource_service)
+        self.analysis_store = analysis_store
+
+    async def analyze(self, resource: Resource, config: PyGhidraCustomAutoAnalyzerConfig):
+        try:
+            program_attrs = resource.get_attributes(ProgramAttributes)
+            language = _arch_info_to_processor_id(program_attrs)
+        except NotFoundError:
+            language = None
+        if config is None:
+            decomp = False
+        else:
+            decomp = config.decomp
+            language = config.language
+
+        # Prepare memory regions data
+        regions = await resource.get_children_as_view(
+            MemoryRegion, r_filter=ResourceFilter.with_tags(MemoryRegion)
+        )
+
+        memory_regions = []
+        for region in regions:
+            region_data = await region.resource.get_data()
+            memory_regions.append({
+                'virtual_address': region.virtual_address,
+                'size': region.size,
+                'data': region_data
+            })
+
+        self.analysis_store.store_analysis(
+            resource.get_id(),
+            unpack(
+                None,
+                decomp,
+                language=language,
+                memory_regions=memory_regions
+            )
+        )
+        return PyGhidraCustomLoadProject()
 
 
 @dataclass

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/components/pyghidra_components.py
@@ -42,7 +42,6 @@ class PyGhidraProject(CachedAnalysis):
     """
     A resource which may be loaded into PyGhidra and analyzed.
     """
-    pass
 
 
 @dataclass
@@ -50,7 +49,6 @@ class PyGhidraAutoLoadProject(PyGhidraProject):
     """
     A resource which PyGhidra can automatically load with one of its existing Loaders (e.g. ELF).
     """
-    pass
 
 
 @dataclass
@@ -59,7 +57,6 @@ class PyGhidraCustomLoadProject(PyGhidraProject):
     A resource which PyGhidra does not have an existing loader for and cannot load automatically.
     Before analysis, we need to inform PyGhidra of correct processor and segments.
     """
-    pass
 
 
 class PyGhidraAnalysisIdentifier(Identifier):
@@ -223,20 +220,17 @@ class PyGhidraCustomLoadAnalyzer(Analyzer[None, PyGhidraCustomLoadProject]):
         memory_regions = []
         for region in regions:
             region_data = await region.resource.get_data()
-            memory_regions.append({
-                'virtual_address': region.virtual_address,
-                'size': region.size,
-                'data': region_data
-            })
+            memory_regions.append(
+                {
+                    "virtual_address": region.virtual_address,
+                    "size": region.size,
+                    "data": region_data,
+                }
+            )
 
         self.analysis_store.store_analysis(
             resource.get_id(),
-            unpack(
-                None,
-                decomp,
-                language=language,
-                memory_regions=memory_regions
-            )
+            unpack(None, decomp, language=language, memory_regions=memory_regions),
         )
         return PyGhidraCustomLoadProject()
 

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
@@ -41,7 +41,7 @@ def unpack(program_file, decompiled, language=None, base_address=None, memory_re
             from java.io import ByteArrayInputStream
 
             # If memory_regions are provided, delete all data and create new regions:
-            if memory_regions and len(memory_regions) > 0:
+            if memory_regions:
                 program = flat_api.getCurrentProgram()
                 memory = program.getMemory()
                 address_factory = program.getAddressFactory()

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
@@ -7,6 +7,7 @@ import argparse
 import time
 import re
 import json
+from tempfile312 import mkdtemp
 
 
 class PyGhidraComponentException(Exception):
@@ -20,8 +21,16 @@ def _parse_offset(java_object):
     return int(str(java_object.getOffsetAsBigInteger()))
 
 
-def unpack(program_file, decompiled, language=None, base_address=None):
+def unpack(program_file, decompiled, language=None, base_address=None, memory_regions=None):
     try:
+        if not program_file and memory_regions and len(memory_regions) > 0:
+            # In the case the user passed memory regions and no program_file,
+            # we still have to pass a file to pyghidra.open_program, so create a dummy one
+            # Data is populated later from the memory regions data.
+            tempdir = mkdtemp(prefix="rbs-pyghidra-bin")
+            program_file = os.path.join(tempdir, "program")
+            with open(program_file, 'wb') as f:
+                f.write(b"\x00")
         with pyghidra.open_program(program_file, language=language) as flat_api:
             # Java packages must be imported after pyghidra.start or pyghidra.open_program
             from ghidra.app.decompiler import DecompInterface, DecompileOptions
@@ -29,7 +38,45 @@ def unpack(program_file, decompiled, language=None, base_address=None):
             from ghidra.program.model.block import BasicBlockModel
             from ghidra.program.model.symbol import RefType
             from java.math import BigInteger
+            from java.io import ByteArrayInputStream
 
+            # If memory_regions are provided, delete all data and create new regions:
+            if memory_regions and len(memory_regions) > 0:
+                program = flat_api.getCurrentProgram()
+                memory = program.getMemory()
+                address_factory = program.getAddressFactory()
+                default_space = address_factory.getDefaultAddressSpace()
+
+                for block in memory.getBlocks():
+                    memory.removeBlock(block, TaskMonitor.DUMMY)
+
+                for region in memory_regions:
+                    addr = default_space.getAddress(region['virtual_address'])
+                    data_bytes = region['data']
+                    block_name = f"region_{region['virtual_address']:x}"
+
+                    try:
+                        # Convert Python bytes to Java InputStream
+                        input_stream = ByteArrayInputStream(data_bytes)
+
+                        memory.createInitializedBlock(
+                            block_name,
+                            addr,
+                            input_stream,
+                            len(data_bytes),
+                            TaskMonitor.DUMMY,
+                            False  # overlay
+                        )
+
+                        # Mark as executable
+                        block = memory.getBlock(addr)
+                        block.setExecute(True)
+                        block.setRead(True)
+                    except Exception as e:
+                        logging.warning(f"Failed to create memory block at 0x{region['virtual_address']:x}: {e}")
+                # Analyze all
+                analysis_mgr = program.getOptions("Analyzers")
+                flat_api.analyzeAll(program)
             # If base_address is provided, rebase the program
             if base_address is not None:
                 # Convert base_address to int if it's a string

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
@@ -1,5 +1,5 @@
 import logging
-
+import os
 import hashlib
 import traceback
 import pyghidra

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
@@ -29,7 +29,7 @@ def unpack(program_file, decompiled, language=None, base_address=None, memory_re
             # Data is populated later from the memory regions data.
             tempdir = mkdtemp(prefix="rbs-pyghidra-bin")
             program_file = os.path.join(tempdir, "program")
-            with open(program_file, 'wb') as f:
+            with open(program_file, "wb") as f:
                 f.write(b"\x00")
         with pyghidra.open_program(program_file, language=language) as flat_api:
             # Java packages must be imported after pyghidra.start or pyghidra.open_program
@@ -51,8 +51,8 @@ def unpack(program_file, decompiled, language=None, base_address=None, memory_re
                     memory.removeBlock(block, TaskMonitor.DUMMY)
 
                 for region in memory_regions:
-                    addr = default_space.getAddress(region['virtual_address'])
-                    data_bytes = region['data']
+                    addr = default_space.getAddress(region["virtual_address"])
+                    data_bytes = region["data"]
                     block_name = f"region_{region['virtual_address']:x}"
 
                     try:
@@ -65,7 +65,7 @@ def unpack(program_file, decompiled, language=None, base_address=None, memory_re
                             input_stream,
                             len(data_bytes),
                             TaskMonitor.DUMMY,
-                            False  # overlay
+                            False,  # overlay
                         )
 
                         # Mark as executable
@@ -73,7 +73,9 @@ def unpack(program_file, decompiled, language=None, base_address=None, memory_re
                         block.setExecute(True)
                         block.setRead(True)
                     except Exception as e:
-                        logging.warning(f"Failed to create memory block at 0x{region['virtual_address']:x}: {e}")
+                        logging.warning(
+                            f"Failed to create memory block at 0x{region['virtual_address']:x}: {e}"
+                        )
                 # Analyze all
                 analysis_mgr = program.getOptions("Analyzers")
                 flat_api.analyzeAll(program)

--- a/disassemblers/ofrak_pyghidra/tests/assets/tini_custom_binary
+++ b/disassemblers/ofrak_pyghidra/tests/assets/tini_custom_binary
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52bdc70d5df05914ddea37357d432b0f0b1f6a6254dd2254e27650a1bc5c813f
+size 52504

--- a/docs/user-guide/disassembler-backends/pyghidra.md
+++ b/docs/user-guide/disassembler-backends/pyghidra.md
@@ -131,6 +131,10 @@ To save a cache to a JSON file:
 #### Loading cached analysis
 To load an analysis JSON file, see the [`Cached Disassembly Backend`](./cached_disassembly.md).
 
+## Troubleshooting
+
+In some cases (not sure what produced this), the PyGhidra backend can get stuck and hang whenever `pyghidra.open_program(...)` is called. In such cases, moving the `/home/<username>/.config/ghidra` directory to a backup location (in case you have anything important in there) has proven to be a good way to bring the PyGhidra backend back to a good state.
+
 <div align="right">
 <img src="../../assets/square_05.png" width="125" height="125">
 </div>


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add a PyGhidraCustomLoadAnalyzer to allow loading of custom binary formats in PyGhidra, from MemoryRegions. 

**Link to Related Issue(s)**

None.

**Please describe the changes in your request.**

With the Ghidra backend we had the `GhidraCustomLoadAnalyzer`, so this is a port to the PyGhidra backend:

- introduce `PyGhidraAutoLoadProject` which corresponds to the former `PyGhidraProject`. Introduce `PyGhidraCustomLoadProject` for binaries that are not in the `_GHIDRA_AUTO_LOADABLE_FORMATS` list.
- `PyGhidraAnalysisIdentifier` now checks the `_GHIDRA_AUTO_LOADABLE_FORMATS` list to add the `PyGhidraAutoLoadProject` or `PyGhidraCustomLoadProject` tag depending on the resource.
- introduce `PyGhidraCustomLoadAnalyzer` which gets the list of MemoryRegions in a program (created by a custom unpacker for example) and passes that to the PyGhidra backend.
- modified the `unpack` method in `pyghidra_analysis.py`: when provided with a list of `memory_regions`, it deletes all data in the program, then creates regions according to the list that was passed.

Another minor thing I fixed is in `CachedCodeRegionUnpacker`, with some binaries, I found that the PyGhidra backend tried to create a few ComplexBlocks outside of the CodeRegion. Instead of raising an alert I turned that into a warning to allow users to continue working with the PyGhidra backend.
[edit] I reverted my changes in the `CachedCodeRegionUnpacker`. It turned out I had a bug in the PyGhidra components: when running the `PyGhidraCodeRegionUnpacker` before any PyGhidra analysis, it was always running the `PyGhidraAutoAnalyzer` even if the `Program` resource did not have the `PyGhidraAutoLoadProject` tag. That resulted in loading the full file in Ghidra (not using the `PyGhidraCustomLoadAnalyzer`) so the region in PyGhidra was larger than the code region in OFRAK, producing `ComplexBlocks` outside of the `CodeRegion`. Now that I fixed the `PyGhidraCodeRegionUnpacker`, it's all good!

Also added a troubleshooting section to the PyGhidra documentation.

**Anyone you think should look at this, specifically?**

No.