### PR TITLE
Remove `pkg_resources` usage broken by setuptools 82.0.0 - fix CI failures

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -6,7 +6,6 @@ import argparse
 import os
 import subprocess
 import sys
-import pkg_resources
 import yaml
 
 from ofrak_core.version import VERSION
@@ -237,10 +236,10 @@ def create_dockerfile_base(config: OfrakImageConfig) -> str:
             if not os.path.exists(requirements_path):
                 continue
             with open(requirements_path) as requirements_handle:
-                python_reqs += [
-                    str(requirement)
-                    for requirement in pkg_resources.parse_requirements(requirements_handle)
-                ]
+                for line in requirements_handle:
+                    line = line.split("#")[0].strip()
+                    if line:
+                        python_reqs.append(line)
         if python_reqs:
             dockerfile_base_parts += [
                 f"### Python dependencies from the {package_path} requirements file[s]",

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 - Fix `Resource.get_attributes` docstring to match implementation ([#692](https://github.com/redballoonsecurity/ofrak/pull/692))
+- Remove `pkg_resources` usage from `build_image.py`, broken by setuptools 82.0.0 ([#708](https://github.com/redballoonsecurity/ofrak/pull/708))
 - Fix GUI serialization of enum values and script creator generating invalid Python syntax for enum values
 - `build_image.py` uses `OFRAK_DIR` from `extra_build_args` to identify `pytest_ofrak` location for develop builds ([#657](https://github.com/redballoonsecurity/ofrak/pull/657/))
 

--- a/ofrak_tutorial/CHANGELOG.md
+++ b/ofrak_tutorial/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to `ofrak-tutorial` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased: 0.1.1](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased: 0.1.2](https://github.com/redballoonsecurity/ofrak/tree/master)
 ### Changed
 - Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))
+- Remove `pkg_resources` usage from `setup.py`, broken by setuptools 82.0.0; inline dependencies directly ([#708](https://github.com/redballoonsecurity/ofrak/pull/708))
 
 ### Fixed
 - Update Notebook 3 output to make testing on different configurations easier ([#593](https://github.com/redballoonsecurity/ofrak/pull/593))

--- a/ofrak_tutorial/setup.py
+++ b/ofrak_tutorial/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-import pkg_resources
 from setuptools.command.egg_info import egg_info
 
 
@@ -20,18 +19,9 @@ with open("LICENSE") as f:
     license = "".join(["\n", f.read()])
 
 
-# Should be the same as in build_image.py
-def read_requirements(requirements_path):
-    with open(requirements_path) as requirements_handle:
-        return [
-            str(requirement)
-            for requirement in pkg_resources.parse_requirements(requirements_handle)
-        ]
-
-
 setuptools.setup(
     name="ofrak_tutorial",
-    version="0.1.1",
+    version="0.1.2rc0",
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",
     description="OFRAK tutorial",
@@ -39,9 +29,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="",
     packages=["ofrak_tutorial"],
-    install_requires=read_requirements("requirements.txt"),
+    install_requires=["notebook>=6.4.10"],
     extras_require={
-        "test": read_requirements("requirements-test.txt"),
+        "test": ["nbval>=0.9.6"],
     },
     python_requires=">=3.9",
     license=license,


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [X] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Remove `pkg_resources` usage broken by setuptools 82.0.0

**Link to Related Issue(s)**

Broken CI on master - https://github.com/redballoonsecurity/ofrak/actions/runs/21807924736

**Please describe the changes in your request.**

`setuptools 82.0.0` (released Feb 8, 2026) removed `pkg_resources` from the package. This broke the tutorial Docker image build because `ofrak_tutorial/setup.py` imports `pkg_resources`, and pip's build isolation downloads the latest setuptools into a temporary environment.

Inline dependencies directly in `setup.py` (matching other packages) and replace `pkg_resources.parse_requirements()` with simple line reading in `build_image.py`.

**Anyone you think should look at this, specifically?**

@whyitfor 