### PR TITLE
Add FlashFieldType.SPARE and FlashSpareAreaResource

### DIFF
--- a/docs/user-guide/advanced/flash_component.md
+++ b/docs/user-guide/advanced/flash_component.md
@@ -55,6 +55,8 @@ class FlashFieldType(Enum):
     CHECKSUM = 6
     DELIMITER = 7
     TOTAL_SIZE = 8
+    SPARE = 9
+    SPARE_SIZE = 10
 ```
 
 - `DATA` is the "useful" information in the dump.
@@ -66,6 +68,8 @@ class FlashFieldType(Enum):
 - `CHECKSUM` ensures that the data is read as expected.
 - `DELIMITER` may be placed between fields in a block or to indicate what type of block it is.
 - `TOTAL_SIZE` indicates the size of the entire region that includes OOB data.
+- `SPARE` is opaque OOB data that should be preserved but not decoded or verified. When a block format contains a `SPARE` field, the unpacker concatenates the spare bytes from every block into a FlashSpareAreaResource sibling of FlashLogicalDataResource. 
+- `SPARE_SIZE` indicates the size of the `SPARE` field.
 
 This class can be overridden or augmented if other field types are encountered.
 

--- a/docs/user-guide/advanced/flash_component.md
+++ b/docs/user-guide/advanced/flash_component.md
@@ -68,7 +68,7 @@ class FlashFieldType(Enum):
 - `CHECKSUM` ensures that the data is read as expected.
 - `DELIMITER` may be placed between fields in a block or to indicate what type of block it is.
 - `TOTAL_SIZE` indicates the size of the entire region that includes OOB data.
-- `SPARE` is opaque OOB data that should be preserved but not decoded or verified. When a block format contains a `SPARE` field, the unpacker concatenates the spare bytes from every block into a `FlashSpareAreaResource` sibling of `FlashLogicalDataResource`. 
+- `SPARE` is opaque OOB data that should be preserved but not decoded or verified. When a block format contains a `SPARE` field, the unpacker concatenates the spare bytes from every block into a `FlashSpareAreaResource` sibling of `FlashLogicalDataResource`. The packer (`FlashLogicalDataResourcePacker`) reads this sibling resource and slices it back into per-block `SPARE` slots so the original OOB layout is reconstructed verbatim, even after modifying the logical data.
 - `SPARE_SIZE` indicates the size of the `SPARE` field.
 
 This class can be overridden or augmented if other field types are encountered.

--- a/docs/user-guide/advanced/flash_component.md
+++ b/docs/user-guide/advanced/flash_component.md
@@ -68,7 +68,7 @@ class FlashFieldType(Enum):
 - `CHECKSUM` ensures that the data is read as expected.
 - `DELIMITER` may be placed between fields in a block or to indicate what type of block it is.
 - `TOTAL_SIZE` indicates the size of the entire region that includes OOB data.
-- `SPARE` is opaque OOB data that should be preserved but not decoded or verified. When a block format contains a `SPARE` field, the unpacker concatenates the spare bytes from every block into a FlashSpareAreaResource sibling of FlashLogicalDataResource. 
+- `SPARE` is opaque OOB data that should be preserved but not decoded or verified. When a block format contains a `SPARE` field, the unpacker concatenates the spare bytes from every block into a `FlashSpareAreaResource` sibling of `FlashLogicalDataResource`. 
 - `SPARE_SIZE` indicates the size of the `SPARE` field.
 
 This class can be overridden or augmented if other field types are encountered.

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
+- Add `FlashFieldType.SPARE` and `FlashSpareAreaResource` so `FlashOobResourceUnpacker` can preserve OOB bytes without ECC/Checksum computation ([#738](https://github.com/redballoonsecurity/ofrak/pull/738))
 - Add cramfs unpacker and packer, using `fsck.cramfs` and `mkfs.cramfs` from `util-linux` 2.38.1 ([#719](https://github.com/redballoonsecurity/ofrak/pull/719))
 - Add ApkAnalyzer to extract package metadata from Android APKs using aapt ([#716](https://github.com/redballoonsecurity/ofrak/pull/716))
 - Add compression level config to `ZipPacker` via `ZipPackerConfig` ([#721](https://github.com/redballoonsecurity/ofrak/pull/721))

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
-- Add `FlashFieldType.SPARE` and `FlashSpareAreaResource` so `FlashOobResourceUnpacker` can preserve OOB bytes without ECC/Checksum computation ([#738](https://github.com/redballoonsecurity/ofrak/pull/738))
+- Add `FlashFieldType.SPARE` and `FlashSpareAreaResource` so `FlashOobResourceUnpacker` can preserve OOB bytes without ECC/Checksum computation, and extend `FlashLogicalDataResourcePacker` to consume the sibling `FlashSpareAreaResource` so the original OOB layout is reconstructed verbatim during repacking ([#738](https://github.com/redballoonsecurity/ofrak/pull/738))
 - Add cramfs unpacker and packer, using `fsck.cramfs` and `mkfs.cramfs` from `util-linux` 2.38.1 ([#719](https://github.com/redballoonsecurity/ofrak/pull/719))
 - Add ApkAnalyzer to extract package metadata from Android APKs using aapt ([#716](https://github.com/redballoonsecurity/ofrak/pull/716))
 - Add compression level config to `ZipPacker` via `ZipPackerConfig` ([#721](https://github.com/redballoonsecurity/ofrak/pull/721))

--- a/ofrak_core/src/ofrak/core/flash.py
+++ b/ofrak_core/src/ofrak/core/flash.py
@@ -596,8 +596,11 @@ class FlashLogicalDataResourcePacker(Packer[None]):
     """
     Packs logical flash data back into the OOB (out-of-band) format, FlashOobResource, by
     recalculating and inserting ECC (Error Correction Code) bytes according to the
-    `FlashAttributes`. Use when recreating flash dumps after modifying the logical data, ensuring
-    ECC is properly calculated for flash device compatibility.
+    `FlashAttributes`. When a sibling `FlashSpareAreaResource` is present, its bytes are sliced
+    in block order and re-emitted into each block's `SPARE` field so that opaque OOB data
+    (which is not regenerable from the logical data) is preserved verbatim. Use when recreating
+    flash dumps after modifying the logical data, ensuring ECC is properly calculated for flash
+    device compatibility.
     """
 
     id = b"FlashLogicalDataResourcePacker"
@@ -614,6 +617,20 @@ class FlashLogicalDataResourcePacker(Packer[None]):
         packed_data = bytearray()
         data_offset = 0
 
+        # If a sibling FlashSpareAreaResource exists, fetch its bytes so we can re-emit
+        # them into each block's SPARE field as we rebuild the OOB layout.
+        parent = await resource.get_parent()
+        spare_data: Optional[bytes] = None
+        try:
+            spare_resource = await parent.get_only_child(
+                r_filter=ResourceFilter.with_tags(FlashSpareAreaResource),
+            )
+        except NotFoundError:
+            spare_resource = None
+        if spare_resource is not None:
+            spare_data = await spare_resource.get_data()
+        spare_offset = 0
+
         for c in flash_attr.iterate_through_all_blocks(original_size, False):
             block_data = b""
             block_data_size = flash_attr.get_field_length_in_block(c, FlashFieldType.DATA)
@@ -623,15 +640,21 @@ class FlashLogicalDataResourcePacker(Packer[None]):
                 data_offset += block_data_size
                 bytes_left -= block_data_size
 
+            block_spare = b""
+            block_spare_size = flash_attr.get_field_length_in_block(c, FlashFieldType.SPARE)
+            if block_spare_size != 0 and spare_data is not None:
+                block_spare = spare_data[spare_offset : spare_offset + block_spare_size]
+                spare_offset += block_spare_size
+
             packed_data += _build_block(
                 cur_block_type=c,
                 attributes=flash_attr,
                 block_data=block_data,
                 original_data=data,
+                block_spare=block_spare,
             )
 
         # Create child under the original FlashOobResource to show that it packed itself
-        parent = await resource.get_parent()
         await parent.create_child(tags=(FlashOobResource,), data=packed_data)
 
 
@@ -732,87 +755,104 @@ def _build_block(
     attributes: FlashAttributes,
     block_data: bytes,
     original_data: bytes,
+    block_spare: bytes = b"",
 ) -> bytes:
     # Update the checksum, even if its not used we use it for tracking if we need it to update ECC
     if attributes is None:
         raise UnpackerError("Cannot pack without providing FlashAttributes")
     data_hash = md5(block_data).digest()
     ecc_attr = attributes.ecc_attributes
+    if ecc_attr is not None and ecc_attr.ecc_class is None:
+        raise UnpackerError("Cannot pack FlashLogicalDataResource without providing ECC class")
     block = b""
-    if ecc_attr is not None:
-        ecc_class = ecc_attr.ecc_class
-        if ecc_class is None:
-            raise UnpackerError("Cannot pack FlashLogicalDataResource without providing ECC class")
-        for field in cur_block_type:
-            if field is not None:
-                f = field.field_type
-                f_size = field.size
-                if f is FlashFieldType.ALIGNMENT:
-                    block += b"\x00" * f_size
-                elif f is FlashFieldType.CHECKSUM:
-                    if attributes.checksum_func is not None:
-                        block += attributes.checksum_func(original_data)
-                elif f is FlashFieldType.DATA:
-                    expected_data_size = attributes.get_field_length_in_block(
-                        cur_block_type, FlashFieldType.DATA
+    for field in cur_block_type:
+        if field is not None:
+            f = field.field_type
+            f_size = field.size
+            if f is FlashFieldType.ALIGNMENT:
+                block += b"\x00" * f_size
+            elif f is FlashFieldType.CHECKSUM:
+                if attributes.checksum_func is not None:
+                    block += attributes.checksum_func(original_data)
+            elif f is FlashFieldType.DATA:
+                expected_data_size = attributes.get_field_length_in_block(
+                    cur_block_type, FlashFieldType.DATA
+                )
+                real_data_len = len(block_data)
+                if real_data_len < expected_data_size:
+                    cur_block_data = bytearray(expected_data_size)
+                    cur_block_data[:real_data_len] = block_data
+                    block_data = cur_block_data
+                block += block_data
+            elif f is FlashFieldType.DATA_SIZE:
+                block += len(original_data).to_bytes(f_size, "big")
+            elif f is FlashFieldType.DELIMITER:
+                if ecc_attr is None:
+                    raise PackerError(
+                        "Tried to add delimiter without specifying in FlashEccAttributes"
                     )
-                    real_data_len = len(block_data)
-                    if real_data_len < expected_data_size:
-                        cur_block_data = bytearray(expected_data_size)
-                        cur_block_data[:real_data_len] = block_data
-                        block_data = cur_block_data
-                    block += block_data
-                elif f is FlashFieldType.DATA_SIZE:
-                    block += len(original_data).to_bytes(f_size, "big")
-                elif f is FlashFieldType.DELIMITER:
-                    if cur_block_type == attributes.header_block_format:
-                        delimiter = ecc_attr.head_delimiter
-                    elif cur_block_type == attributes.first_data_block_format:
-                        delimiter = ecc_attr.first_data_delimiter
-                    elif cur_block_type == attributes.data_block_format:
-                        delimiter = ecc_attr.data_delimiter
-                    elif cur_block_type == attributes.last_data_block_format:
-                        delimiter = ecc_attr.last_data_delimiter
-                    elif cur_block_type == attributes.tail_block_format:
-                        delimiter = ecc_attr.tail_delimiter
-                    else:
+                if cur_block_type == attributes.header_block_format:
+                    delimiter = ecc_attr.head_delimiter
+                elif cur_block_type == attributes.first_data_block_format:
+                    delimiter = ecc_attr.first_data_delimiter
+                elif cur_block_type == attributes.data_block_format:
+                    delimiter = ecc_attr.data_delimiter
+                elif cur_block_type == attributes.last_data_block_format:
+                    delimiter = ecc_attr.last_data_delimiter
+                elif cur_block_type == attributes.tail_block_format:
+                    delimiter = ecc_attr.tail_delimiter
+                else:
+                    raise PackerError(
+                        "Tried to add delimiter without specifying in FlashEccAttributes"
+                    )
+                if delimiter is not None:
+                    block += delimiter
+            elif f is FlashFieldType.ECC:
+                if ecc_attr is None:
+                    raise PackerError(
+                        "Cannot pack FlashLogicalDataResource without providing ECC class"
+                    )
+                if data_hash in DATA_HASHES:
+                    ecc = DATA_HASHES[data_hash]
+                else:
+                    # Assumes that all previously added data in the block should be included in the ECC
+                    # TODO: Support ECC that comes before data
+                    try:
+                        if ecc_attr.ecc_class is not None:
+                            ecc = ecc_attr.ecc_class.encode(block)
+                    except TypeError:
                         raise PackerError(
-                            "Tried to add delimiter without specifying in FlashEccAttributes"
+                            "Tried to encode ECC without specifying ecc_class in FlashEccAttributes"
                         )
-                    if delimiter is not None:
-                        block += delimiter
-                elif f is FlashFieldType.ECC:
-                    if data_hash in DATA_HASHES:
-                        ecc = DATA_HASHES[data_hash]
-                    else:
-                        # Assumes that all previously added data in the block should be included in the ECC
-                        # TODO: Support ECC that comes before data
-                        try:
-                            if ecc_attr.ecc_class is not None:
-                                ecc = ecc_attr.ecc_class.encode(block)
-                        except TypeError:
-                            raise PackerError(
-                                "Tried to encode ECC without specifying ecc_class in FlashEccAttributes"
-                            )
-                    block += ecc
-                elif f is FlashFieldType.ECC_SIZE:
-                    block_ecc_field = attributes.get_field_in_block(
-                        cur_block_type, FlashFieldType.ECC
-                    )
-                    if block_ecc_field is not None:
-                        block += block_ecc_field.size.to_bytes(f_size, "big")
-                elif f is FlashFieldType.TOTAL_SIZE:
-                    data_size = len(original_data)
-                    oob_size = attributes.get_total_oob_size(data_len=data_size)
-                    expected_data_size = attributes.get_total_field_size(
-                        data_len=data_size, field_type=FlashFieldType.DATA
-                    )
-                    total_size = expected_data_size + oob_size
-                    block += (total_size).to_bytes(f_size, "big")
-                elif f is FlashFieldType.MAGIC:
-                    if ecc_attr.ecc_magic is None:
-                        raise PackerError(
-                            "Tried to add Magic without specifying in FlashEccAttributes"
-                        )
-                    block += ecc_attr.ecc_magic
+                block += ecc
+            elif f is FlashFieldType.ECC_SIZE:
+                block_ecc_field = attributes.get_field_in_block(cur_block_type, FlashFieldType.ECC)
+                if block_ecc_field is not None:
+                    block += block_ecc_field.size.to_bytes(f_size, "big")
+            elif f is FlashFieldType.TOTAL_SIZE:
+                data_size = len(original_data)
+                oob_size = attributes.get_total_oob_size(data_len=data_size)
+                expected_data_size = attributes.get_total_field_size(
+                    data_len=data_size, field_type=FlashFieldType.DATA
+                )
+                total_size = expected_data_size + oob_size
+                block += (total_size).to_bytes(f_size, "big")
+            elif f is FlashFieldType.MAGIC:
+                if ecc_attr is None or ecc_attr.ecc_magic is None:
+                    raise PackerError("Tried to add Magic without specifying in FlashEccAttributes")
+                block += ecc_attr.ecc_magic
+            elif f is FlashFieldType.SPARE:
+                real_spare_len = len(block_spare)
+                if real_spare_len < f_size:
+                    cur_block_spare = bytearray(f_size)
+                    cur_block_spare[:real_spare_len] = block_spare
+                    block += bytes(cur_block_spare)
+                else:
+                    block += bytes(block_spare[:f_size])
+            elif f is FlashFieldType.SPARE_SIZE:
+                block_spare_field = attributes.get_field_in_block(
+                    cur_block_type, FlashFieldType.SPARE
+                )
+                if block_spare_field is not None:
+                    block += block_spare_field.size.to_bytes(f_size, "big")
     return block

--- a/ofrak_core/src/ofrak/core/flash.py
+++ b/ofrak_core/src/ofrak/core/flash.py
@@ -70,6 +70,14 @@ class FlashLogicalEccResource(GenericBinary):
     """
 
 
+@dataclass
+class FlashSpareAreaResource(GenericBinary):
+    """
+    Represents spare area data that is not part of the logical data.
+    Is meant to be used when we don't want to discard the spare area.
+    """
+
+
 #####################
 #     ATTRIBUTES    #
 #####################
@@ -105,6 +113,8 @@ class FlashFieldType(Enum):
     CHECKSUM = 6
     DELIMITER = 7
     TOTAL_SIZE = 8
+    SPARE = 9
+    SPARE_SIZE = 10
 
 
 @dataclass
@@ -420,6 +430,7 @@ class FlashOobResourceUnpacker(Unpacker[None]):
     children = (
         FlashLogicalDataResource,
         FlashLogicalEccResource,
+        FlashSpareAreaResource,
     )
 
     async def unpack(self, resource: Resource, config=None):
@@ -438,6 +449,7 @@ class FlashOobResourceUnpacker(Unpacker[None]):
         offset = 0
         only_data = list()
         only_ecc = list()
+        only_spare = list()
         for block in flash_attr.iterate_through_all_blocks(data_len, True):
             block_size = flash_attr.get_block_size(block)
             block_end_offset = offset + block_size
@@ -498,6 +510,8 @@ class FlashOobResourceUnpacker(Unpacker[None]):
                     else:
                         # No ECC found in block, just add the data directly
                         only_data.append(block_data[block_data_range.start : block_data_range.end])
+                if field.field_type == FlashFieldType.SPARE:
+                    only_spare.append(block_data[field_range.start : field_range.end])
                 field_offset += field.size
             offset += block_size
 
@@ -515,6 +529,14 @@ class FlashOobResourceUnpacker(Unpacker[None]):
                 data=b"".join(only_ecc),
                 attributes=[
                     ecc_attr,
+                ],
+            )
+        if only_spare:
+            await oob_resource.create_child(
+                tags=(FlashSpareAreaResource,),
+                data=b"".join(only_spare),
+                attributes=[
+                    flash_attr,
                 ],
             )
 

--- a/ofrak_core/tests/components/test_flash_component.py
+++ b/ofrak_core/tests/components/test_flash_component.py
@@ -9,6 +9,7 @@ Requirements Mapping:
 
 import pytest
 import os
+from abc import ABC
 from hashlib import md5
 
 from .. import components
@@ -276,78 +277,90 @@ class TestFlashSpareAreaUnpacker:
         assert ecc_descendants == []
 
 
-class TestFlashSpareAreaPacker:
+class _SpareUMPBase(UnpackModifyPackPattern, ABC):
     """
-    Exercises `FlashLogicalDataResourcePacker` for block formats that declare a `SPARE` field.
-    The packer must consume the sibling `FlashSpareAreaResource` and re-emit each per-block
-    spare slice into its original position so the OOB layout is reconstructed verbatim.
+    Shared scaffolding for `FlashLogicalDataResourcePacker` tests that exercise block formats
+    declaring a `SPARE` field. The packer must consume the sibling `FlashSpareAreaResource`
+    and re-emit each per-block spare slice into its original position so the OOB layout is
+    reconstructed verbatim. Subclasses provide `modify` and `verify` to express each scenario.
     """
 
-    async def _build_root(self, ofrak_context: OFRAKContext) -> Resource:
+    async def create_root_resource(self, ofrak_context: OFRAKContext) -> Resource:
         root = await ofrak_context.create_root_resource_from_file(SPARE_TEST_FILE)
         root.add_tag(FlashResource)
         root.add_attributes(SPARE_TEST_ATTR)
         await root.save()
-        await root.unpack_recursively()
         return root
 
-    async def test_pack_roundtrips_without_modification(self, ofrak_context: OFRAKContext):
-        """
-        Unpack and immediately repack with no modifications; the packed bytes must equal the
-        original file byte-for-byte (DATA from `FlashLogicalDataResource`, SPARE from
-        `FlashSpareAreaResource`).
-        """
+    async def unpack(self, root_resource: Resource) -> None:
+        await root_resource.unpack_recursively()
+
+    async def repack(self, modified_root_resource: Resource) -> None:
+        await modified_root_resource.pack_recursively()
+
+
+class TestFlashSpareAreaPackerRoundtrip(_SpareUMPBase):
+    """
+    Unpack and immediately repack with no modifications; the packed bytes must equal the
+    original file byte-for-byte (DATA from `FlashLogicalDataResource`, SPARE from
+    `FlashSpareAreaResource`).
+    """
+
+    async def modify(self, unpacked_root_resource: Resource) -> None:
+        pass
+
+    async def verify(self, repacked_root_resource: Resource) -> None:
         with open(SPARE_TEST_FILE, "rb") as f:
             original = f.read()
-
-        root = await self._build_root(ofrak_context)
-        await root.pack_recursively()
-
-        repacked = await root.get_data()
+        repacked = await repacked_root_resource.get_data()
         assert repacked == original
 
-    async def test_pack_preserves_spare_after_data_modification(self, ofrak_context: OFRAKContext):
-        """
-        Modifying logical data must not disturb the spare-area bytes: the per-block OOB regions
-        in the repacked dump should match the original file's OOB regions exactly.
-        """
+
+class TestFlashSpareAreaPackerLogicalDataPatch(_SpareUMPBase):
+    """
+    Modifying logical data must not disturb the spare-area bytes: the per-block OOB regions
+    in the repacked dump should match the original file's OOB regions exactly.
+    """
+
+    PATCH_OFFSET = 0x10
+    PATCH = b"PATCHED!"
+
+    async def modify(self, unpacked_root_resource: Resource) -> None:
+        logical = await unpacked_root_resource.get_only_descendant(
+            r_filter=ResourceFilter.with_tags(FlashLogicalDataResource),
+        )
+        await logical.run(BinaryPatchModifier, BinaryPatchConfig(self.PATCH_OFFSET, self.PATCH))
+
+    async def verify(self, repacked_root_resource: Resource) -> None:
         with open(SPARE_TEST_FILE, "rb") as f:
             original = f.read()
         _, expected_spare = _split_blocks(original, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
-
-        root = await self._build_root(ofrak_context)
-        logical = await root.get_only_descendant(
-            r_filter=ResourceFilter.with_tags(FlashLogicalDataResource),
-        )
-        patch = b"PATCHED!"
-        await logical.run(BinaryPatchModifier, BinaryPatchConfig(0x10, patch))
-
-        await root.pack_recursively()
-        repacked = await root.get_data()
+        repacked = await repacked_root_resource.get_data()
 
         assert len(repacked) == len(original)
         repacked_data, repacked_spare = _split_blocks(repacked, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
         assert repacked_spare == expected_spare
-        assert repacked_data[0x10 : 0x10 + len(patch)] == patch
+        assert repacked_data[self.PATCH_OFFSET : self.PATCH_OFFSET + len(self.PATCH)] == self.PATCH
 
-    async def test_pack_propagates_spare_modification(self, ofrak_context: OFRAKContext):
-        """
-        Modifying the spare-area resource directly must round-trip into the packed image at
-        the corresponding per-block OOB offsets, while logical data stays intact.
-        """
-        with open(SPARE_TEST_FILE, "rb") as f:
-            original = f.read()
-        expected_data, expected_spare = _split_blocks(original, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
 
-        root = await self._build_root(ofrak_context)
-        spare = await root.get_only_descendant(
+class TestFlashSpareAreaPackerSparePatch(_SpareUMPBase):
+    """
+    Modifying the spare-area resource directly must round-trip into the packed image at
+    the corresponding per-block OOB offsets, while logical data stays intact.
+    """
+
+    async def modify(self, unpacked_root_resource: Resource) -> None:
+        spare = await unpacked_root_resource.get_only_descendant(
             r_filter=ResourceFilter.with_tags(FlashSpareAreaResource),
         )
         # Patch the very first byte of the very first block's spare region.
         await spare.run(BinaryPatchModifier, BinaryPatchConfig(0, b"\xAB"))
 
-        await root.pack_recursively()
-        repacked = await root.get_data()
+    async def verify(self, repacked_root_resource: Resource) -> None:
+        with open(SPARE_TEST_FILE, "rb") as f:
+            original = f.read()
+        expected_data, expected_spare = _split_blocks(original, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
+        repacked = await repacked_root_resource.get_data()
 
         assert len(repacked) == len(original)
         repacked_data, repacked_spare = _split_blocks(repacked, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)

--- a/ofrak_core/tests/components/test_flash_component.py
+++ b/ofrak_core/tests/components/test_flash_component.py
@@ -276,6 +276,85 @@ class TestFlashSpareAreaUnpacker:
         assert ecc_descendants == []
 
 
+class TestFlashSpareAreaPacker:
+    """
+    Exercises `FlashLogicalDataResourcePacker` for block formats that declare a `SPARE` field.
+    The packer must consume the sibling `FlashSpareAreaResource` and re-emit each per-block
+    spare slice into its original position so the OOB layout is reconstructed verbatim.
+    """
+
+    async def _build_root(self, ofrak_context: OFRAKContext) -> Resource:
+        root = await ofrak_context.create_root_resource_from_file(SPARE_TEST_FILE)
+        root.add_tag(FlashResource)
+        root.add_attributes(SPARE_TEST_ATTR)
+        await root.save()
+        await root.unpack_recursively()
+        return root
+
+    async def test_pack_roundtrips_without_modification(self, ofrak_context: OFRAKContext):
+        """
+        Unpack and immediately repack with no modifications; the packed bytes must equal the
+        original file byte-for-byte (DATA from `FlashLogicalDataResource`, SPARE from
+        `FlashSpareAreaResource`).
+        """
+        with open(SPARE_TEST_FILE, "rb") as f:
+            original = f.read()
+
+        root = await self._build_root(ofrak_context)
+        await root.pack_recursively()
+
+        repacked = await root.get_data()
+        assert repacked == original
+
+    async def test_pack_preserves_spare_after_data_modification(self, ofrak_context: OFRAKContext):
+        """
+        Modifying logical data must not disturb the spare-area bytes: the per-block OOB regions
+        in the repacked dump should match the original file's OOB regions exactly.
+        """
+        with open(SPARE_TEST_FILE, "rb") as f:
+            original = f.read()
+        _, expected_spare = _split_blocks(original, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
+
+        root = await self._build_root(ofrak_context)
+        logical = await root.get_only_descendant(
+            r_filter=ResourceFilter.with_tags(FlashLogicalDataResource),
+        )
+        patch = b"PATCHED!"
+        await logical.run(BinaryPatchModifier, BinaryPatchConfig(0x10, patch))
+
+        await root.pack_recursively()
+        repacked = await root.get_data()
+
+        assert len(repacked) == len(original)
+        repacked_data, repacked_spare = _split_blocks(repacked, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
+        assert repacked_spare == expected_spare
+        assert repacked_data[0x10 : 0x10 + len(patch)] == patch
+
+    async def test_pack_propagates_spare_modification(self, ofrak_context: OFRAKContext):
+        """
+        Modifying the spare-area resource directly must round-trip into the packed image at
+        the corresponding per-block OOB offsets, while logical data stays intact.
+        """
+        with open(SPARE_TEST_FILE, "rb") as f:
+            original = f.read()
+        expected_data, expected_spare = _split_blocks(original, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
+
+        root = await self._build_root(ofrak_context)
+        spare = await root.get_only_descendant(
+            r_filter=ResourceFilter.with_tags(FlashSpareAreaResource),
+        )
+        # Patch the very first byte of the very first block's spare region.
+        await spare.run(BinaryPatchModifier, BinaryPatchConfig(0, b"\xAB"))
+
+        await root.pack_recursively()
+        repacked = await root.get_data()
+
+        assert len(repacked) == len(original)
+        repacked_data, repacked_spare = _split_blocks(repacked, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
+        assert repacked_data == expected_data
+        assert repacked_spare == b"\xAB" + expected_spare[1:]
+
+
 class TestFlashUnpackModifyPackUnpackVerify(TestFlashUnpackModifyPack):
     async def test_unpack_modify_pack(self, ofrak_context):
         """

--- a/ofrak_core/tests/components/test_flash_component.py
+++ b/ofrak_core/tests/components/test_flash_component.py
@@ -17,6 +17,8 @@ from ofrak.resource import Resource
 from ofrak.core.flash import (
     FlashResource,
     FlashLogicalDataResource,
+    FlashLogicalEccResource,
+    FlashSpareAreaResource,
     FlashAttributes,
     FlashEccAttributes,
     FlashField,
@@ -208,6 +210,70 @@ class TestFlashUnpackModifyPack(UnpackModifyPackPattern):
         repacked_data = await repacked_resource.get_data()
 
         assert verified_data == repacked_data
+
+
+SPARE_TEST_FILE = os.path.join(components.ASSETS_DIR, "flash_test_plain.bin")
+SPARE_BLOCK_DATA = 223
+SPARE_BLOCK_OOB = 32
+SPARE_BLOCK_TOTAL = SPARE_BLOCK_DATA + SPARE_BLOCK_OOB  # 255
+SPARE_TEST_ATTR = FlashAttributes(
+    data_block_format=[
+        FlashField(FlashFieldType.DATA, SPARE_BLOCK_DATA),
+        FlashField(FlashFieldType.SPARE, SPARE_BLOCK_OOB),
+    ],
+)
+
+
+def _split_blocks(raw: bytes, block_size: int, data_size: int):
+    data_parts = []
+    spare_parts = []
+    for off in range(0, len(raw), block_size):
+        block = raw[off : off + block_size]
+        data_parts.append(block[:data_size])
+        spare_parts.append(block[data_size:])
+    return b"".join(data_parts), b"".join(spare_parts)
+
+
+class TestFlashSpareAreaUnpacker:
+    async def test_spare_field_creates_spare_resource(self, ofrak_context: OFRAKContext):
+        """
+        Asserts that a `FlashAttributes` with a `SPARE` field (and no `ecc_attributes`) causes
+        `FlashOobResourceUnpacker` to emit a `FlashSpareAreaResource` containing the raw
+        per-block OOB bytes verbatim, with no ECC decode or checksum verification.
+        """
+        with open(SPARE_TEST_FILE, "rb") as f:
+            raw = f.read()
+        assert (
+            len(raw) % SPARE_BLOCK_TOTAL == 0
+        ), f"Asset size {len(raw)} is not a multiple of {SPARE_BLOCK_TOTAL}"
+        expected_data, expected_spare = _split_blocks(raw, SPARE_BLOCK_TOTAL, SPARE_BLOCK_DATA)
+
+        root = await ofrak_context.create_root_resource_from_file(SPARE_TEST_FILE)
+        root.add_tag(FlashResource)
+        root.add_attributes(SPARE_TEST_ATTR)
+        await root.save()
+        await root.unpack_recursively()
+
+        logical = await root.get_only_descendant(
+            r_filter=ResourceFilter.with_tags(FlashLogicalDataResource),
+        )
+        spare = await root.get_only_descendant(
+            r_filter=ResourceFilter.with_tags(FlashSpareAreaResource),
+        )
+
+        logical_bytes = await logical.get_data()
+        spare_bytes = await spare.get_data()
+
+        assert logical_bytes == expected_data
+        assert spare_bytes == expected_spare
+
+        # No ECC resource should be created when ecc_attributes is unset.
+        ecc_descendants = list(
+            await root.get_descendants(
+                r_filter=ResourceFilter.with_tags(FlashLogicalEccResource),
+            )
+        )
+        assert ecc_descendants == []
 
 
 class TestFlashUnpackModifyPackUnpackVerify(TestFlashUnpackModifyPack):


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**
Add `FlashFieldType.SPARE` and `FlashSpareAreaResource` so `FlashOobResourceUnpacker` can preserve OOB bytes without ECC/Checksum computation

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
- New `FlashFieldType.SPARE` (and `SPARE_SIZE`) enum member, plus a `FlashSpareAreaResource` dataclass.
- `FlashOobResourceUnpacker` now recognizes `SPARE` fields and emits a `FlashSpareAreaResource` sibling of `FlashLogicalDataResource` containing the raw per-block OOB bytes concatenated across blocks. No ECC decoding or checksum computation is performed for `SPARE`.
- Documentation in `docs/user-guide/advanced/flash_component.md` updated with the new enum members

**Anyone you think should look at this, specifically?**
@rbs-jacob 