### PR TITLE
Use magic.from_file to workaround libmagic 5.47 bug

### DIFF
--- a/ofrak_core/src/ofrak/core/magic.py
+++ b/ofrak_core/src/ofrak/core/magic.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import tempfile
 from dataclasses import dataclass
 from typing import Callable, Dict, Iterable, Union
@@ -73,13 +74,14 @@ class MagicAnalyzer(Analyzer[None, Magic]):
         if not MAGIC_INSTALLED:
             raise ComponentMissingDependencyError(self, LIBMAGIC_DEP)
         else:
-            # libmagic 5.47 workaround - 5.47 has incorrect output when calling
-            # magic.from_buffer. Use magic.from_file instead.
-            with tempfile.NamedTemporaryFile() as tmp:
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
                 tmp.write(data)
-                tmp.flush()
-                magic_mime = magic.from_file(tmp.name, mime=True)
-                magic_description = magic.from_file(tmp.name)
+                tmp_path = tmp.name
+            try:
+                magic_mime = magic.from_file(tmp_path, mime=True)
+                magic_description = magic.from_file(tmp_path)
+            finally:
+                os.unlink(tmp_path)
             return Magic(magic_mime, magic_description)
 
 


### PR DESCRIPTION
- [ ] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
