### PR TITLE
Use `$(PYTHON) -m` for running mypy

### DIFF
--- a/disassemblers/ofrak_angr/Makefile
+++ b/disassemblers/ofrak_angr/Makefile
@@ -10,7 +10,7 @@ develop:
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect

--- a/disassemblers/ofrak_binary_ninja/Makefile
+++ b/disassemblers/ofrak_binary_ninja/Makefile
@@ -10,7 +10,7 @@ develop:
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect

--- a/disassemblers/ofrak_capstone/Makefile
+++ b/disassemblers/ofrak_capstone/Makefile
@@ -10,7 +10,7 @@ develop:
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect

--- a/ofrak_core/Makefile
+++ b/ofrak_core/Makefile
@@ -11,7 +11,7 @@ develop: src/ofrak/gui/public
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect

--- a/ofrak_io/Makefile
+++ b/ofrak_io/Makefile
@@ -10,7 +10,7 @@ develop:
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect

--- a/ofrak_patch_maker/Makefile
+++ b/ofrak_patch_maker/Makefile
@@ -11,7 +11,7 @@ develop:
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect

--- a/ofrak_tutorial/Makefile
+++ b/ofrak_tutorial/Makefile
@@ -38,7 +38,7 @@ install:
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect

--- a/ofrak_type/Makefile
+++ b/ofrak_type/Makefile
@@ -10,7 +10,7 @@ develop:
 
 .PHONY: inspect
 inspect:
-	mypy
+	$(PYTHON) -m mypy
 
 .PHONY: test
 test: inspect


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Use `$(PYTHON) -m` for running mypy
(but not sure whether it needs to be in a changelog)

**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

Currently, our `Makefile`s call `mypy` directly for `make inspect`. This may cause issues, particularly when within a venv created with `--system-site-packages`. This commit replaces it with `$(PYTHON) -m mypy` that 
1. Should be slightly more robust/consistent. 
2. Would allow `make PYTHON=specific_python_version_and_or_path inspect`

**Anyone you think should look at this, specifically?**
