### PR TITLE
Cover ofrak_type.range mutmut gaps in test_range.py

### DIFF
--- a/ofrak_type/tests/test_range.py
+++ b/ofrak_type/tests/test_range.py
@@ -210,6 +210,16 @@ REMOVE_SUBRANGES_TEST_CASES = [
         [Range(0x20, 0x40), Range(0x60, 0x80)],
         [],
     ),  # remove everything, exact match
+    (
+        [Range(0, 10), Range(20, 30), Range(40, 50)],
+        [Range(0, 5)],
+        [Range(5, 10), Range(20, 30), Range(40, 50)],
+    ),  # to_remove exhausted with multiple ranges remaining
+    (
+        [Range(5, 5)],
+        [Range(5, 10)],
+        [Range(5, 5)],
+    ),  # empty range at the lower boundary of to_remove is preserved
 ]
 
 
@@ -448,17 +458,17 @@ def test_very_large_ranges():
     assert Range.MAX not in r
 
 
-def test_chunk_ranges_invalid_chunk_size():
-    """
-    Test chunk_ranges with invalid chunk sizes.
-    """
-    ranges = [Range(0, 10)]
-
+@pytest.mark.parametrize(
+    "ranges, chunk_size",
+    [
+        ([Range(0, 10)], 0),
+        ([Range(0, 10)], -1),
+        ([], 0),
+    ],
+)
+def test_chunk_ranges_invalid_chunk_size(ranges: List[Range], chunk_size: int):
     with pytest.raises(ValueError):
-        chunk_ranges(ranges, 0)
-
-    with pytest.raises(ValueError):
-        chunk_ranges(ranges, -1)
+        chunk_ranges(ranges, chunk_size)
 
 
 def test_contains_constant_time():


### PR DESCRIPTION
Add three behavioral cases surfaced by mutation testing:
- chunk_ranges([], 0) so the chunk_size check itself must reject 0 (an inner range(...) call can no longer raise on its own)
- remove_subranges with trailing unaffected ranges, covering the ranges[i+1:] extension path
- remove_subranges with an empty input range at a to_remove boundary, covering the `cr.end <= ctr.start` equality case

- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.


