### PR TITLE
EXT packer

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
+- Add EXT analyzer and packer ([#709](https://github.com/redballoonsecurity/ofrak/pull/709))
 - Add Android sparse image unpacker and packer ([#662](https://github.com/redballoonsecurity/ofrak/pull/662))
 - Add OFRAK requirements, requirement to test mapping, test specifications ([#656](https://github.com/redballoonsecurity/ofrak/pull/656))
 - Add `-V, --version` flag to ofrak cli ([#652](https://github.com/redballoonsecurity/ofrak/pull/652))

--- a/ofrak_core/src/ofrak/core/extfs.py
+++ b/ofrak_core/src/ofrak/core/extfs.py
@@ -2,8 +2,10 @@ import asyncio
 import tempfile312 as tempfile
 from dataclasses import dataclass
 from subprocess import CalledProcessError
+from typing import Optional
 
-from ofrak import Unpacker, Resource
+from ofrak import Analyzer, Unpacker, Resource
+from ofrak.component.packer import Packer, PackerError
 from ofrak.core import (
     GenericBinary,
     FilesystemRoot,
@@ -13,6 +15,7 @@ from ofrak.core import (
     MagicDescriptionPattern,
 )
 from ofrak.model.component_model import ComponentExternalTool, ComponentConfig
+from ofrak_type.range import Range
 
 _DEBUGFS = ComponentExternalTool(
     "debugfs", "https://e2fsprogs.sourceforge.net/", "-V", brew_package="e2fsprogs"
@@ -21,7 +24,18 @@ _DEBUGFS = ComponentExternalTool(
 
 @dataclass
 class ExtFilesystem(GenericBinary, FilesystemRoot):
-    pass
+    block_size: int
+    block_count: int
+    blocks_per_group: Optional[int] = None
+    inode_size: Optional[int] = None
+    number_of_inodes: Optional[int] = None
+    reserved_block_count: Optional[int] = None
+    creator_os: Optional[str] = None
+    filesystem_features: Optional[str] = None
+    filesystem_revision: Optional[int] = None
+    volume_label: Optional[str] = None
+    last_mounted_directory: Optional[str] = None
+    uuid: Optional[str] = None
 
 
 @dataclass
@@ -45,14 +59,83 @@ class Ext4Filesystem(ExtFilesystem):
     """
 
 
+class ExtAnalyzer(Analyzer[None, ExtFilesystem]):
+    """
+    Extracts EXT filesystem parameters from the superblock using dumpe2fs. These parameters are
+    required for correctly repacking the filesystem with mke2fs.
+    """
+
+    targets = (ExtFilesystem,)
+    outputs = (ExtFilesystem,)
+    external_dependencies = (_DEBUGFS,)
+
+    async def analyze(self, resource: Resource, config=None) -> ExtFilesystem:
+        async with resource.temp_to_disk(suffix=".extfs") as temp_path:
+            proc = await asyncio.create_subprocess_exec(
+                "dumpe2fs",
+                "-h",
+                temp_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await proc.communicate()
+            if proc.returncode:
+                raise CalledProcessError(
+                    returncode=proc.returncode, cmd=["dumpe2fs", "-h", temp_path]
+                )
+
+            params = {}
+            for line in stdout.decode().splitlines():
+                if ":" not in line:
+                    continue
+                key, _, value = line.partition(":")
+                params[key.strip()] = value.strip()
+
+            block_size = int(params["Block size"])
+            block_count = int(params["Block count"])
+
+            volume_label = params.get("Filesystem volume name")
+            if volume_label == "<none>":
+                volume_label = None
+
+            last_mounted_directory = params.get("Last mounted on")
+            if last_mounted_directory == "<not available>":
+                last_mounted_directory = None
+
+            revision_str = params.get("Filesystem revision #")
+            filesystem_revision = None
+            if revision_str:
+                filesystem_revision = int(revision_str.split()[0])
+
+            def _parse_optional_int(params: dict, key: str) -> Optional[int]:
+                val = params.get(key)
+                if val is not None:
+                    return int(val)
+                return None
+
+            return ExtFilesystem(
+                block_size=block_size,
+                block_count=block_count,
+                blocks_per_group=_parse_optional_int(params, "Blocks per group"),
+                inode_size=_parse_optional_int(params, "Inode size"),
+                number_of_inodes=_parse_optional_int(params, "Inode count"),
+                reserved_block_count=_parse_optional_int(params, "Reserved block count"),
+                creator_os=params.get("Filesystem OS type"),
+                filesystem_features=params.get("Filesystem features"),
+                filesystem_revision=filesystem_revision,
+                volume_label=volume_label,
+                last_mounted_directory=last_mounted_directory,
+                uuid=params.get("Filesystem UUID"),
+            )
+
+
 class ExtUnpacker(Unpacker[None]):
     """
     Extracts files and directories from Linux Extended (EXT2/EXT3/EXT4) filesystems, the standard
     Linux filesystem family. These filesystems support full Unix permissions, symbolic links, hard
     links, and extended attributes. Use when analyzing disk images, partition dumps, or embedded
     system storage that uses EXT filesystems. Common in Linux-based embedded devices, development
-    boards, and virtualized environments. Note that there are currently no EXT packers, so after
-    unpacking, the resource cannot be repacked.
+    boards, and virtualized environments.
     """
 
     targets = (ExtFilesystem,)
@@ -77,6 +160,84 @@ class ExtUnpacker(Unpacker[None]):
 
                 fs_view = await resource.view_as(ExtFilesystem)
                 await fs_view.initialize_from_disk(temp_dir)
+
+
+class ExtPacker(Packer[None]):
+    """
+    Packs files and directories into a Linux Extended (EXT2/EXT3/EXT4) filesystem image using
+    mke2fs. The filesystem type is determined by the resource's tag. The filesystem parameters
+    (block size, block count, etc.) are preserved from the original image via ExtAnalyzer.
+    """
+
+    targets = (ExtFilesystem,)
+    external_dependencies = (_DEBUGFS,)
+
+    async def pack(self, resource: Resource, config: ComponentConfig = None) -> None:
+        ext_view = await resource.view_as(ExtFilesystem)
+        flush_dir = await ext_view.flush_to_disk()
+        original_size = await resource.get_data_length()
+
+        if resource.has_tag(Ext2Filesystem):
+            ext_type = "ext2"
+        elif resource.has_tag(Ext3Filesystem):
+            ext_type = "ext3"
+        elif resource.has_tag(Ext4Filesystem):
+            ext_type = "ext4"
+        else:
+            raise PackerError(
+                f"Cannot pack {resource} because it is not one of [Ext2Filesystem, Ext3Filesystem, Ext4Filesystem]."
+            )
+
+        with tempfile.NamedTemporaryFile(mode="rb", suffix=".img", delete_on_close=False) as temp:
+            temp.close()
+            cmd = [
+                "mke2fs",
+                "-t",
+                ext_type,
+                "-b",
+                str(ext_view.block_size),
+                "-d",
+                flush_dir,
+            ]
+
+            if ext_view.blocks_per_group:
+                cmd.extend(["-g", str(ext_view.blocks_per_group)])
+            if ext_view.inode_size:
+                cmd.extend(["-I", str(ext_view.inode_size)])
+            if ext_view.number_of_inodes:
+                cmd.extend(["-N", str(ext_view.number_of_inodes)])
+            if ext_view.reserved_block_count and ext_view.block_count > 0:
+                percentage = round(ext_view.reserved_block_count / ext_view.block_count * 100)
+                cmd.extend(["-m", str(percentage)])
+            if ext_view.creator_os:
+                cmd.extend(["-o", ext_view.creator_os])
+            if ext_view.filesystem_features:
+                features = "none," + ext_view.filesystem_features.replace(" ", ",")
+                cmd.extend(["-O", features])
+            if ext_view.filesystem_revision:
+                cmd.extend(["-r", str(ext_view.filesystem_revision)])
+            if ext_view.volume_label:
+                cmd.extend(["-L", ext_view.volume_label])
+            if ext_view.last_mounted_directory:
+                cmd.extend(["-M", ext_view.last_mounted_directory])
+            if ext_view.uuid:
+                cmd.extend(["-U", ext_view.uuid])
+
+            cmd.extend([temp.name, str(ext_view.block_count)])
+
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            returncode = await proc.wait()
+            if returncode:
+                raise CalledProcessError(returncode=returncode, cmd=cmd)
+
+            with open(temp.name, "rb") as new_fh:
+                new_data = new_fh.read()
+
+            resource.queue_patch(Range(0, original_size), new_data)
 
 
 MagicDescriptionPattern.register(Ext2Filesystem, lambda s: "ext2 filesystem" in s.lower())

--- a/ofrak_core/src/ofrak/core/extfs.py
+++ b/ofrak_core/src/ofrak/core/extfs.py
@@ -79,12 +79,14 @@ class ExtAnalyzer(Analyzer[None, ExtFilesystem]):
                 "-h",
                 temp_path,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _ = await proc.communicate()
+            stdout, stderr = await proc.communicate()
             if proc.returncode:
                 raise CalledProcessError(
-                    returncode=proc.returncode, cmd=["dumpe2fs", "-h", temp_path]
+                    returncode=proc.returncode,
+                    cmd=["dumpe2fs", "-h", temp_path],
+                    stderr=stderr,
                 )
 
             params = {}
@@ -202,27 +204,27 @@ class ExtPacker(Packer[None]):
                 flush_dir,
             ]
 
-            if ext_view.blocks_per_group:
+            if ext_view.blocks_per_group is not None:
                 cmd.extend(["-g", str(ext_view.blocks_per_group)])
-            if ext_view.inode_size:
+            if ext_view.inode_size is not None:
                 cmd.extend(["-I", str(ext_view.inode_size)])
-            if ext_view.number_of_inodes:
+            if ext_view.number_of_inodes is not None:
                 cmd.extend(["-N", str(ext_view.number_of_inodes)])
-            if ext_view.reserved_block_count and ext_view.block_count > 0:
+            if ext_view.reserved_block_count is not None and ext_view.block_count > 0:
                 percentage = round(ext_view.reserved_block_count / ext_view.block_count * 100)
                 cmd.extend(["-m", str(percentage)])
-            if ext_view.creator_os:
+            if ext_view.creator_os is not None:
                 cmd.extend(["-o", ext_view.creator_os])
-            if ext_view.filesystem_features:
+            if ext_view.filesystem_features is not None:
                 features = "none," + ext_view.filesystem_features.replace(" ", ",")
                 cmd.extend(["-O", features])
-            if ext_view.filesystem_revision:
+            if ext_view.filesystem_revision is not None:
                 cmd.extend(["-r", str(ext_view.filesystem_revision)])
-            if ext_view.volume_label:
+            if ext_view.volume_label is not None:
                 cmd.extend(["-L", ext_view.volume_label])
-            if ext_view.last_mounted_directory:
+            if ext_view.last_mounted_directory is not None:
                 cmd.extend(["-M", ext_view.last_mounted_directory])
-            if ext_view.uuid:
+            if ext_view.uuid is not None:
                 cmd.extend(["-U", ext_view.uuid])
 
             cmd.extend([temp.name, str(ext_view.block_count)])

--- a/ofrak_core/tests/components/test_extfs_component.py
+++ b/ofrak_core/tests/components/test_extfs_component.py
@@ -5,7 +5,11 @@ Requirements Mapping:
 - REQ1.3
 - REQ4.4
 """
+import os
 import os.path
+import shutil
+import subprocess
+import tempfile312 as tempfile
 from dataclasses import dataclass
 from typing import Dict
 
@@ -16,6 +20,7 @@ from ofrak.resource import Resource
 
 from ofrak import OFRAKContext
 from ofrak.core.extfs import *
+from pytest_ofrak.patterns.pack_unpack_filesystem import FilesystemPackUnpackVerifyPattern
 from pytest_ofrak.patterns.unpack_verify import (
     UnpackAndVerifyPattern,
     UnpackAndVerifyTestCase,
@@ -212,3 +217,114 @@ class TestExt4UnpackModifyPack(_TestExtUnpackModifyPack):
             for name, child in children.items()
             if child.is_file()
         }
+
+
+class _TestExtPackUnpack(FilesystemPackUnpackVerifyPattern):
+    EXT_TYPE: str
+
+    def setup(self):
+        super().setup()
+        self.check_stat = False
+        self.check_xattrs = False
+
+    async def create_root_resource(self, ofrak_context: OFRAKContext, directory: str) -> Resource:
+        with tempfile.NamedTemporaryFile(suffix=".img", delete_on_close=False) as ext_blob:
+            ext_blob.close()
+            command = [
+                "mke2fs",
+                "-t",
+                self.EXT_TYPE,
+                "-d",
+                directory,
+                ext_blob.name,
+                "20M",
+            ]
+            subprocess.run(command, check=True, capture_output=True)
+            return await ofrak_context.create_root_resource_from_file(ext_blob.name)
+
+    async def unpack(self, root_resource: Resource) -> None:
+        await root_resource.unpack()
+
+    async def repack(self, root_resource: Resource) -> None:
+        await root_resource.pack()
+
+    async def extract(self, root_resource: Resource, extract_dir: str) -> None:
+        async with root_resource.temp_to_disk() as ext_blob_path:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                command = [
+                    "debugfs",
+                    "-R",
+                    f"rdump / {temp_dir}",
+                    ext_blob_path,
+                ]
+                subprocess.run(command, check=True, capture_output=True)
+                for item in os.listdir(temp_dir):
+                    src = os.path.join(temp_dir, item)
+                    dst = os.path.join(str(extract_dir), item)
+                    if os.path.isdir(src):
+                        shutil.copytree(src, dst, symlinks=True)
+                    else:
+                        shutil.copy2(src, dst)
+
+
+@pytest.mark.skipif_missing_deps([ExtUnpacker, ExtPacker])
+class TestExt2PackUnpack(_TestExtPackUnpack):
+    EXT_TYPE = "ext2"
+
+
+@pytest.mark.skipif_missing_deps([ExtUnpacker, ExtPacker])
+class TestExt3PackUnpack(_TestExtPackUnpack):
+    EXT_TYPE = "ext3"
+
+
+@pytest.mark.skipif_missing_deps([ExtUnpacker, ExtPacker])
+class TestExt4PackUnpack(_TestExtPackUnpack):
+    EXT_TYPE = "ext4"
+
+
+@pytest.mark.skipif_missing_deps([ExtUnpacker, ExtPacker])
+async def test_attributes_preserved(ofrak_context: OFRAKContext):
+    asset_path = os.path.join(components.ASSETS_DIR, "ext2.4096.img")
+    original_resource = await ofrak_context.create_root_resource_from_file(asset_path)
+    await original_resource.identify()
+    original_view = await original_resource.view_as(Ext2Filesystem)
+    original_attrs = {
+        "block_size": original_view.block_size,
+        "block_count": original_view.block_count,
+        "blocks_per_group": original_view.blocks_per_group,
+        "inode_size": original_view.inode_size,
+        "number_of_inodes": original_view.number_of_inodes,
+        "reserved_block_count": original_view.reserved_block_count,
+        "creator_os": original_view.creator_os,
+        "filesystem_features": original_view.filesystem_features,
+        "filesystem_revision": original_view.filesystem_revision,
+        "uuid": original_view.uuid,
+    }
+
+    await original_resource.unpack()
+    await original_resource.pack()
+
+    async with original_resource.temp_to_disk(suffix=".img") as repacked_path:
+        repacked_resource = await ofrak_context.create_root_resource_from_file(repacked_path)
+
+    await repacked_resource.identify()
+    repacked_view = await repacked_resource.view_as(Ext2Filesystem)
+    repacked_attrs = {
+        "block_size": repacked_view.block_size,
+        "block_count": repacked_view.block_count,
+        "blocks_per_group": repacked_view.blocks_per_group,
+        "inode_size": repacked_view.inode_size,
+        "number_of_inodes": repacked_view.number_of_inodes,
+        "reserved_block_count": repacked_view.reserved_block_count,
+        "creator_os": repacked_view.creator_os,
+        "filesystem_features": repacked_view.filesystem_features,
+        "filesystem_revision": repacked_view.filesystem_revision,
+        "uuid": repacked_view.uuid,
+    }
+
+    for attr_name, original_val in original_attrs.items():
+        repacked_val = repacked_attrs[attr_name]
+        assert original_val == repacked_val, (
+            f"Attribute {attr_name!r} changed after repack: "
+            f"{original_val!r} -> {repacked_val!r}"
+        )

--- a/ofrak_core/tests/components/test_extfs_component.py
+++ b/ofrak_core/tests/components/test_extfs_component.py
@@ -7,7 +7,6 @@ Requirements Mapping:
 """
 import os
 import os.path
-import shutil
 import subprocess
 import tempfile312 as tempfile
 from dataclasses import dataclass
@@ -234,21 +233,13 @@ class ExtFilesystemPackUnpackVerifyPattern(FilesystemPackUnpackVerifyPattern):
 
     async def extract(self, root_resource: Resource, extract_dir: str) -> None:
         async with root_resource.temp_to_disk() as ext_blob_path:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                command = [
-                    "debugfs",
-                    "-R",
-                    f"rdump / {temp_dir}",
-                    ext_blob_path,
-                ]
-                subprocess.run(command, check=True, capture_output=True)
-                for item in os.listdir(temp_dir):
-                    src = os.path.join(temp_dir, item)
-                    dst = os.path.join(str(extract_dir), item)
-                    if os.path.isdir(src):
-                        shutil.copytree(src, dst, symlinks=True)
-                    else:
-                        shutil.copy2(src, dst)
+            command = [
+                "debugfs",
+                "-R",
+                f"rdump / {extract_dir}",
+                ext_blob_path,
+            ]
+            subprocess.run(command, check=True, capture_output=True)
 
 
 class _TestExtPackUnpack(ExtFilesystemPackUnpackVerifyPattern):

--- a/ofrak_core/tests/components/test_extfs_component.py
+++ b/ofrak_core/tests/components/test_extfs_component.py
@@ -241,6 +241,18 @@ class ExtFilesystemPackUnpackVerifyPattern(FilesystemPackUnpackVerifyPattern):
             ]
             subprocess.run(command, check=True, capture_output=True)
 
+    def _validate_folder_equality(self, old_path: str, new_path: str):
+        old_files = os.listdir(old_path)
+        new_files = list(f for f in os.listdir(new_path) if f != "lost+found")
+        assert len(old_files) == len(new_files) and set(old_files) == set(
+            new_files
+        ), f"{old_path} and {new_path} contain different files\nold: {old_files}\nnew: {new_files}"
+
+        for old_f, new_f in zip(old_files, new_files):
+            old_f = os.path.join(old_path, old_f)
+            new_f = os.path.join(new_path, new_f)
+            self.verify_filesystem_equality(old_f, new_f)
+
 
 class _TestExtPackUnpack(ExtFilesystemPackUnpackVerifyPattern):
     EXT_TYPE: str

--- a/pytest_ofrak/src/pytest_ofrak/patterns/pack_unpack_filesystem.py
+++ b/pytest_ofrak/src/pytest_ofrak/patterns/pack_unpack_filesystem.py
@@ -163,6 +163,11 @@ class FilesystemPackUnpackVerifyPattern(ABC):
     def _validate_folder_equality(self, old_path: str, new_path: str):
         old_files = os.listdir(old_path)
         new_files = os.listdir(new_path)
+        # a "lost+found" directory might be created when flushed to disk, but might also happen to be present in the filesystem, so ignore it:
+        if "lost+found" in old_files:
+            old_files.remove("lost+found")
+        if "lost+found" in new_files:
+            new_files.remove("lost+found")
         assert len(old_files) == len(new_files) and set(old_files) == set(
             new_files
         ), f"{old_path} and {new_path} contain different files\nold: {old_files}\nnew: {new_files}"

--- a/pytest_ofrak/src/pytest_ofrak/patterns/pack_unpack_filesystem.py
+++ b/pytest_ofrak/src/pytest_ofrak/patterns/pack_unpack_filesystem.py
@@ -163,11 +163,6 @@ class FilesystemPackUnpackVerifyPattern(ABC):
     def _validate_folder_equality(self, old_path: str, new_path: str):
         old_files = os.listdir(old_path)
         new_files = os.listdir(new_path)
-        # a "lost+found" directory might be created when flushed to disk, but might also happen to be present in the filesystem, so ignore it:
-        if "lost+found" in old_files:
-            old_files.remove("lost+found")
-        if "lost+found" in new_files:
-            new_files.remove("lost+found")
         assert len(old_files) == len(new_files) and set(old_files) == set(
             new_files
         ), f"{old_path} and {new_path} contain different files\nold: {old_files}\nnew: {new_files}"


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Add EXT packer, analyzer and tests.

**Link to Related Issue(s)**

https://github.com/redballoonsecurity/ofrak/issues/529

**Please describe the changes in your request.**

- Add `ExtAnalyzer` that uses the `dumpe2fs` command to determine all the EXT attributes.
- Add `ExtPacker` that uses the `mke2fs` command and the analysis from the `ExtAnalyzer` to create an EXT2/3/4 filesystem without having to mount anything or use loop devices. 
- Add tests using `FilesystemPackUnpackVerifyPattern` and a round trip test to make sure attributes are preserved
- Note that I had to modify the `_validate_folder_equality` method in `pytest_ofrak/src/pytest_ofrak/patterns/pack_unpack_filesystem.py` because linux will sometimes create a `lost+found` directory when extracting the filesystem. But it could also be present in the original filesystem. So I just removed that from the equality comparison.

Compared to https://github.com/redballoonsecurity/ofrak/pull/558 PR, this merge request is more compact and less complex (no need to write a debugfs script, etc).

**Anyone you think should look at this, specifically?**

No