### PR TITLE
Put pyghidra after cached disasm in make develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ develop: develop-core
 	-$(MAKE) -C disassemblers/ofrak_angr develop
 	-$(MAKE) -C disassemblers/ofrak_capstone develop
 	-$(MAKE) -C disassemblers/ofrak_ghidra develop
-	-$(MAKE) -C disassemblers/ofrak_pyghidra develop
 	-$(MAKE) -C disassemblers/ofrak_cached_disassembly develop
+	-$(MAKE) -C disassemblers/ofrak_pyghidra develop
 	-$(MAKE) -C frontend develop
 	-$(MAKE) -C ofrak_tutorial develop
 	@echo "Development installation complete!"


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

Fix the OFRAK `make develop` package order so that PyGhidra is installed after its dependency `ofrak_cached_disassembly`. 