### PR TITLE
Remove the Identify button from OFRAK GUI

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -60,7 +60,7 @@
   let currentResource, rootResource, modifierView, bottomLeftPane;
   let prevSelectedForAutoIdentify = undefined;
 
-  // Keeps expand/collapse state 
+  // Keeps expand/collapse state
   // reloads children so the tree matches post-identify models.
   function refreshResourceTreeChildren(resourceId, resource) {
     resourceNodeDataMap.update((map) => {
@@ -111,7 +111,11 @@
 
   // Run identify on the selected resource if it is not
   // already identified.
-  $: if (showRootResource && $selected !== undefined && resources[$selected] !== undefined) {
+  $: if (
+    showRootResource &&
+    $selected !== undefined &&
+    resources[$selected] !== undefined
+  ) {
     const id = $selected;
     const res = resources[id];
     if (id !== prevSelectedForAutoIdentify) {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -37,11 +37,14 @@
   import ContentView from "./views/ContentView.svelte";
 
   import { printConsoleArt } from "./console-art.js";
+  import { get } from "svelte/store";
+  import { tick } from "svelte";
   import {
     selected,
     selectedResource,
     settings,
     dataLength,
+    resourceNodeDataMap,
   } from "./stores.js";
   import { keyEventToString, shortcuts } from "./keyboard.js";
 
@@ -55,6 +58,23 @@
     rootResourceLoadPromise = new Promise((resolve) => {}),
     resources = {};
   let currentResource, rootResource, modifierView, bottomLeftPane;
+  let prevSelectedForAutoIdentify = undefined;
+
+  // Keeps expand/collapse state 
+  // reloads children so the tree matches post-identify models.
+  function refreshResourceTreeChildren(resourceId, resource) {
+    resourceNodeDataMap.update((map) => {
+      const nodeState = map[resourceId] ?? {};
+      return {
+        ...map,
+        [resourceId]: {
+          ...nodeState,
+          collapsed: !!nodeState.collapsed,
+          childrenPromise: resource.get_children(),
+        },
+      };
+    });
+  }
 
   // TODO: Move to settings
   let riddleAnswered = JSON.parse(window.localStorage.getItem("riddleSolved"));
@@ -87,6 +107,31 @@
     if ($selected !== window.location.hash.slice(1)) {
       window.history.pushState(null, "", `#${$selected}`);
     }
+  }
+
+  // Run identify on the selected resource if it is not
+  // already identified.
+  $: if (showRootResource && $selected !== undefined && resources[$selected] !== undefined) {
+    const id = $selected;
+    const res = resources[id];
+    if (id !== prevSelectedForAutoIdentify) {
+      prevSelectedForAutoIdentify = id;
+      (async () => {
+        await res.identify();
+        if (get(selected) !== id) {
+          return;
+        }
+        refreshResourceTreeChildren(id, res);
+        document.title = "OFRAK App – " + res.get_caption();
+        // refresh the selected resource
+        const cur = get(selected);
+        selected.set(undefined);
+        await tick();
+        selected.set(cur);
+      })();
+    }
+  } else if (!showRootResource) {
+    prevSelectedForAutoIdentify = undefined;
   }
 
   function backButton() {

--- a/frontend/src/resource/ResourceTreeToolbar.svelte
+++ b/frontend/src/resource/ResourceTreeToolbar.svelte
@@ -73,23 +73,6 @@
   $: {
     toolbarButtons = [
       {
-        text: "Identify",
-        iconUrl: "/icons/identify.svg",
-        shortcut: "i",
-        onclick: async (e) => {
-          await rootResource.identify();
-          if (!$resourceNodeDataMap[$selected]) {
-            $resourceNodeDataMap[$selected] = {};
-          }
-          $resourceNodeDataMap[$selected].collapsed =
-            !!$resourceNodeDataMap[$selected]?.collapsed;
-          $resourceNodeDataMap[$selected].childrenPromise =
-            rootResource.get_children();
-          refreshResource();
-        },
-      },
-
-      {
         text: "Unpack",
         iconUrl: "/icons/unpack.svg",
         shortcut: "u",


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.  

Note: these changes only apply to files under `frontend/`, which does not maintain a changelog

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Identify button was removed from toolbar, now `identify()` is ran on a resource automatically when it is selected in the GUI.   

**Link to Related Issue(s)**
#635 

**Please describe the changes in your request.**  
When exploring resources in the OFRAK GUI, when a resource is clicked or otherwise selected, identifiers automatically run against that resource and the resource's captions and ResourceTags get updated automatically. Because of this, the "Identify" button is no longer needed.  

Given that the initial issue had some concerns about this change negatively impacting the responsiveness of the GUI I decided to run some manual benchmarking. I used a [RPI5 squashfs Image](https://downloads.openwrt.org/releases/25.12.2/targets/bcm27xx/bcm2712/openwrt-25.12.2-bcm27xx-bcm2712-rpi-5-squashfs-sysupgrade.img.gz) from openwrt. Benchmarking showed an average delay of 115ms (worst case 758.8 ms when running identify on the top level image) per resource selection to identify and update the frontend. Due to the asynchronous nature of the UI and the fact that other things (such as the hex view) also update when you select a new resource, this was not noticeable in my opinion. Additionally, OFRAK does not re-run identifiers on resources that have already been identified. If we find this delay unacceptable, I could pivot to merging the "identify" and "unpack" buttons, as mentioned in the issue.

**Anyone you think should look at this, specifically?**
@whyitfor 