### PR TITLE
Use wget instead of curl for downloading the Binary Ninja install script

### DIFF
--- a/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh
+++ b/disassemblers/ofrak_binary_ninja/install_binary_ninja_headless_linux.sh
@@ -9,7 +9,7 @@ PACKAGE_NAME="binaryninja-headless.zip"
 INSTALL_DIR=/opt/rbs
 mkdir -p $INSTALL_DIR
 cd $INSTALL_DIR
-curl -O https://raw.githubusercontent.com/Vector35/binaryninja-api/dev/scripts/download_headless.py
+wget https://raw.githubusercontent.com/Vector35/binaryninja-api/dev/scripts/download_headless.py
 python3 -m pip --no-input install requests
 python3 download_headless.py --serial $SERIAL --output "$PACKAGE_NAME"
 unzip "$PACKAGE_NAME"


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

FIx an install script download failure in the default docker environment

**Link to Related Issue(s)**

Fixes #686

**Please describe the changes in your request.**

Use wget (installed by Dockerfile.base) instead of curl (missing) for downloading the Binary Ninja install script

**Anyone you think should look at this, specifically?**

@whyitfor 
