### PR TITLE
Document `CodeRegion` requirement to be descendant of `Program`

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 - Fix `Resource.get_attributes` docstring to match implementation ([#692](https://github.com/redballoonsecurity/ofrak/pull/692))
+- Document `CodeRegion` requirement to be descendant of `Program` for disassembly ([#696](https://github.com/redballoonsecurity/ofrak/pull/696))
 - Fix GUI serialization of enum values and script creator generating invalid Python syntax for enum values
 - `build_image.py` uses `OFRAK_DIR` from `extra_build_args` to identify `pytest_ofrak` location for develop builds ([#657](https://github.com/redballoonsecurity/ofrak/pull/657/))
 

--- a/ofrak_core/src/ofrak/core/code_region.py
+++ b/ofrak_core/src/ofrak/core/code_region.py
@@ -9,6 +9,9 @@ from ofrak.resource import Resource
 class CodeRegion(MemoryRegion):
     """
     A memory region within a [program][ofrak.core.program.Program] that contains executable code.
+
+    Must be a descendant of a Program for disassembly, as disassembler backends use the ancestor
+    Program to locate their analysis context.
     """
 
 


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [X] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Document `CodeRegion` requirement to be descendant of `Program` for disassembly

**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

Document `CodeRegion` requirement to be descendant of `Program` for disassembly

**Anyone you think should look at this, specifically?**

@whyitfor 