### PR TITLE
Add Attributes from the GUI

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -188,7 +188,10 @@ Answer by running riddle.answer('your answer here') from the console.`);
               bind:bottomLeftPane="{bottomLeftPane}"
             />
           {:else}
-            <AttributesView resource="{currentResource}" />
+            <AttributesView
+              resource="{currentResource}"
+              bind:modifierView="{modifierView}"
+            />
           {/if}
         </Pane>
       </Split>

--- a/frontend/src/ofrak/remote_resource.js
+++ b/frontend/src/ofrak/remote_resource.js
@@ -509,6 +509,29 @@ export class RemoteResource extends Resource {
     await this.update_script();
   }
 
+  async add_attributes(attributes_type, attributes) {
+    await fetch(`${this.uri}/add_attributes`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: attributes_type,
+        attributes: attributes,
+      }),
+    }).then(async (r) => {
+      if (!r.ok) {
+        throw Error(JSON.stringify(await r.json(), undefined, 2));
+      }
+      const updated_model = await r.json();
+      remote_model_to_resource(updated_model, this.resource_list);
+    });
+    this.flush_cache();
+    this.update();
+
+    await this.update_script();
+  }
+
   async delete_comment(optional_range, comment_text) {
     await fetch(`${this.uri}/delete_comment`, {
       method: "POST",

--- a/frontend/src/ofrak/resource.js
+++ b/frontend/src/ofrak/resource.js
@@ -226,7 +226,7 @@ export class Resource {
     throw new NotImplementedError("remove_tag");
   }
 
-  async add_attributes(attributes) {
+  async add_attributes(attributes_type, attributes) {
     // Sync in ResourceInterface
     throw new NotImplementedError("add_attributes");
   }

--- a/frontend/src/views/AddAttributesView.svelte
+++ b/frontend/src/views/AddAttributesView.svelte
@@ -1,0 +1,277 @@
+<style>
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+  }
+
+  .container {
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    justify-content: center;
+    align-items: stretch;
+    align-content: center;
+  }
+
+  .inputs {
+    flex-grow: 1;
+  }
+
+  .inputs *:first-child {
+    margin-top: 0;
+  }
+
+  .actions {
+    margin-top: 1em;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-evenly;
+    align-items: center;
+    align-content: center;
+  }
+
+  .error {
+    color: var(--error-color, #ff6b6b);
+    margin-top: 1em;
+  }
+
+  select,
+  option {
+    background-color: var(--main-bg-color);
+    color: inherit;
+    border: 1px solid;
+    border-color: inherit;
+    border-radius: 0;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    padding-left: 1em;
+    padding-right: 1em;
+    margin-left: 0.5em;
+    margin-right: 0.5em;
+    font-size: inherit;
+    font-family: var(--font);
+    box-shadow: none;
+  }
+
+  select {
+    flex-grow: 1;
+    margin: 0 2ch;
+  }
+
+  option {
+    font-family: monospace;
+  }
+
+  textarea {
+    background-color: var(--main-bg-color);
+    color: inherit;
+    border: 1px solid;
+    border-color: inherit;
+    border-radius: 0;
+    padding: 1em;
+    font-size: 12px;
+    font-family: monospace;
+    line-height: 1.5;
+    resize: vertical;
+    min-height: 200px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+  }
+
+  label {
+    font-weight: bold;
+  }
+</style>
+
+<script>
+  import {
+    selected,
+    selectedResource,
+    settings,
+    resourceNodeDataMap,
+  } from "../stores.js";
+  import Button from "../utils/Button.svelte";
+  import { onMount } from "svelte";
+  import LoadingText from "../utils/LoadingText.svelte";
+  import { cleanOfrakType } from "../helpers";
+
+  export let modifierView;
+  let errorMessage = "";
+  let attributeTypesPromise = new Promise(() => {});
+  let selectedAttributeType = null;
+  let jsonPayload = "";
+
+  async function refreshResource() {
+    // Force tree view children refresh
+    $resourceNodeDataMap[$selected].collapsed = false;
+    $resourceNodeDataMap[$selected].childrenPromise =
+      $selectedResource.get_children();
+
+    // Force resource refresh by getting latest model from backend
+    await $selectedResource.get_latest_model();
+
+    // Force hex view refresh with colors
+    const originalSelected = $selected;
+    $selected = undefined;
+    $selected = originalSelected;
+  }
+
+  function validateJSON() {
+    try {
+      JSON.parse(jsonPayload);
+      return true;
+    } catch (e) {
+      errorMessage = `Invalid JSON: ${e.message}`;
+      return false;
+    }
+  }
+
+  async function submitAttributes() {
+    if (!selectedAttributeType) {
+      errorMessage = "Please select an attribute type";
+      return;
+    }
+
+    if (!validateJSON()) {
+      return;
+    }
+
+    try {
+      errorMessage = "";
+      const payload = JSON.parse(jsonPayload);
+
+      const response = await fetch(
+        `${$settings.backendUrl}/${$selectedResource.resource_id}/add_attributes`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: selectedAttributeType.type,
+            attributes: payload,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || `HTTP ${response.status}`);
+      }
+
+      modifierView = undefined;
+      await refreshResource();
+    } catch (err) {
+      errorMessage = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  function onAttributeTypeChange(e) {
+    // Clear payload when type changes - user should provide JSON
+    jsonPayload = "";
+  }
+
+  onMount(async () => {
+    try {
+      const response = await fetch(
+        `${$settings.backendUrl}/get_all_resource_attributes`
+      );
+      if (!response.ok) {
+        throw Error("Failed to fetch attribute types");
+      }
+      const types = await response.json();
+      types.sort((a, b) =>
+        cleanOfrakType(a.type).localeCompare(cleanOfrakType(b.type))
+      );
+      attributeTypesPromise = Promise.resolve(types);
+    } catch (err) {
+      errorMessage = err instanceof Error ? err.message : "Unknown error";
+      attributeTypesPromise = Promise.resolve([]);
+    }
+  });
+</script>
+
+<div class="container">
+  <div class="inputs">
+    <p>Select a resource attribute type to add.</p>
+    {#await attributeTypesPromise}
+      <LoadingText />
+    {:then attributeTypes}
+      {#if attributeTypes && attributeTypes.length > 0}
+        <form on:submit|preventDefault="{submitAttributes}">
+          <div class="form-group">
+            <label for="attr-type">Attribute Type:</label>
+            <select
+              id="attr-type"
+              bind:value="{selectedAttributeType}"
+              on:change="{onAttributeTypeChange}"
+              on:click="{(e) => e.stopPropagation()}"
+            >
+              <option value="{null}">Select an attribute type</option>
+              {#each attributeTypes as attrType}
+                <option value="{attrType}">
+                  {cleanOfrakType(attrType.type)}
+                </option>
+              {/each}
+            </select>
+          </div>
+
+          {#if selectedAttributeType}
+            <div class="form-group">
+              <label for="json-payload">Configuration (JSON):</label>
+              <textarea
+                id="json-payload"
+                bind:value="{jsonPayload}"
+                placeholder="Edit JSON configuration here..."
+                on:click="{(e) => e.stopPropagation()}"></textarea>
+              <p style="font-size: 0.9em; color: #888; margin-top: 0.5em;">
+                For nested objects, use format: <code
+                  style="background: #f0f0f0; padding: 2px 4px;"
+                  >["package.module.ClassName", {"{"}fields{"}"}]</code
+                >
+              </p>
+            </div>
+          {/if}
+
+          <div class="actions">
+            <Button
+              --button-margin="0 .5em 0 .5em"
+              --button-padding=".5em 1em .5em 1em"
+              on:click="{(e) => {
+                e.stopPropagation();
+                modifierView = undefined;
+              }}"
+            >
+              Cancel
+            </Button>
+            <Button
+              --button-margin="0 .5em 0 .5em"
+              --button-padding=".5em 1em .5em 1em"
+              on:click="{(e) => e.stopPropagation()}"
+              disabled="{!selectedAttributeType || !jsonPayload.trim()}"
+              type="submit"
+            >
+              Add Attributes
+            </Button>
+          </div>
+        </form>
+      {:else}
+        <p>No attribute types found!</p>
+      {/if}
+    {:catch err}
+      <p>Failed to load attribute types!</p>
+      <p>The back end server may be down.</p>
+    {/await}
+  </div>
+
+  {#if errorMessage}
+    <div class="error">{errorMessage}</div>
+  {/if}
+</div>

--- a/frontend/src/views/AttributesView.svelte
+++ b/frontend/src/views/AttributesView.svelte
@@ -16,10 +16,13 @@
 
 <script>
   import StructuredList from "../utils/StructuredList.svelte";
+  import Button from "../utils/Button.svelte";
+  import AddAttributesView from "./AddAttributesView.svelte";
 
   import { cleanOfrakType } from "../helpers.js";
 
   export let resource;
+  export let modifierView;
   let attributes;
   $: if (resource !== undefined) {
     attributes = {};
@@ -55,7 +58,16 @@
         rel="noreferrer">{cleanOfrakType(tag)}</a
       >{i !== resource.get_tags().length - 1 ? ", " : ""}
     {/each}
-    <h1>Attributes:</h1>
+    <h1 style="display: flex; align-items: center;">
+      <span>Attributes:</span>
+      <Button
+        style="margin-left: auto;"
+        --button-margin="0"
+        --button-padding=".2em .5em .2em .5em"
+        on:click="{() => (modifierView = AddAttributesView)}"
+        >+ Add Attribute</Button
+      >
+    </h1>
     <StructuredList object="{attributes}" />
   {/if}
 </div>

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add `-V, --version` flag to ofrak cli ([#652](https://github.com/redballoonsecurity/ofrak/pull/652))
 - Add LZ4 compression format unpackers and packers with support for all frame types (modern, legacy, skippable) ([#661](https://github.com/redballoonsecurity/ofrak/pull/661))
 - Add missing component docstrings and improve existing docstrings ([#654](https://github.com/redballoonsecurity/ofrak/pull/654))
-- Added `add_attribute` and `get_all_resource_attributes` endpoints to `server.py` to allow certain workflows entirely from GUI (e.g flash unpacking) ([#573](https://github.com/redballoonsecurity/ofrak/issues/573)) 
+- Added `add_attribute` and `get_all_resource_attributes` endpoints to `server.py` and Button/View to GUI to allow adding ResourceAttribtues manually from GUI, supporting certain workflows like flash unpacking ([#573](https://github.com/redballoonsecurity/ofrak/issues/573))   
 
 ### Changed
 - Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add `-V, --version` flag to ofrak cli ([#652](https://github.com/redballoonsecurity/ofrak/pull/652))
 - Add LZ4 compression format unpackers and packers with support for all frame types (modern, legacy, skippable) ([#661](https://github.com/redballoonsecurity/ofrak/pull/661))
 - Add missing component docstrings and improve existing docstrings ([#654](https://github.com/redballoonsecurity/ofrak/pull/654))
+- Added `add_attribute` and `get_all_resource_attributes` endpoints to `server.py` to allow certain workflows entirely from GUI (e.g flash unpacking) ([#573](https://github.com/redballoonsecurity/ofrak/issues/573)) 
 
 ### Changed
 - Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))

--- a/ofrak_core/src/ofrak/gui/server.py
+++ b/ofrak_core/src/ofrak/gui/server.py
@@ -1,11 +1,13 @@
 import asyncio
 import binascii
 import dataclasses
+import importlib
 import re
 from enum import Enum
 import functools
 import itertools
 import logging
+
 
 from ofrak.project.project import OfrakProject
 
@@ -198,11 +200,13 @@ class AiohttpOFRAKServer:
                 web.post("/{resource_id}/search_for_string", self.search_for_string),
                 web.post("/{resource_id}/search_for_bytes", self.search_for_bytes),
                 web.post("/{resource_id}/add_tag", self.add_tag),
+                web.post("/{resource_id}/add_attributes", self.add_attributes),
                 web.post("/{resource_id}/remove_tag", self.remove_tag),
                 web.post(
                     "/{resource_id}/add_flush_to_disk_to_script", self.add_flush_to_disk_to_script
                 ),
                 web.get("/get_all_tags", self.get_all_tags),
+                web.get("/get_all_resource_attributes", self.get_all_resource_attributes),
                 web.get("/{resource_id}/get_script", self.get_script),
                 web.post(
                     "/{resource_id}/get_components",
@@ -959,6 +963,91 @@ class AiohttpOFRAKServer:
         return json_response(self._serialize_resource(resource))
 
     @exceptions_to_http(SerializedError)
+    async def add_attributes(self, request: Request) -> Response:
+        resource = await self._get_resource_for_request(request)
+        data = await request.json()
+        attributes_type = data["type"]
+        attributes_data = data["attributes"]
+        # Construct attributes directly without PJSON to avoid deserialization issues
+        attributes = self._construct_attributes_from_dict(attributes_type, attributes_data)
+
+        resource.add_attributes(attributes)
+        await resource.save()
+        return json_response(self._serialize_resource(resource))
+
+    def _import_class_from_path(self, type_path: str) -> Any:
+        """
+        Import and return a class given its fully qualified path
+        (e.g., 'module.submodule.ClassName').
+        """
+        module_name, class_name = type_path.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, class_name)
+
+    def _construct_attributes_from_dict(self, type_str: str, data: dict) -> Any:
+        """
+        Construct attribute objects directly from dict.
+        Recursively instantiates nested objects.
+        """
+        target_class = self._import_class_from_path(type_str)
+
+        # Recursively process all fields
+        processed_fields = {}
+        for field_name, field_value in data.items():
+            processed_fields[field_name] = self._process_attribute_value(field_value)
+
+        # Instantiate the target class with processed fields
+        return target_class(**processed_fields)
+
+    def _process_attribute_value(self, value: Any) -> Any:
+        """
+        Recursively process attribute values, instantiating classes from [type_str, fields] format
+        and converting enum string references to actual enum objects.
+        """
+        if value is None:
+            return None
+
+        # Handle enum string references like "ofrak.core.flash.FlashFieldType.DATA"
+        if isinstance(value, str) and "." in value:
+            try:
+                # Split into module path and enum member
+                parts = value.rsplit(".", 1)
+                if len(parts) == 2:
+                    enum_type_path, member_name = parts
+                    enum_class = self._import_class_from_path(enum_type_path)
+                    # Check if it's an Enum class and try to get the member
+                    if inspect.isclass(enum_class) and issubclass(enum_class, Enum):
+                        return enum_class[member_name]
+            except Exception:
+                # If conversion fails, just return the string as-is
+                pass
+            return value
+
+        # Handle [ClassName, fields_dict] format
+        if isinstance(value, list) and len(value) == 2:
+            type_str, fields = value
+            if isinstance(type_str, str) and isinstance(fields, dict):
+                # Recursively process nested fields
+                processed_fields = {k: self._process_attribute_value(v) for k, v in fields.items()}
+                # Instantiate the class
+                try:
+                    cls = self._import_class_from_path(type_str)
+                    return cls(**processed_fields)
+                except Exception as e:
+                    raise ValueError(f"Failed to instantiate {type_str}: {e}")
+
+        # Handle lists of objects
+        if isinstance(value, list):
+            return [self._process_attribute_value(item) for item in value]
+
+        # Handle nested dicts
+        if isinstance(value, dict):
+            return {k: self._process_attribute_value(v) for k, v in value.items()}
+
+        # Return primitive values as-is
+        return value
+
+    @exceptions_to_http(SerializedError)
     async def remove_tag(self, request: Request) -> Response:
         resource = await self._get_resource_for_request(request)
         tag = self._serializer.from_pjson(await request.json(), ResourceTag)
@@ -985,6 +1074,17 @@ class AiohttpOFRAKServer:
         return json_response(
             self._serializer.to_pjson(set(self._all_tags.values()), Set[ResourceTag])
         )
+
+    @exceptions_to_http(SerializedError)
+    async def get_all_resource_attributes(self, request: Request) -> Response:
+        resource_attributes = [
+            {
+                "type": f"{attr_type.__module__}.{attr_type.__qualname__}",
+                "label": attr_type.__name__,
+            }
+            for attr_type in self._get_all_resource_attribute_types()
+        ]
+        return json_response(resource_attributes)
 
     @exceptions_to_http(SerializedError)
     async def add_flush_to_disk_to_script(self, request: Request) -> Response:
@@ -1539,33 +1639,67 @@ class AiohttpOFRAKServer:
         else:
             return {name: value.value for name, value in obj.__members__.items()}
 
+    def _get_all_resource_attribute_types(self) -> List[Type[ResourceAttributes]]:
+        def recurse(attribute_type: Type[ResourceAttributes]) -> List[Type[ResourceAttributes]]:
+            result = []
+            for child in attribute_type.__subclasses__():
+                result.append(child)
+                result.extend(recurse(child))
+            return result
+
+        return sorted(
+            recurse(ResourceAttributes),
+            key=lambda cls: f"{cls.__module__}.{cls.__qualname__}",
+        )
+
     def _has_elipsis(self, obj):
         return any([isinstance(arg, type(...)) for arg in get_args(obj)])
 
     def _convert_to_class_name_str(self, obj: Any):
+        # Check for generic types first (before checking membership in sets,
+        # which fails for unhashable types)
+        if hasattr(obj, "__origin__"):
+            origin = obj.__origin__
+            if origin is list:
+                return "typing.List"
+            elif origin is Iterable.__origin__:  # type: ignore
+                return "typing.Iterable"
+            elif origin is tuple:
+                return "typing.Tuple"
+            elif origin is dict:
+                return "typing.Dict"
+
+        # Check for typing constructs
+        if typing_inspect.is_optional_type(obj):
+            return "typing.Optional"
+        if typing_inspect.is_union_type(obj):
+            return "typing.Union"
+
+        # Check for common builtin types
+        if obj is bool:
+            return "builtins.bool"
+        if obj is str:
+            return "builtins.str"
+        if obj is bytes:
+            return "builtins.bytes"
+        if obj is int:
+            return "builtins.int"
+        if obj is float:
+            return "builtins.float"
+        if obj is list:
+            return "typing.List"
+        if obj is dict:
+            return "typing.Dict"
+        if obj is tuple:
+            return "typing.Tuple"
+        if obj is Range:
+            return "ofrak_type.range.Range"
+
+        # Check for classes with module and qualname
         if hasattr(obj, "__qualname__") and hasattr(obj, "__module__"):
             return f"{obj.__module__}.{obj.__qualname__}"
-        else:
-            if obj in {bool, str, bytes, int}:
-                return f"builtins.{obj.__name__}"
-            elif typing_inspect.is_optional_type(obj):
-                return "typing.Optional"
-            elif typing_inspect.is_union_type(obj):
-                return "typing.Union"
-            elif obj is Range:
-                return "ofrak_type.range.Range"
-            elif hasattr(obj, "__origin__"):
-                origin = obj.__origin__
-                if origin is list:
-                    return "typing.List"
-                elif origin is Iterable.__origin__:  # type: ignore
-                    return "typing.Iterable"
-                elif origin is tuple:
-                    return "typing.Tuple"
-                elif origin is dict:
-                    return "typing.Dict"
-            else:
-                return repr(obj).split("[")[0]
+
+        return repr(obj).split("[")[0]
 
     async def _get_resource_by_id(self, resource_id: bytes, job_id: bytes) -> Resource:
         resource = await self._ofrak_context.resource_factory.create(

--- a/ofrak_core/tests/unit/test_ofrak_server.py
+++ b/ofrak_core/tests/unit/test_ofrak_server.py
@@ -9,6 +9,7 @@ from ofrak.resource import Resource
 import pytest
 from pytest_lazyfixture import lazy_fixture
 import re
+from .. import components
 
 from multiprocessing import Process
 from typing import List, Tuple
@@ -2359,3 +2360,292 @@ def update_linkable_symbols_config():
             LinkableSymbol(0x2000, "data_b", LinkableSymbolType.RO_DATA, InstructionSetMode.NONE),
         )
     )
+
+
+@pytest.fixture
+def flash_attributes_simple():
+    """Simple FlashAttributes without ECC."""
+    return {
+        "data_block_format": [
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.DATA", "size": 223},
+            ],
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.ECC", "size": 32},
+            ],
+        ]
+    }
+
+
+@pytest.fixture
+def flash_attributes_with_ecc():
+    """FlashAttributes with ECC (includes ReedSolomon)."""
+    return {
+        "data_block_format": [
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.DATA", "size": 223},
+            ],
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.ECC", "size": 32},
+            ],
+        ],
+        "ecc_attributes": [
+            "ofrak.core.flash.FlashEccAttributes",
+            {"ecc_class": ["ofrak.core.ecc.reedsolomon.ReedSolomon", {"nsym": 32}]},
+        ],
+    }
+
+
+@pytest.fixture
+def flash_attributes_multiple_enums():
+    """FlashAttributes with multiple enum values."""
+    return {
+        "data_block_format": [
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.DATA", "size": 100},
+            ],
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.ECC", "size": 32},
+            ],
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.ALIGNMENT", "size": 0},
+            ],
+        ]
+    }
+
+
+@pytest.fixture
+def flash_attributes_rs_parameters():
+    """FlashAttributes with ReedSolomon parameters."""
+    return {
+        "data_block_format": [
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.DATA", "size": 223},
+            ],
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.ECC", "size": 32},
+            ],
+        ],
+        "ecc_attributes": [
+            "ofrak.core.flash.FlashEccAttributes",
+            {
+                "ecc_class": [
+                    "ofrak.core.ecc.reedsolomon.ReedSolomon",
+                    {"nsym": 32, "nsize": 255, "fcr": 1},
+                ]
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "attributes_fixture,test_name",
+    [
+        pytest.param(
+            "flash_attributes_simple",
+            "simple_without_ecc",
+            id="simple_without_ecc",
+        ),
+        pytest.param(
+            "flash_attributes_with_ecc",
+            "with_ecc",
+            id="with_ecc",
+        ),
+        pytest.param(
+            "flash_attributes_multiple_enums",
+            "multiple_enums",
+            id="multiple_enums",
+        ),
+        pytest.param(
+            "flash_attributes_rs_parameters",
+            "rs_parameters",
+            id="rs_parameters",
+        ),
+        pytest.param(
+            "flash_attributes_simple",
+            "optional_fields_only",
+            id="optional_fields_only",
+        ),
+    ],
+)
+async def test_add_flash_attributes(
+    ofrak_client: TestClient, hello_elf, request, attributes_fixture, test_name
+):
+    """Test FlashAttributes with various configurations.
+
+    Tests cover:
+    - Adding simple FlashAttributes without ECC
+    - Adding FlashAttributes with ECC (includes ReedSolomon)
+    - Enum string value conversion with multiple enum values
+    - ReedSolomon with various parameters
+    - FlashAttributes with optional nested fields omitted
+    """
+    attributes_json = request.getfixturevalue(attributes_fixture)
+
+    create_resp = await ofrak_client.post(
+        "/create_root_resource", params={"name": f"test_{test_name}"}, data=hello_elf
+    )
+    create_body = await create_resp.json()
+    resource_id = create_body["id"]
+
+    # Add FlashResource tag
+    await ofrak_client.post(
+        f"/{resource_id}/add_tag",
+        json="ofrak.core.flash.FlashResource",
+    )
+
+    # Add attributes
+    resp = await ofrak_client.post(
+        f"/{resource_id}/add_attributes",
+        json={"type": "ofrak.core.flash.FlashAttributes", "attributes": attributes_json},
+    )
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result is not None
+    assert "attributes" in result
+
+
+@pytest.mark.parametrize(
+    "attr_type,error_case",
+    [
+        pytest.param(
+            "ofrak.core.flash.FlashAttributes",
+            "empty_json",
+            id="missing_required_fields",
+        ),
+        pytest.param(
+            "ofrak.core.flash.NonExistentAttributes",
+            "unknown_type",
+            id="unknown_type",
+        ),
+    ],
+)
+async def test_add_flash_attributes_error_handling(
+    ofrak_client: TestClient, hello_elf, attr_type, error_case
+):
+    """Test error handling for invalid attribute configurations.
+
+    Tests cover:
+    - Missing required fields in attribute JSON
+    - Unknown attribute type
+    """
+    create_resp = await ofrak_client.post(
+        "/create_root_resource", params={"name": f"test_error_{error_case}"}, data=hello_elf
+    )
+    create_body = await create_resp.json()
+    resource_id = create_body["id"]
+
+    # Try to add attributes with invalid configuration
+    resp = await ofrak_client.post(
+        f"/{resource_id}/add_attributes",
+        json={"type": attr_type, "attributes": {}},
+    )
+
+    # Should fail due to validation error
+    assert resp.status >= 400
+
+
+async def test_get_all_resource_attributes(ofrak_client: TestClient):
+    """Test retrieving all available resource attribute types."""
+    resp = await ofrak_client.get("/get_all_resource_attributes")
+
+    assert resp.status == 200
+    attribute_types = await resp.json()
+
+    # Verify response structure
+    assert isinstance(attribute_types, list)
+    assert len(attribute_types) > 0
+
+    # Check that each attribute type has required fields
+    for attr_type in attribute_types:
+        assert "type" in attr_type
+        assert "label" in attr_type
+        assert isinstance(attr_type["type"], str)
+        assert isinstance(attr_type["label"], str)
+        # Type should be in format "module.path.ClassName"
+        assert "." in attr_type["type"]
+
+    # Verify FlashAttributes is in the list
+    flash_attr_types = [t for t in attribute_types if "FlashAttributes" in t["type"]]
+    assert len(flash_attr_types) > 0
+
+
+async def test_add_flash_attributes_plain_unpacking(ofrak_client: TestClient):
+    """
+    Test adding FlashAttributes via server endpoint and unpacking.
+
+    This test verifies that:
+    - FlashAttributes can be added via the server endpoint using actual flash_test_plain.bin
+    - Resource can be unpacked after adding attributes
+    - The unpacking produces expected child resources
+    - This mirrors the flash_test_plain test case from test_flash_component.py
+    """
+
+    # Load actual flash_test_plain.bin file
+    plain_test_file = os.path.join(components.ASSETS_DIR, "flash_test_plain.bin")
+    with open(plain_test_file, "rb") as f:
+        plain_test_data = f.read()
+
+    # Create root resource
+    create_resp = await ofrak_client.post(
+        "/create_root_resource", params={"name": "test_plain_unpack"}, data=plain_test_data
+    )
+    assert create_resp.status == 200
+    create_body = await create_resp.json()
+    resource_id = create_body["id"]
+
+    # Add FlashResource tag
+    tag_resp = await ofrak_client.post(
+        f"/{resource_id}/add_tag",
+        json="ofrak.core.flash.FlashResource",
+    )
+    assert tag_resp.status == 200
+
+    # Add FlashAttributes with simple configuration (matches flash_test_plain from test_flash_component.py)
+    attributes_json = {
+        "data_block_format": [
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.DATA", "size": 223},
+            ],
+            [
+                "ofrak.core.flash.FlashField",
+                {"field_type": "ofrak.core.flash.FlashFieldType.ECC", "size": 32},
+            ],
+        ],
+        "ecc_attributes": [
+            "ofrak.core.flash.FlashEccAttributes",
+            {
+                "ecc_class": [
+                    "ofrak.core.ecc.reedsolomon.ReedSolomon",
+                    {"nsym": 32},
+                ]
+            },
+        ],
+    }
+
+    attr_resp = await ofrak_client.post(
+        f"/{resource_id}/add_attributes",
+        json={"type": "ofrak.core.flash.FlashAttributes", "attributes": attributes_json},
+    )
+    assert attr_resp.status == 200
+    attr_body = await attr_resp.json()
+    assert "attributes" in attr_body
+
+    # Attempt to unpack the resource with the added attributes
+    unpack_resp = await ofrak_client.post(f"/{resource_id}/unpack")
+    assert unpack_resp.status == 200
+    unpack_body = await unpack_resp.json()
+    # Unpacking may create resources or not depending on data format
+    assert "created" in unpack_body
+    assert "modified" in unpack_body


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Added `add_attribute` and `get_all_resource_attributes` endpoints to `server.py` and Button/View to GUI to allow adding ResourceAttribtues manually from GUI, supporting certain workflows like flash unpacking ([#573](https://github.com/redballoonsecurity/ofrak/issues/573))   

**Link to Related Issue(s)**
https://github.com/redballoonsecurity/ofrak/issues/573  

**Please describe the changes in your request.**
Added a button to the AttributesView that displays a view that allows users to manually add ResourceAttributes through the GUI. There is a dropdown menu that lists all resource attributes for ease of selection (with hotkeys for search). Nested attributes can be added  through a JSON text input. AttributesView updates automatically after new attributes are added.

Much of the code is largely based on that for the Add Tag functionality, including code in `remote_resource.js` and `AddAttributesView.svelte` (mirrors `AddTagView.svelte`)  

Besides unit tests, for manual testing using `flash_test_plain.bin` do:
1. Add FlashResource tag using toolbar button
2. Add FlashAttributes using new button/view and the following JSON to configure for the test image:
```json
{
    "data_block_format": [
      ["ofrak.core.flash.FlashField", {"field_type": "ofrak.core.flash.FlashFieldType.DATA", "size": 223}],
      ["ofrak.core.flash.FlashField", {"field_type": "ofrak.core.flash.FlashFieldType.ECC", "size": 32}]
    ],
    "ecc_attributes": ["ofrak.core.flash.FlashEccAttributes", 
       {"ecc_class": ["ofrak.core.ecc.reedsolomon.ReedSolomon", {"nsym": 32}]}
    ]
}
```
3. Unpack now works for Flash image.

**Anyone you think should look at this, specifically?**
@whyitfor 