### PR TITLE
Use `tmp_path` for ELF test output artifacts instead of source tree

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))
 
 ### Fixed
+- Fix ELF modifier tests writing generated artifacts into source tree instead of tmp_path ([#705](https://github.com/redballoonsecurity/ofrak/pull/705))
 - Fix `Resource.get_attributes` docstring to match implementation ([#692](https://github.com/redballoonsecurity/ofrak/pull/692))
 - Fix GUI serialization of enum values and script creator generating invalid Python syntax for enum values
 - `build_image.py` uses `OFRAK_DIR` from `extra_build_args` to identify `pytest_ofrak` location for develop builds ([#657](https://github.com/redballoonsecurity/ofrak/pull/657/))

--- a/ofrak_core/tests/components/test_patch_from_source.py
+++ b/ofrak_core/tests/components/test_patch_from_source.py
@@ -50,6 +50,7 @@ async def test_patch_from_source_modifier(
     ofrak_context: OFRAKContext,
     large_elf_file,
     patch_file,
+    tmp_path,
 ) -> None:
     """
     Tests the patch from source modifier functionality (REQ6.2).
@@ -152,9 +153,9 @@ async def test_patch_from_source_modifier(
     resource = await ofrak_context.create_root_resource_from_file(large_elf_file)
     new_segment = await add_and_return_segment(resource, 0x440000, 0x2000)
 
-    output_file_name = os.path.join(os.path.dirname(patch_file), "test_patch")
+    output_file_name = str(tmp_path / "test_patch")
 
-    source_dir = os.path.join(os.path.dirname(patch_file))
+    source_dir = os.path.dirname(patch_file)
 
     await apply_patch(resource, source_dir, new_segment)
     await call_new_segment_instead(resource, new_segment)

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,1 +1,1 @@
-VERSION = "3.4.0rc5"
+VERSION = "3.4.0rc6"


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [X] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Use `tmp_path` for ELF test output artifacts instead of source tree

**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

The current test implementation uses `tmp_path` for some generated artifacts, but not for all - and those in-tree generated artifacts are not even gitignored, resulting in bogus `git status` pollution. This makes sure `tmp_path` is consistently used

**Anyone you think should look at this, specifically?**

@whyitfor 