### PR TITLE
Fix hashlib calls when using FIPS OpenSSL

### DIFF
--- a/disassemblers/ofrak_cached_disassembly/CHANGELOG.md
+++ b/disassemblers/ofrak_cached_disassembly/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to `ofrak-cached-disassembly` will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.0 - 2025-07-25
+## [Unreleased 0.2.0rc1](https://github.com/redballoonsecurity/ofrak/tree/master)
+
+### Fixed
+- Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
+
+## 0.1.0 - 2025-07-25
 ### Added
 Initial release. Hello world!

--- a/disassemblers/ofrak_cached_disassembly/setup.py
+++ b/disassemblers/ofrak_cached_disassembly/setup.py
@@ -21,7 +21,7 @@ with open("LICENSE") as f:
 
 setuptools.setup(
     name="ofrak_cached_disassembly",
-    version="0.1.0",
+    version="0.2.0rc1",
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",
     description="OFRAK Disassembler Components for Cached Results",

--- a/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
+++ b/disassemblers/ofrak_cached_disassembly/src/ofrak_cached_disassembly/components/cached_disassembly_unpacker.py
@@ -98,7 +98,7 @@ class CachedAnalysisAnalyzer(Analyzer[CachedAnalysisAnalyzerConfig, CachedAnalys
 
     async def verify_cache_file(self, resource: Resource):
         data = await resource.get_data()
-        md5_hash = hashlib.md5(data)
+        md5_hash = hashlib.md5(data, usedforsecurity=False)
         return (
             md5_hash.digest().hex()
             == self.analysis_store.get_analysis(resource.get_id())["metadata"]["hash"]

--- a/disassemblers/ofrak_ghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_ghidra/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Pin java version ([#683](https://github.com/redballoonsecurity/ofrak/pull/683))
 - Fix duplicate import and integer overflow in CreateMemoryBlocks.java and GetDecompilation.java ([#700](https://github.com/redballoonsecurity/ofrak/pull/700))
 - Fix issue installing JDK in AARCH64 Docker build ([#718](https://github.com/redballoonsecurity/ofrak/pull/718))
+- Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
 
 ## 0.1.1 - 2024-02-15
 ### Added

--- a/disassemblers/ofrak_ghidra/setup.py
+++ b/disassemblers/ofrak_ghidra/setup.py
@@ -21,7 +21,7 @@ with open("LICENSE") as f:
 
 setuptools.setup(
     name="ofrak_ghidra",
-    version="0.2.0rc6",
+    version="0.2.0rc7",
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",
     description="OFRAK Ghidra Components",

--- a/disassemblers/ofrak_ghidra/src/ofrak_ghidra/components/ghidra_analyzer.py
+++ b/disassemblers/ofrak_ghidra/src/ofrak_ghidra/components/ghidra_analyzer.py
@@ -122,7 +122,7 @@ class GhidraProjectAnalyzer(Analyzer[None, GhidraProject]):
         else:
             tmp_dir = tempfile.TemporaryDirectory()
             data = await resource.get_data()
-            hash_sha256 = hashlib.sha256()
+            hash_sha256 = hashlib.sha256(usedforsecurity=False)
             hash_sha256.update(data)
 
             fname = name if name is not None else hash_sha256.hexdigest()

--- a/disassemblers/ofrak_pyghidra/CHANGELOG.md
+++ b/disassemblers/ofrak_pyghidra/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to `ofrak-pyghidra` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased 0.2.0rc5](https://github.com/redballoonsecurity/ofrak/tree/master)
+## [Unreleased 0.2.0rc6](https://github.com/redballoonsecurity/ofrak/tree/master)
 
 ### Added
 - Add a PyGhidra custom load analyzer to allow for loading programs with a custom layout ([#677](https://github.com/redballoonsecurity/ofrak/pull/677))
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix auto discovery of `PyGhidraDecompilationAnalyzer` ([#650](https://github.com/redballoonsecurity/ofrak/pull/650))
 - Fix redundant re-analysis of complex blocks in the standalone analysis script ([#672](https://github.com/redballoonsecurity/ofrak/pull/672))
 - Pin Jpype1 (transitive dependency via PyGhidra) ([#736](https://github.com/redballoonsecurity/ofrak/pull/736))
+- Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
 
 ### Changed
 - Reduce the decompilation time of PyGhidra by reusing cached unpacking results. ([#623](https://github.com/redballoonsecurity/ofrak/pull/623))

--- a/disassemblers/ofrak_pyghidra/setup.py
+++ b/disassemblers/ofrak_pyghidra/setup.py
@@ -21,7 +21,7 @@ with open("LICENSE") as f:
 
 setuptools.setup(
     name="ofrak_pyghidra",
-    version="0.2.0rc5",
+    version="0.2.0rc6",
     author="Red Balloon Security",
     author_email="ofrak@redballoonsecurity.com",
     description="OFRAK PyGhidra Components",

--- a/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
+++ b/disassemblers/ofrak_pyghidra/src/ofrak_pyghidra/standalone/pyghidra_analysis.py
@@ -121,7 +121,7 @@ def unpack(
                 main_dictionary["metadata"]["base_address"] = base_address
             with open(program_file, "rb") as fh:
                 data = fh.read()
-                md5_hash = hashlib.md5(data)
+                md5_hash = hashlib.md5(data, usedforsecurity=False)
                 main_dictionary["metadata"]["hash"] = md5_hash.digest().hex()
 
             LOGGER.info(f"Program contains {len(code_regions)} code regions")

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -221,7 +221,7 @@ def test_example_9(tmp_path):
         data = f.read()
         expected_string = b"INSERT ME!"
         assert expected_string in data, f"{str(file)} doesn't contain the {expected_string} string"
-        md5sum = md5(data).hexdigest()
+        md5sum = md5(data, usedforsecurity=False).hexdigest()
         expected_md5 = "6277eb7c64b12f247913eb4e875f5758"
         assert (
             md5sum == expected_md5

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `build_image.py` uses `OFRAK_DIR` from `extra_build_args` to identify `pytest_ofrak` location for develop builds ([#657](https://github.com/redballoonsecurity/ofrak/pull/657/))
 - Pin Pygments==2.19.2 for OFRAK docs ([#728](https://github.com/redballoonsecurity/ofrak/pull/728))
 - Fix typo in `find` command used by CPIO packer ([#740](https://github.com/redballoonsecurity/ofrak/pull/740))
+- Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
 
 ## [3.3.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.2.0...ofrak-v3.3.0) - 2025-10-03
 

--- a/ofrak_core/src/ofrak/core/checksum.py
+++ b/ofrak_core/src/ofrak/core/checksum.py
@@ -26,7 +26,7 @@ class Sha256Analyzer(Analyzer[None, Sha256Attributes]):
 
     async def analyze(self, resource: Resource, config=None) -> Sha256Attributes:
         data = await resource.get_data()
-        sha256 = hashlib.sha256()
+        sha256 = hashlib.sha256(usedforsecurity=False)
         sha256.update(data)
         return Sha256Attributes(sha256.hexdigest())
 
@@ -49,6 +49,6 @@ class Md5Analyzer(Analyzer[None, Md5Attributes]):
 
     async def analyze(self, resource: Resource, config=None) -> Md5Attributes:
         data = await resource.get_data()
-        md5 = hashlib.md5()
+        md5 = hashlib.md5(usedforsecurity=False)
         md5.update(data)
         return Md5Attributes(md5.hexdigest())

--- a/ofrak_core/src/ofrak/core/flash/flash.py
+++ b/ofrak_core/src/ofrak/core/flash/flash.py
@@ -476,7 +476,9 @@ class FlashOobResourceUnpacker(Unpacker[None]):
                     cur_block_ecc = block_data[block_ecc_range.start : block_ecc_range.end]
                     only_ecc.append(cur_block_ecc)
                     # Add hash of everything up to the ECC to our dict for faster packing
-                    block_data_hash = md5(block_data[: block_ecc_range.start]).digest()
+                    block_data_hash = md5(
+                        block_data[: block_ecc_range.start], usedforsecurity=False
+                    ).digest()
                     DATA_HASHES[block_data_hash] = cur_block_ecc
 
                 if field.field_type == FlashFieldType.DATA:
@@ -760,7 +762,7 @@ def _build_block(
     # Update the checksum, even if its not used we use it for tracking if we need it to update ECC
     if attributes is None:
         raise UnpackerError("Cannot pack without providing FlashAttributes")
-    data_hash = md5(block_data).digest()
+    data_hash = md5(block_data, usedforsecurity=False).digest()
     ecc_attr = attributes.ecc_attributes
     if ecc_attr is not None and ecc_attr.ecc_class is None:
         raise UnpackerError("Cannot pack FlashLogicalDataResource without providing ECC class")

--- a/ofrak_core/src/ofrak/resource.py
+++ b/ofrak_core/src/ofrak/resource.py
@@ -1710,7 +1710,7 @@ async def _default_summarize_resource(resource: Resource) -> str:
             else:
                 data_string = f"data_hex={data.hex()}"
         else:
-            sha256 = hashlib.sha256()
+            sha256 = hashlib.sha256(usedforsecurity=False)
             sha256.update(data)
             data_string = f"data_hash={sha256.hexdigest()[:8]}"
         data_info = (

--- a/ofrak_core/tests/components/test_flash_component.py
+++ b/ofrak_core/tests/components/test_flash_component.py
@@ -69,7 +69,7 @@ DEFAULT_TEST_ATTR = FlashAttributes(
         last_data_delimiter=b"$",
         tail_delimiter=b"!",
     ),
-    checksum_func=(lambda x: md5(x).digest()),
+    checksum_func=(lambda x: md5(x, usedforsecurity=False).digest()),
 )
 
 FLASH_TEST_CASES = [
@@ -120,7 +120,7 @@ FLASH_TEST_CASES = [
             ecc_attributes=FlashEccAttributes(
                 ecc_class=ReedSolomon(nsym=32, fcr=1),
             ),
-            checksum_func=(lambda x: md5(x).digest()),
+            checksum_func=(lambda x: md5(x, usedforsecurity=False).digest()),
         ),
     ),
     (
@@ -156,7 +156,7 @@ FLASH_TEST_CASES = [
                 data_delimiter=b"*",
                 last_data_delimiter=b"$",
             ),
-            checksum_func=(lambda x: md5(x).digest()),
+            checksum_func=(lambda x: md5(x, usedforsecurity=False).digest()),
         ),
     ),
 ]

--- a/ofrak_core/tests/components/test_ubi.py
+++ b/ofrak_core/tests/components/test_ubi.py
@@ -78,6 +78,6 @@ class TestUbiUnpackModifyPack(CompressedFileUnpackModifyPackPattern):
             ubi_vol_data = await ubi_vol.get_data()
             ubi_vol_id = ubi_vol_view.UbiVolumeId
 
-            ubi_vol_hash = hashlib.sha256()
+            ubi_vol_hash = hashlib.sha256(usedforsecurity=False)
             ubi_vol_hash.update(ubi_vol_data)
             assert ubi_vol_hash.hexdigest() == EXPECTED_HASHES[ubi_vol_id]

--- a/ofrak_core/tests/unit/test_ofrak_cli.py
+++ b/ofrak_core/tests/unit/test_ofrak_cli.py
@@ -256,7 +256,7 @@ async def all_expected_hashes(ofrak_context: OFRAKContext):
             if child.get_data_id() is not None:
                 data = await child.get_data()
                 if len(data) > 0:
-                    expected_hashes.add(hashlib.sha256(data).hexdigest())
+                    expected_hashes.add(hashlib.sha256(data, usedforsecurity=False).hexdigest())
         all_expected_hashes[filename] = expected_hashes
     await ofrak_context.shutdown_context()
     return all_expected_hashes
@@ -283,7 +283,7 @@ def test_unpack(ofrak_cli_parser, capsys, filename, tmpdir, ofrak_context, all_e
         for unpacked_file in filenames:
             path = os.path.join(dirpath, unpacked_file)
             with open(path, "rb") as file:
-                unpacked_hashes.add(hashlib.sha256(file.read()).hexdigest())
+                unpacked_hashes.add(hashlib.sha256(file.read(), usedforsecurity=False).hexdigest())
     expected_hashes = all_expected_hashes[filename]
 
     assert unpacked_hashes == expected_hashes

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,1 +1,1 @@
-VERSION = "3.4.0rc13"
+VERSION = "3.4.0rc14"


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix `hashlib` calls that use FIPS OpenSSL to avoid the following error:

```
ValueError: [digital envelope routines] unsupported
```

**Anyone you think should look at this, specifically?**

@whyitfor 