### PR TITLE
Pre-install virtualenv to avoid 429 on macOS

### DIFF
--- a/.github/actions/build-wheels/action.yml
+++ b/.github/actions/build-wheels/action.yml
@@ -54,6 +54,7 @@ runs:
         CIBW_ARCHS_MACOS: "x86_64 arm64"
         CIBW_ARCHS_LINUX: "x86_64"
         CIBW_BUILD_VERBOSITY: 1
+        CIBW_DEPENDENCY_VERSIONS: "latest"
       run: |
         # Convert Python version to cibuildwheel format (3.9 -> 39)
         PY_VERSION_NO_DOT="${{ inputs.python-version }}"


### PR DESCRIPTION
- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
