### PR TITLE
Patchmaker: prevent emission of NEON instructions (aarch64)

### DIFF
--- a/ofrak_patch_maker/CHANGELOG.md
+++ b/ofrak_patch_maker/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to `ofrak-patch-maker` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+### Fixed
+- Patchmaker: prevent emission of NEON instructions (aarch64) ([#742](https://github.com/redballoonsecurity/ofrak/pull/742))
+
 ## [4.1.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-patch-maker-v.4.0.2...ofrak-patch-maker-v.4.1.0) - 2025-10-03
 
 ### Added

--- a/ofrak_patch_maker/setup.py
+++ b/ofrak_patch_maker/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as f:
 
 setuptools.setup(
     name="ofrak_patch_maker",
-    version="4.1.0",
+    version="4.1.1rc0",
     description="PatchMaker tool for applying source-code patches to binaries",
     packages=setuptools.find_packages("src"),
     package_dir={"": "src"},

--- a/ofrak_patch_maker/src/ofrak_patch_maker/toolchain/gnu_aarch64.py
+++ b/ofrak_patch_maker/src/ofrak_patch_maker/toolchain/gnu_aarch64.py
@@ -21,6 +21,9 @@ class GNU_AARCH64_LINUX_10_Toolchain(GNU_10_Toolchain):
         self._compiler_flags.append("-mno-outline-atomics")
         # Force literal pools at end of functions, rather than .rodata
         self._compiler_flags.append("-mpc-relative-literal-loads")
+        # On aarch64, prevent the compiler from emitting NEON/FP/SIMD instructions unless hard_float is set.
+        if not self._config.hard_float:
+            self._compiler_flags.append("-mgeneral-regs-only")
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Patchmaker: prevent emission of NEON instructions (aarch64).

**Link to Related Issue(s)**

(None)

**Please describe the changes in your request.**

In the aarch64 toolchain, pass `-mgeneral-regs-only` unless the `hard_float` config is set. That way, the patchmaker will not generate floating-point instructions or use floating-point registers.

**Anyone you think should look at this, specifically?**

No