### PR TITLE
Fix typo in CPIO packer's `find` command

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Explicitly raise ValueError if ubireader guess_leb_size/guess_peb_size returns None ([#714](https://github.com/redballoonsecurity/ofrak/pull/714))
 - `build_image.py` uses `OFRAK_DIR` from `extra_build_args` to identify `pytest_ofrak` location for develop builds ([#657](https://github.com/redballoonsecurity/ofrak/pull/657/))
 - Pin Pygments==2.19.2 for OFRAK docs ([#728](https://github.com/redballoonsecurity/ofrak/pull/728))
+- Fix typo in `find` command used by CPIO packer ([#740](https://github.com/redballoonsecurity/ofrak/pull/740))
 
 ## [3.3.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.2.0...ofrak-v3.3.0) - 2025-10-03
 

--- a/ofrak_core/src/ofrak/core/cpio.py
+++ b/ofrak_core/src/ofrak/core/cpio.py
@@ -136,6 +136,7 @@ class CpioPacker(Packer[None]):
         cpio_format = cpio_v.archive_type.value
         list_files_cmd = [
             "find",
+            ".",
             "-print",
         ]
         list_files_proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix typo in CPIO packer's `find` command.

[Introduced in `7906ec5b6`.](https://github.com/redballoonsecurity/ofrak/commit/7906ec5b6f582cd6b2bd156bbcfb211f144b1408#diff-4ce2ffab5c36b69f08df8d0e274865bf9085509e0babbefb9ceefe85ecd9a82fL113-R123)

**Anyone you think should look at this, specifically?**

@rbs-andre 