### PR TITLE
Fix UEFI chdir test failure

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix typo in `find` command used by CPIO packer ([#740](https://github.com/redballoonsecurity/ofrak/pull/740))
 - Fix bug in Segment Injector: favor regions with data when injecting data ([#682](https://github.com/redballoonsecurity/ofrak/pull/682))
 - Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
+- Fix `chdir` in UEFI components causing failing tests. ([#747](https://github.com/redballoonsecurity/ofrak/pull/747))
 
 ## [3.3.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.2.0...ofrak-v3.3.0) - 2025-10-03
 

--- a/ofrak_core/src/ofrak/core/uefi.py
+++ b/ofrak_core/src/ofrak/core/uefi.py
@@ -41,15 +41,15 @@ class UefiUnpacker(Unpacker[None]):
         ROM_FILE = "uefi.rom"
 
         with tempfile.TemporaryDirectory() as temp_flush_dir:
-            # uefiextract always outputs to the CWD, so we must run this command from the temp dir to not leave behind artifacts
-            os.chdir(temp_flush_dir)
-            await resource.flush_data_to_disk(ROM_FILE)
+            await resource.flush_data_to_disk(os.path.join(temp_flush_dir, ROM_FILE))
             cmd = [
                 "uefiextract",
                 ROM_FILE,
             ]
+            # uefiextract always outputs to the CWD, so we must run this command from the temp dir to not leave behind artifacts
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
+                cwd=temp_flush_dir,
             )
             returncode = await proc.wait()
             if proc.returncode:


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

A `chdir` in UEFI components was breaking stuff. This fixes it.

This should fix the failing tests on #715.

I reviewed the original file and commented on the use of `chdir`, but probably should never have let that get merged as-is. My bad @Ivanov1ch 