### PR TITLE
FastSegmentInjectorModifier

### DIFF
--- a/disassemblers/ofrak_ghidra/tests/test_ghidra_program_analyzer.py
+++ b/disassemblers/ofrak_ghidra/tests/test_ghidra_program_analyzer.py
@@ -211,5 +211,5 @@ async def _make_dummy_program(resource: Resource, arch_info):
 
     await resource.run(
         SegmentInjectorModifier,
-        SegmentInjectorModifierConfig.from_fem(fem),
+        SegmentInjectorModifierConfig.from_fems([fem]),
     )

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
+- Add FastSegmentInjectorModifier for optimized bulk segment injection ([#685](https://github.com/redballoonsecurity/ofrak/pull/685))
 - Add Android sparse image unpacker and packer ([#662](https://github.com/redballoonsecurity/ofrak/pull/662))
 - Add OFRAK requirements, requirement to test mapping, test specifications ([#656](https://github.com/redballoonsecurity/ofrak/pull/656))
 - Add `-V, --version` flag to ofrak cli ([#652](https://github.com/redballoonsecurity/ofrak/pull/652))

--- a/ofrak_core/src/ofrak/core/patch_maker/modifiers.py
+++ b/ofrak_core/src/ofrak/core/patch_maker/modifiers.py
@@ -3,7 +3,7 @@ import logging
 import os
 import tempfile312 as tempfile
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Dict, Iterable, List, Optional, Tuple, Type, Union, cast
 
 from ofrak_patch_maker.model import PatchRegionConfig, FEM
 from ofrak_patch_maker.patch_maker import PatchMaker
@@ -210,6 +210,18 @@ class SegmentInjectorModifierConfig(ComponentConfig):
                 segment_data = exe_data[segment.offset : segment.offset + segment.length]
 
             extracted_segments.append((segment, segment_data))
+        return SegmentInjectorModifierConfig(tuple(extracted_segments))
+
+    @staticmethod
+    def from_fems(fems: Iterable[FEM]) -> "SegmentInjectorModifierConfig":
+        """
+        Automatically build a config from a list of FEMs by extracting each segment's bytes and metadata.
+        """
+        extracted_segments: List[Tuple[Segment, bytes]] = []
+        for fem in fems:
+            extracted_segments.extend(
+                list(SegmentInjectorModifierConfig.from_fem(fem).segments_and_data)
+            )
         return SegmentInjectorModifierConfig(tuple(extracted_segments))
 
 

--- a/ofrak_core/tests/components/test_patch_maker_component.py
+++ b/ofrak_core/tests/components/test_patch_maker_component.py
@@ -42,6 +42,7 @@ from ofrak.core.patch_maker.modifiers import (
     FastSegmentInjectorModifier,
     SourceBundle,
 )
+from ofrak_patch_maker.model import FEM, LinkedExecutable
 from ofrak_patch_maker.toolchain.model import (
     CompilerOptimizationLevel,
     BinFileType,
@@ -358,3 +359,50 @@ async def test_fast_segment_injector_applies_patches(ofrak_context: OFRAKContext
     )
 
     await root_resource.run(FastSegmentInjectorModifier, cfg)
+
+
+def test_segment_injector_modifier_config_from_fems(tmp_path):
+    """
+    Tests that SegmentInjectorModifierConfig.from_fems correctly merges segment data extracted
+    from multiple FEMs into a single config (REQ6.1).
+    """
+    exe_a_path = tmp_path / "exec_a"
+    exe_a_data = b"AAAABBBB"
+    exe_a_path.write_bytes(exe_a_data)
+
+    exe_b_path = tmp_path / "exec_b"
+    exe_b_data = b"CCCCDDDDEEEE"
+    exe_b_path.write_bytes(exe_b_data)
+
+    segment_a = Segment(".text", 0x1000, 0, False, 4, MemoryPermissions.RX)
+    segment_b_text = Segment(".text", 0x2000, 0, False, 4, MemoryPermissions.RX)
+    segment_b_data = Segment(".data", 0x3000, 4, False, 8, MemoryPermissions.RW)
+
+    fem_a = FEM(
+        name="patch_a",
+        executable=LinkedExecutable(
+            path=str(exe_a_path),
+            file_format=BinFileType.ELF,
+            segments=(segment_a,),
+            symbols={},
+            relocatable=False,
+        ),
+    )
+    fem_b = FEM(
+        name="patch_b",
+        executable=LinkedExecutable(
+            path=str(exe_b_path),
+            file_format=BinFileType.ELF,
+            segments=(segment_b_text, segment_b_data),
+            symbols={},
+            relocatable=False,
+        ),
+    )
+
+    cfg = SegmentInjectorModifierConfig.from_fems([fem_a, fem_b])
+
+    assert cfg.segments_and_data == (
+        (segment_a, b"AAAA"),
+        (segment_b_text, b"CCCC"),
+        (segment_b_data, b"DDDDEEEE"),
+    )

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,1 +1,1 @@
-VERSION = "3.4.0rc7"
+VERSION = "3.4.0rc8"

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,1 +1,1 @@
-VERSION = "3.4.0rc5"
+VERSION = "3.4.0rc6"


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add FastSegmentInjectorModifier for optimized bulk segment injection

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
This PR adds `FastSegmentInjectorModifier`, a performance-optimized alternative to `SegmentInjectorModifier`. Instead of running `BinaryInjectorModifier` separately for each segment, it collects all segment patches and applies them in a single bulk operation. This modifier does NOT delete stale descendant resources after patching. The resource tree may be inconsistent after use. Use when performance is critical and resource tree consistency can be sacrificed.

**Anyone you think should look at this, specifically?**
@whyitfor 
