### PR TITLE
Skip tests requiring root privileges when running as non-root user

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 - Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))
+- Skip tests requiring root privileges when running as non-root user ([#704](https://github.com/redballoonsecurity/ofrak/pull/704))
 
 ### Fixed
 - Fix `Resource.get_attributes` docstring to match implementation ([#692](https://github.com/redballoonsecurity/ofrak/pull/692))

--- a/ofrak_core/tests/components/test_tar_component.py
+++ b/ofrak_core/tests/components/test_tar_component.py
@@ -234,6 +234,9 @@ class TestTarNestedUnpackModifyPack(UnpackModifyPackPattern):
                 assert self.EXPECTED_DATA == f.read()
 
 
+@pytest.mark.skipif(
+    os.geteuid() != 0, reason="Extracting device nodes from testtar.tar requires root"
+)
 class TestComplexTarWithSpecialFiles(FilesystemPackUnpackVerifyPattern):
     """
     Test unpacking and repacking a tar archive containing special file types.

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,1 +1,1 @@
-VERSION = "3.4.0rc5"
+VERSION = "3.4.0rc6"


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [X] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Skip tests requiring root privileges when running as non-root user

**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

Skip tests requiring root privileges when running as non-root user; specifically:

- Skip TestComplexTarWithSpecialFiles (device nodes require root)
- Handle testtar.tar unpack failure in CLI test fixture

With this change, `make test` in `ofrak_core` passes cleanly when invoked by a non-root user

**Anyone you think should look at this, specifically?**

@whyitfor 