### PR TITLE
Fix binwalk (and entropy) file descriptor leak

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix bug in Segment Injector: favor regions with data when injecting data ([#682](https://github.com/redballoonsecurity/ofrak/pull/682))
 - Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
 - Fix `chdir` in UEFI components causing failing tests. ([#747](https://github.com/redballoonsecurity/ofrak/pull/747))
-- Fix binwalk file descriptor leak. ([#749](https://github.com/redballoonsecurity/ofrak/pull/749))
+- Fix binwalk and entropy file descriptor leak. ([#749](https://github.com/redballoonsecurity/ofrak/pull/749))
 
 ## [3.3.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.2.0...ofrak-v3.3.0) - 2025-10-03
 

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix bug in Segment Injector: favor regions with data when injecting data ([#682](https://github.com/redballoonsecurity/ofrak/pull/682))
 - Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
 - Fix `chdir` in UEFI components causing failing tests. ([#747](https://github.com/redballoonsecurity/ofrak/pull/747))
+- Fix binwalk file descriptor leak. ([#749](https://github.com/redballoonsecurity/ofrak/pull/749))
 
 ## [3.3.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.2.0...ofrak-v3.3.0) - 2025-10-03
 

--- a/ofrak_core/src/ofrak/core/binwalk.py
+++ b/ofrak_core/src/ofrak/core/binwalk.py
@@ -1,5 +1,5 @@
 import asyncio
-from concurrent.futures.process import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from typing import Dict
 
@@ -35,8 +35,6 @@ class _BinwalkExternalTool(ComponentExternalTool):
 
 BINWALK_TOOL = _BinwalkExternalTool()
 
-pool = ProcessPoolExecutor(max_workers=1)
-
 
 @dataclass(**ResourceAttributes.DATACLASS_PARAMS)
 class BinwalkAttributes(ResourceAttributes):
@@ -66,9 +64,12 @@ class BinwalkAnalyzer(Analyzer[None, BinwalkAttributes]):
         async with resource.temp_to_disk() as temp_path:
             # Should errors be handled the way they are in the `DataSummaryAnalyzer`? Likely to be
             # overkill here.
-            offsets = await asyncio.get_running_loop().run_in_executor(
-                pool, _run_binwalk_on_file, temp_path
-            )
+            # Spin up a dedicated process pool for this analysis and shut it down afterwards so its
+            # worker process and the FDs it opens are released.
+            with ProcessPoolExecutor(max_workers=1) as pool:
+                offsets = await asyncio.get_running_loop().run_in_executor(
+                    pool, _run_binwalk_on_file, temp_path
+                )
         return BinwalkAttributes(offsets)
 
 

--- a/ofrak_core/src/ofrak/core/binwalk.py
+++ b/ofrak_core/src/ofrak/core/binwalk.py
@@ -3,7 +3,7 @@ from concurrent.futures.process import ProcessPoolExecutor
 from dataclasses import dataclass
 from typing import Dict
 
-from ofrak.resource import ResourceFactory, Resource
+from ofrak.resource import Resource
 
 from ofrak.model.resource_model import ResourceAttributes
 
@@ -19,8 +19,6 @@ except ImportError:
 
 from ofrak.core.binary import GenericBinary
 from ofrak.model.component_model import ComponentExternalTool
-from ofrak.service.data_service_i import DataServiceInterface
-from ofrak.service.resource_service_i import ResourceServiceInterface
 
 
 class _BinwalkExternalTool(ComponentExternalTool):
@@ -60,25 +58,16 @@ class BinwalkAnalyzer(Analyzer[None, BinwalkAttributes]):
     outputs = (BinwalkAttributes,)
     external_dependencies = (BINWALK_TOOL,)
 
-    def __init__(
-        self,
-        resource_factory: ResourceFactory,
-        data_service: DataServiceInterface,
-        resource_service: ResourceServiceInterface,
-    ):
-        super().__init__(resource_factory, data_service, resource_service)
-
     async def analyze(self, resource: Resource, config=None) -> BinwalkAttributes:
         if not BINWALK_INSTALLED:
             raise ComponentMissingDependencyError(self, BINWALK_TOOL)
-        pool = ProcessPoolExecutor()
-        async with resource.temp_to_disk() as temp_path:
-            # Should errors be handled the way they are in the `DataSummaryAnalyzer`? Likely to be
-            # overkill here.
-            offsets = await asyncio.get_running_loop().run_in_executor(
-                pool, _run_binwalk_on_file, temp_path
-            )
-        pool.shutdown(wait=True, cancel_futures=True)
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            async with resource.temp_to_disk() as temp_path:
+                # Should errors be handled the way they are in the `DataSummaryAnalyzer`? Likely to be
+                # overkill here.
+                offsets = await asyncio.get_running_loop().run_in_executor(
+                    pool, _run_binwalk_on_file, temp_path
+                )
         return BinwalkAttributes(offsets)
 
 

--- a/ofrak_core/src/ofrak/core/binwalk.py
+++ b/ofrak_core/src/ofrak/core/binwalk.py
@@ -62,8 +62,6 @@ class BinwalkAnalyzer(Analyzer[None, BinwalkAttributes]):
         if not BINWALK_INSTALLED:
             raise ComponentMissingDependencyError(self, BINWALK_TOOL)
         async with resource.temp_to_disk() as temp_path:
-            # Should errors be handled the way they are in the `DataSummaryAnalyzer`? Likely to be
-            # overkill here.
             # Spin up a dedicated process pool for this analysis and shut it down afterwards so its
             # worker process and the FDs it opens are released.
             with ProcessPoolExecutor(max_workers=1) as pool:

--- a/ofrak_core/src/ofrak/core/binwalk.py
+++ b/ofrak_core/src/ofrak/core/binwalk.py
@@ -35,6 +35,8 @@ class _BinwalkExternalTool(ComponentExternalTool):
 
 BINWALK_TOOL = _BinwalkExternalTool()
 
+pool = ProcessPoolExecutor(max_workers=1)
+
 
 @dataclass(**ResourceAttributes.DATACLASS_PARAMS)
 class BinwalkAttributes(ResourceAttributes):
@@ -61,13 +63,12 @@ class BinwalkAnalyzer(Analyzer[None, BinwalkAttributes]):
     async def analyze(self, resource: Resource, config=None) -> BinwalkAttributes:
         if not BINWALK_INSTALLED:
             raise ComponentMissingDependencyError(self, BINWALK_TOOL)
-        with ProcessPoolExecutor(max_workers=1) as pool:
-            async with resource.temp_to_disk() as temp_path:
-                # Should errors be handled the way they are in the `DataSummaryAnalyzer`? Likely to be
-                # overkill here.
-                offsets = await asyncio.get_running_loop().run_in_executor(
-                    pool, _run_binwalk_on_file, temp_path
-                )
+        async with resource.temp_to_disk() as temp_path:
+            # Should errors be handled the way they are in the `DataSummaryAnalyzer`? Likely to be
+            # overkill here.
+            offsets = await asyncio.get_running_loop().run_in_executor(
+                pool, _run_binwalk_on_file, temp_path
+            )
         return BinwalkAttributes(offsets)
 
 

--- a/ofrak_core/src/ofrak/core/binwalk.py
+++ b/ofrak_core/src/ofrak/core/binwalk.py
@@ -67,17 +67,18 @@ class BinwalkAnalyzer(Analyzer[None, BinwalkAttributes]):
         resource_service: ResourceServiceInterface,
     ):
         super().__init__(resource_factory, data_service, resource_service)
-        self.pool = ProcessPoolExecutor()
 
     async def analyze(self, resource: Resource, config=None) -> BinwalkAttributes:
         if not BINWALK_INSTALLED:
             raise ComponentMissingDependencyError(self, BINWALK_TOOL)
+        pool = ProcessPoolExecutor()
         async with resource.temp_to_disk() as temp_path:
             # Should errors be handled the way they are in the `DataSummaryAnalyzer`? Likely to be
             # overkill here.
             offsets = await asyncio.get_running_loop().run_in_executor(
-                self.pool, _run_binwalk_on_file, temp_path
+                pool, _run_binwalk_on_file, temp_path
             )
+        pool.shutdown(wait=True, cancel_futures=True)
         return BinwalkAttributes(offsets)
 
 

--- a/ofrak_core/src/ofrak/core/entropy/entropy.py
+++ b/ofrak_core/src/ofrak/core/entropy/entropy.py
@@ -3,8 +3,6 @@ import logging
 from typing import Dict
 
 import math
-from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
 
 from ofrak.component.analyzer import Analyzer
@@ -21,9 +19,6 @@ try:
     entropy_func = get_entropy_c()
 except:
     from ofrak.core.entropy.entropy_py import entropy_py as entropy_func
-
-
-pool = ProcessPoolExecutor(max_workers=1)
 
 
 @dataclass
@@ -65,7 +60,6 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummaryCache]):
         resource_service: ResourceServiceInterface,
     ):
         super().__init__(resource_factory, data_service, resource_service)
-        self.max_analysis_retries = 10
         self._cache: Dict[str, DataSummary] = {}
 
     async def analyze(self, resource: Resource, config=None) -> DataSummaryCache:
@@ -79,31 +73,18 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummaryCache]):
         cache_info = resource.get_attributes(DataSummaryCache)
         return self._cache[cache_info.cache_key]
 
-    async def _compute_data_summary(self, resource: Resource, depth=0) -> DataSummary:
-        global pool
-        if depth > self.max_analysis_retries:
-            raise RuntimeError(
-                f"Analysis process killed more than {self.max_analysis_retries} times. Aborting."
-            )
-        try:
-            data = await resource.get_data()
-            entropy = await asyncio.get_running_loop().run_in_executor(
-                pool, sample_entropy, data, resource.get_id()
-            )
-            magnitude = await asyncio.get_running_loop().run_in_executor(
-                pool, sample_magnitude, data
-            )
-            data_summary = DataSummary(entropy, magnitude)
-            return data_summary
-        except BrokenProcessPool:
-            # If the previous one was aborted, try again with a new pool
-            pool = ProcessPoolExecutor()
-            return await self._compute_data_summary(resource, depth=depth + 1)
+    async def _compute_data_summary(self, resource: Resource) -> DataSummary:
+        data = await resource.get_data()
+        # When using the C version, the GIL is released, improving parallel performance
+        # When using the python version, the GIL is hold, so no improvements when running multiple analysis in parallel
+        entropy, magnitude = await asyncio.gather(
+            asyncio.to_thread(sample_entropy, data, resource.get_id()),
+            asyncio.to_thread(sample_magnitude, data),
+        )
+        return DataSummary(entropy, magnitude)
 
 
-def sample_entropy(
-    data: bytes, resource_id: bytes, window_size=256, max_samples=2**20
-) -> bytes:  # pragma: no cover
+def sample_entropy(data: bytes, resource_id: bytes, window_size=256, max_samples=2**20) -> bytes:
     """
     Return a list of entropy values where each value represents the Shannon entropy of the byte
     value distribution over a fixed-size, sliding window. If the entropy data is larger than a
@@ -131,7 +112,7 @@ def sample_entropy(
     return bytes(result[math.floor(i * skip)] for i in range(max_samples))
 
 
-def sample_magnitude(data: bytes, max_samples=2**20) -> bytes:  # pragma: no cover
+def sample_magnitude(data: bytes, max_samples=2**20) -> bytes:
     if len(data) < max_samples:
         # TODO: Should this be a shallow copy instead?
         return data

--- a/ofrak_core/src/ofrak/core/entropy/entropy.py
+++ b/ofrak_core/src/ofrak/core/entropy/entropy.py
@@ -23,6 +23,9 @@ except:
     from ofrak.core.entropy.entropy_py import entropy_py as entropy_func
 
 
+pool = ProcessPoolExecutor(max_workers=1)
+
+
 @dataclass
 class DataSummary:
     """
@@ -62,7 +65,6 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummaryCache]):
         resource_service: ResourceServiceInterface,
     ):
         super().__init__(resource_factory, data_service, resource_service)
-        self.pool = ProcessPoolExecutor()
         self.max_analysis_retries = 10
         self._cache: Dict[str, DataSummary] = {}
 
@@ -78,6 +80,7 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummaryCache]):
         return self._cache[cache_info.cache_key]
 
     async def _compute_data_summary(self, resource: Resource, depth=0) -> DataSummary:
+        global pool
         if depth > self.max_analysis_retries:
             raise RuntimeError(
                 f"Analysis process killed more than {self.max_analysis_retries} times. Aborting."
@@ -85,16 +88,16 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummaryCache]):
         try:
             data = await resource.get_data()
             entropy = await asyncio.get_running_loop().run_in_executor(
-                self.pool, sample_entropy, data, resource.get_id()
+                pool, sample_entropy, data, resource.get_id()
             )
             magnitude = await asyncio.get_running_loop().run_in_executor(
-                self.pool, sample_magnitude, data
+                pool, sample_magnitude, data
             )
             data_summary = DataSummary(entropy, magnitude)
             return data_summary
         except BrokenProcessPool:
             # If the previous one was aborted, try again with a new pool
-            self.pool = ProcessPoolExecutor()
+            pool = ProcessPoolExecutor()
             return await self._compute_data_summary(resource, depth=depth + 1)
 
 

--- a/ofrak_core/src/ofrak/core/entropy/entropy.py
+++ b/ofrak_core/src/ofrak/core/entropy/entropy.py
@@ -76,7 +76,7 @@ class DataSummaryAnalyzer(Analyzer[None, DataSummaryCache]):
     async def _compute_data_summary(self, resource: Resource) -> DataSummary:
         data = await resource.get_data()
         # When using the C version, the GIL is released, improving parallel performance
-        # When using the python version, the GIL is hold, so no improvements when running multiple analysis in parallel
+        # When using the python version, the GIL is held, so no improvements when running multiple analysis calls in parallel
         entropy, magnitude = await asyncio.gather(
             asyncio.to_thread(sample_entropy, data, resource.get_id()),
             asyncio.to_thread(sample_magnitude, data),

--- a/ofrak_core/tests/components/test_binwalk_component.py
+++ b/ofrak_core/tests/components/test_binwalk_component.py
@@ -92,10 +92,7 @@ async def test_binwalk_does_not_leak_fds(ofrak_context):
     """
     fd_dir = f"/proc/{os.getpid()}/fd"
     asset_path = os.path.join(BINWALK_ASSETS_PATH, "dirtraversal.tar")
-
-    root_resource = await ofrak_context.create_root_resource_from_file(asset_path)
     before = len(os.listdir(fd_dir))
-    await root_resource.analyze(BinwalkAttributes)
 
     iterations = 5
     for _ in range(iterations):

--- a/ofrak_core/tests/components/test_binwalk_component.py
+++ b/ofrak_core/tests/components/test_binwalk_component.py
@@ -114,7 +114,7 @@ async def test_binwalk_does_not_leak_fds(ofrak_context):
 async def test_binwalk_parallel_faster_than_sequential(ofrak_context):
     """
     Time two binwalk analyses run sequentially vs. run concurrently with
-    ``asyncio.gather``, and assert that the concurrent version is faster.
+    `asyncio.gather`, and assert that the concurrent version is faster.
     """
     asset_path = os.path.join(BINWALK_ASSETS_PATH, "firmware.zip")
 

--- a/ofrak_core/tests/components/test_binwalk_component.py
+++ b/ofrak_core/tests/components/test_binwalk_component.py
@@ -7,7 +7,10 @@ Requirements Mapping:
 from dataclasses import dataclass
 from typing import Dict, Optional
 
+import asyncio
 import os
+import time
+
 import pytest
 
 from ofrak.core.binwalk import BinwalkAnalyzer, BinwalkAttributes
@@ -104,4 +107,35 @@ async def test_binwalk_does_not_leak_fds(ofrak_context):
     assert delta < 10, (
         f"BinwalkAnalyzer leaked {delta} FDs across {iterations} iterations "
         f"({before} -> {after})."
+    )
+
+
+@pytest.mark.skipif_missing_deps([BinwalkAnalyzer])
+async def test_binwalk_parallel_faster_than_sequential(ofrak_context):
+    """
+    Time two binwalk analyses run sequentially vs. run concurrently with
+    ``asyncio.gather``, and assert that the concurrent version is faster.
+    """
+    asset_path = os.path.join(BINWALK_ASSETS_PATH, "firmware.zip")
+
+    async def analyze_once():
+        root_resource = await ofrak_context.create_root_resource_from_file(asset_path)
+        await root_resource.analyze(BinwalkAttributes)
+        return root_resource.get_attributes(BinwalkAttributes)
+
+    # Sequential:
+    start = time.perf_counter()
+    await analyze_once()
+    await analyze_once()
+    sequential_time = time.perf_counter() - start
+
+    # Parallel:
+    start = time.perf_counter()
+    await asyncio.gather(analyze_once(), analyze_once())
+    parallel_time = time.perf_counter() - start
+
+    assert parallel_time < sequential_time * 0.7, (
+        f"Expected parallel analysis to be at least 30% faster, but sequential took "
+        f"{sequential_time:.3f}s and parallel took {parallel_time:.3f}s "
+        f"({parallel_time / sequential_time:.0%} of sequential)."
     )

--- a/ofrak_core/tests/components/test_binwalk_component.py
+++ b/ofrak_core/tests/components/test_binwalk_component.py
@@ -134,8 +134,8 @@ async def test_binwalk_parallel_faster_than_sequential(ofrak_context):
     await asyncio.gather(analyze_once(), analyze_once())
     parallel_time = time.perf_counter() - start
 
-    assert parallel_time < sequential_time * 0.7, (
-        f"Expected parallel analysis to be at least 30% faster, but sequential took "
+    assert parallel_time < sequential_time * 0.85, (
+        f"Expected parallel analysis to be at least 15% faster, but sequential took "
         f"{sequential_time:.3f}s and parallel took {parallel_time:.3f}s "
         f"({parallel_time / sequential_time:.0%} of sequential)."
     )

--- a/ofrak_core/tests/components/test_binwalk_component.py
+++ b/ofrak_core/tests/components/test_binwalk_component.py
@@ -79,3 +79,32 @@ async def test_binwalk_component(ofrak_context, test_case):
     if test_case.number_of_results is not None:
         assert len(binwalk_offsets) == test_case.number_of_results
     assert test_case.subset_of_results.items() <= binwalk_offsets.items()
+
+
+@pytest.mark.skipif(
+    not os.path.isdir(f"/proc/{os.getpid()}/fd"),
+    reason="Requires /proc/<pid>/fd (Linux only)",
+)
+@pytest.mark.skipif_missing_deps([BinwalkAnalyzer])
+async def test_binwalk_does_not_leak_fds(ofrak_context):
+    """
+    Regression test for the ProcessPoolExecutor FD leak in BinwalkAnalyzer.
+    """
+    fd_dir = f"/proc/{os.getpid()}/fd"
+    asset_path = os.path.join(BINWALK_ASSETS_PATH, "dirtraversal.tar")
+
+    root_resource = await ofrak_context.create_root_resource_from_file(asset_path)
+    before = len(os.listdir(fd_dir))
+    await root_resource.analyze(BinwalkAttributes)
+
+    iterations = 5
+    for _ in range(iterations):
+        root_resource = await ofrak_context.create_root_resource_from_file(asset_path)
+        await root_resource.analyze(BinwalkAttributes)
+    after = len(os.listdir(fd_dir))
+
+    delta = after - before
+    assert delta < 10, (
+        f"BinwalkAnalyzer leaked {delta} FDs across {iterations} iterations "
+        f"({before} -> {after})."
+    )

--- a/ofrak_core/tests/components/test_entropy_component.py
+++ b/ofrak_core/tests/components/test_entropy_component.py
@@ -114,7 +114,7 @@ async def test_entropy_does_not_leak_fds(ofrak_context: OFRAKContext):
 async def test_entropy_parallel_faster_than_sequential(ofrak_context: OFRAKContext):
     """
     Time two entropy analyses run sequentially vs. run concurrently with
-    ``asyncio.gather``, and assert that the concurrent version is faster.
+    `asyncio.gather`, and assert that the concurrent version is faster.
     """
     asset_path = os.path.join(components.ASSETS_DIR, "uimage_multi")
 

--- a/ofrak_core/tests/components/test_entropy_component.py
+++ b/ofrak_core/tests/components/test_entropy_component.py
@@ -136,8 +136,8 @@ async def test_entropy_parallel_faster_than_sequential(ofrak_context: OFRAKConte
     await asyncio.gather(analyze_once(), analyze_once())
     parallel_time = time.perf_counter() - start
 
-    assert parallel_time < sequential_time * 0.7, (
-        f"Expected parallel analysis to be at least 30% faster, but sequential took "
+    assert parallel_time < sequential_time * 0.85, (
+        f"Expected parallel analysis to be at least 15% faster, but sequential took "
         f"{sequential_time:.3f}s and parallel took {parallel_time:.3f}s "
         f"({parallel_time / sequential_time:.0%} of sequential)."
     )

--- a/ofrak_core/tests/components/test_entropy_component.py
+++ b/ofrak_core/tests/components/test_entropy_component.py
@@ -82,3 +82,28 @@ def _almost_equal(bytes1: bytes, bytes2: bytes) -> bool:
             print(f"Inputs differ at byte {i} ({bytes1[i]} != {bytes2[i]})")
             return False
     return True
+
+
+@pytest.mark.skipif(
+    not os.path.isdir(f"/proc/{os.getpid()}/fd"),
+    reason="Requires /proc/<pid>/fd (Linux only)",
+)
+async def test_entropy_does_not_leak_fds(ofrak_context: OFRAKContext):
+    """
+    Regression test for the ProcessPoolExecutor FD leak in DataSummaryAnalyzer.
+    """
+    fd_dir = f"/proc/{os.getpid()}/fd"
+    asset_path = os.path.join(components.ASSETS_DIR, "hello.out")
+    before = len(os.listdir(fd_dir))
+
+    iterations = 5
+    for _ in range(iterations):
+        root_resource = await ofrak_context.create_root_resource_from_file(asset_path)
+        await root_resource.run(DataSummaryAnalyzer)
+    after = len(os.listdir(fd_dir))
+
+    delta = after - before
+    assert delta < 10, (
+        f"DataSummaryAnalyzer leaked {delta} FDs across {iterations} iterations "
+        f"({before} -> {after})."
+    )

--- a/ofrak_core/tests/components/test_entropy_component.py
+++ b/ofrak_core/tests/components/test_entropy_component.py
@@ -4,7 +4,9 @@ Test entropy analysis component functionality.
 Requirements Mapping:
 - REQ2.2
 """
+import asyncio
 import os.path
+import time
 
 import pytest
 from ofrak.core.entropy import DataSummaryAnalyzer
@@ -106,4 +108,36 @@ async def test_entropy_does_not_leak_fds(ofrak_context: OFRAKContext):
     assert delta < 10, (
         f"DataSummaryAnalyzer leaked {delta} FDs across {iterations} iterations "
         f"({before} -> {after})."
+    )
+
+
+async def test_entropy_parallel_faster_than_sequential(ofrak_context: OFRAKContext):
+    """
+    Time two entropy analyses run sequentially vs. run concurrently with
+    ``asyncio.gather``, and assert that the concurrent version is faster.
+    """
+    asset_path = os.path.join(components.ASSETS_DIR, "uimage_multi")
+
+    async def analyze_once():
+        root_resource = await ofrak_context.create_root_resource_from_file(asset_path)
+        analyzer: DataSummaryAnalyzer = ofrak_context.component_locator.get_by_id(
+            DataSummaryAnalyzer.get_id()
+        )
+        return await analyzer.get_data_summary(root_resource)
+
+    # Sequential:
+    start = time.perf_counter()
+    await analyze_once()
+    await analyze_once()
+    sequential_time = time.perf_counter() - start
+
+    # Parallel:
+    start = time.perf_counter()
+    await asyncio.gather(analyze_once(), analyze_once())
+    parallel_time = time.perf_counter() - start
+
+    assert parallel_time < sequential_time * 0.7, (
+        f"Expected parallel analysis to be at least 30% faster, but sequential took "
+        f"{sequential_time:.3f}s and parallel took {parallel_time:.3f}s "
+        f"({parallel_time / sequential_time:.0%} of sequential)."
     )


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix binwalk and entropy file descriptor leak

**Link to Related Issue(s)**

None.

**Please describe the changes in your request.**

I was running into errors like this: `OSError: [Errno 24] Too many open files: '/usr/local/lib/python3.9/site-packages/pygments/__init__.py'`.

It turns out that binwalk creates a `ProcessPoolExecutor`, which opens a lot of file descriptors for pipes (depending on the CPU core count). When running tests that used the binwalk analyzer, it was creating a lot of FDs for each test case, which rapidly scaled and triggered the `OSError: [Errno 24] Too many open files`

A simple test I ran was this one:
```
import asyncio
import os

from ofrak import OFRAK
from ofrak.core.binwalk import BinwalkAttributes


def fd_count() -> int:
    return len(os.listdir(f"/proc/{os.getpid()}/fd"))

async def main(ofrak_context):
    resource = await ofrak_context.create_root_resource_from_file("/usr/bin/ls")
    before = fd_count()
    print(f"FDs before binwalk: {before}")
    await resource.analyze(BinwalkAttributes)
    after = fd_count()
    print(f"FDs after binwalk:  {after}  (delta = {after - before})")

if __name__ == "__main__":
    ofrak = OFRAK()
    ofrak.run(main)
```

Before my fix, this resulted in `FDs after binwalk:  116  (delta = 96)`. With the proposed fix, I saw: `FDs after binwalk:  14  (delta = -6)`.

I added a regression test for this.

**Anyone you think should look at this, specifically?**

@rbs-jacob ?