### PR TITLE
Replace blocking `time.sleep` with `asyncio.sleep` in Ghidra analyzer

### DIFF
--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Move to OpenJDK version 17 with the docker container move to Debian 12 ([#502](https://github.com/redballoonsecurity/ofrak/pull/502))
 
 ### Fixed
+- Replace blocking `time.sleep` calls with `asyncio.sleep` in Ghidra analyzer ([#PLACEHOLDER](https://github.com/redballoonsecurity/ofrak/pull/PLACEHOLDER))
 - Bump `aiohttp` to >=3.13.3 to address CVE-2025-69223 ([#693](https://github.com/redballoonsecurity/ofrak/pull/693))
 - Speedup: do not run Ghidra auto-analysis upon importing a program. ([#473](https://github.com/redballoonsecurity/ofrak/pull/473))
 - Ensure large 64-bit addresses are interpreted as unsigned. ([#474](https://github.com/redballoonsecurity/ofrak/pull/474))

--- a/disassemblers/ofrak_ghidra/setup.py
+++ b/disassemblers/ofrak_ghidra/setup.py
@@ -21,7 +21,7 @@ with open("LICENSE") as f:
 
 setuptools.setup(
     name="ofrak_ghidra",
-    version="0.2.0rc4",
+    version="0.2.0rc5",
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",
     description="OFRAK Ghidra Components",

--- a/disassemblers/ofrak_ghidra/src/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/src/ofrak_ghidra/components/ghidra_analyzer.py
@@ -3,7 +3,6 @@ import hashlib
 import logging
 import os
 import tempfile
-import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import lru_cache
@@ -221,7 +220,7 @@ class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
                 raise GhidraComponentException("Ghidra client exited unexpectedly")
 
             if line.startswith("Repository Server:"):
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
                 ghidra_proc.stdin.write((GHIDRA_PASS + "\n").encode("ascii"))
                 await ghidra_proc.stdin.drain()
             if "Disconnected from repository" in line:
@@ -302,7 +301,7 @@ class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
             if len(line) > 0:
                 LOGGER.debug(line)
             if line.startswith("Repository Server:"):
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
                 ghidra_proc.stdin.write((GHIDRA_PASS + "\n").encode("ascii"))
                 await ghidra_proc.stdin.drain()
             if "Disconnected from repository" in line:


### PR DESCRIPTION
- [X] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [X] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Replace blocking `time.sleep` with `asyncio.sleep` in Ghidra analyzer

**Link to Related Issue(s)**

N/A

**Please describe the changes in your request.**

2-line change:
The two `time.sleep(0.5)` calls in `GhidraProjectAnalyzer` blocked the event loop while waiting for the Ghidra repository server password prompt. Switched to `await asyncio.sleep(0.5)` so other coroutines can proceed.

**Anyone you think should look at this, specifically?**
