### PR TITLE
Add pyghidra to `ofrak-dev.yml`; make it the default backend

### DIFF
--- a/ofrak-dev.yml
+++ b/ofrak-dev.yml
@@ -7,10 +7,12 @@ packages_paths:
     "ofrak_io",
     "ofrak_patch_maker",
     "ofrak_core",
-    "disassemblers/ofrak_ghidra",
-    "disassemblers/ofrak_binary_ninja",
     "disassemblers/ofrak_capstone",
     "disassemblers/ofrak_angr",
+    "disassemblers/ofrak_ghidra",
+    "disassemblers/ofrak_cached_disassembly",
+    "disassemblers/ofrak_pyghidra",
+    "disassemblers/ofrak_binary_ninja",
     "frontend",
   ]
 extra_build_args:
@@ -21,5 +23,4 @@ extra_build_args:
   ]
 entrypoint: |
     nginx \
-      & python3 -m ofrak_ghidra.server start \
-      & python3 -m ofrak gui -H 0.0.0.0 -p 8877 --backend ghidra
+      & python3 -m ofrak gui -H 0.0.0.0 -p 8877 --backend pyghidra


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add pyghidra to `ofrak-dev.yml`; make it the default backend

That said, not sure which CHANGELOG.md, if any, this belongs to.

**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

The`ofrak-dev.yml` used to be the "include everything" configuration, but when `ofrak_pygidra` was created, it was not added to `ofrak-dev.yml`. This change restores the `ofrak-dev.yml` as the "everything" configuration, it also makes it slightly more similar to `ofrak-ghidra.yml` (order of packages, use of pyghidra as default backend) for consistency and to improve docker caching across different configurations 

**Anyone you think should look at this, specifically?**

@whyitfor 