### PR TITLE
Remove duplicate test dependencies already in `requirements-dev.txt`

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add LZ4 compression format unpackers and packers with support for all frame types (modern, legacy, skippable) ([#661](https://github.com/redballoonsecurity/ofrak/pull/661))
 - Add missing component docstrings and improve existing docstrings ([#654](https://github.com/redballoonsecurity/ofrak/pull/654))
 
+### Changed
+- Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))
+
 ### Fixed
 - Fix `Resource.get_attributes` docstring to match implementation ([#692](https://github.com/redballoonsecurity/ofrak/pull/692))
 - Fix GUI serialization of enum values and script creator generating invalid Python syntax for enum values

--- a/ofrak_core/requirements-test.txt
+++ b/ofrak_core/requirements-test.txt
@@ -1,3 +1,2 @@
 filelock==3.19.1
-psutil~=5.9
 pyelftools==0.29

--- a/ofrak_tutorial/CHANGELOG.md
+++ b/ofrak_tutorial/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `ofrak-tutorial` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased: 0.1.1](https://github.com/redballoonsecurity/ofrak/tree/master)
+### Changed
+- Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))
+
 ### Fixed
 - Update Notebook 3 output to make testing on different configurations easier ([#593](https://github.com/redballoonsecurity/ofrak/pull/593))
 

--- a/ofrak_tutorial/requirements-test.txt
+++ b/ofrak_tutorial/requirements-test.txt
@@ -1,4 +1,1 @@
-fun-coverage==0.2.0
 nbval~=0.9.6
-pytest~=7.1.1
-black[jupyter]


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [X] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Remove duplicate test dependencies already in `requirements-dev.txt`

**Link to Related Issue(s)**

N/A. Implements @whyitfor suggestion from https://github.com/redballoonsecurity/ofrak/pull/688#discussion_r2754748987

**Please describe the changes in your request.**

- ofrak_tutorial: Remove fun-coverage, pytest, black[jupyter] (keep nbval)
- ofrak_core: Remove psutil

These packages are already specified in the global requirements-dev.txt, so having them in package-specific requirements-test.txt files causes version conflicts and is redundant.

**Anyone you think should look at this, specifically?**

@whyitfor 