### PR TITLE
ISO unpacker bugfix for files in root directory

### DIFF
--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fix bug in Segment Injector: favor regions with data when injecting data ([#682](https://github.com/redballoonsecurity/ofrak/pull/682))
 - Pass `usedforsecurity=False` to non-cryptographic `hashlib` calls to prevent failures when Python links against FIPS OpenSSL ([#744](https://github.com/redballoonsecurity/ofrak/pull/744))
 - Fix `chdir` in UEFI components causing failing tests. ([#747](https://github.com/redballoonsecurity/ofrak/pull/747))
+- Fix bug in `ISO9660Unpacker` for files in root directory. ([#750](https://github.com/redballoonsecurity/ofrak/pull/750))
 
 ## [3.3.0](https://github.com/redballoonsecurity/ofrak/compare/ofrak-v3.2.0...ofrak-v3.3.0) - 2025-10-03
 

--- a/ofrak_core/src/ofrak/core/iso9660.py
+++ b/ofrak_core/src/ofrak/core/iso9660.py
@@ -257,7 +257,7 @@ class ISO9660Unpacker(Unpacker[None]):
                     iso_version=iso_version,
                 )
                 await iso_resource.add_file(
-                    path,
+                    path.lstrip("/"),
                     file_data,
                     None,
                     None,

--- a/ofrak_core/tests/components/test_iso_component.py
+++ b/ofrak_core/tests/components/test_iso_component.py
@@ -13,6 +13,7 @@ from typing import Optional
 import pytest
 from pycdlib import PyCdlib
 
+from ofrak import OFRAKContext
 from ofrak.resource import Resource
 from ofrak.core.iso9660 import (
     ISO9660Entry,
@@ -167,3 +168,41 @@ class TestJolietUnpackModifyPack(Iso9660UnpackModifyPackPattern):
         )
         iso.write(os.path.join(tmpdir, self.TEST_ISO_NAME))
         self._test_file = os.path.join(tmpdir, self.TEST_ISO_NAME)
+
+
+@pytest.mark.skipif_missing_deps([ISO9660Unpacker])
+class TestIso9660RootLevelFileUnpack:
+    """
+    Test for an ISO that contains a file directly at the root (no enclosing directory).
+    """
+
+    TEST_ISO_NAME = "root_file.iso"
+    ROOT_FILE_NAME = "ROOTFILE.TXT"
+    ROOT_FILE_DATA = b"hello at the root\n"
+
+    @pytest.fixture
+    def iso_with_root_level_file(self, tmpdir):
+        iso = PyCdlib()
+        iso.new(interchange_level=3)
+        iso.add_fp(
+            BytesIO(self.ROOT_FILE_DATA),
+            len(self.ROOT_FILE_DATA),
+            "/" + self.ROOT_FILE_NAME + ";1",
+        )
+        path = os.path.join(tmpdir, self.TEST_ISO_NAME)
+        iso.write(path)
+        iso.close()
+        return path
+
+    async def test_unpack_iso_with_root_level_file(
+        self, ofrak_context: OFRAKContext, iso_with_root_level_file
+    ):
+        root_resource = await ofrak_context.create_root_resource_from_file(iso_with_root_level_file)
+        await root_resource.unpack()
+
+        iso_resource = await root_resource.view_as(ISO9660Image)
+        for descendant in await iso_resource.resource.get_descendants():
+            assert ISO9660Entry in descendant.get_tags(), (
+                f"Descendant {descendant.get_id().hex()} with tags {tags} is missing "
+                f"ISO9660Entry"
+            )


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Fix bug in `ISO9660Unpacker` for files in root directory

**Link to Related Issue(s)**

None.

**Please describe the changes in your request.**

When ISOs have files at the root level (like this [alpine ISO](https://dl-cdn.alpinelinux.org/alpine/v3.23/releases/aarch64/alpine-virt-3.23.4-aarch64.iso) I was working with), the ISO unpacker would create the following resource tree:
```
┌d58d0a39b8c54f769c61ab6bcb4d5084: [caption=(File: alpine-virt-3.23.4-aarch64.iso, ISO9660Image), attributes=(AttributesType[FilesystemEntry], Magic, ISO9660ImageAttributes), global_offset=(0x0-0x5987800), parent_offset=(0x0-0x0), data_hash=3ced796c]
...
└───┬23d87c85b80c427db443694dccc02fe6: [caption=(Folder: ), attributes=(AttributesType[FilesystemEntry]), global_offset=(0x0-0x0), parent_offset=(0x0-0x0), data_ascii=""]
    ├────11409fedde8e4105bb6f01031c3810d9: [caption=(ISO9660Entry, File: boot.catalog), attributes=(AttributesType[FilesystemEntry], AttributesType[ISO9660Entry]), global_offset=(0x0-0x800), parent_offset=(0x0-0x0), data_hash=6dda4cd1]
    └────42d79ad8ace3408da7666936e98fbeaa: [caption=(ISO9660Entry, File: .alpine-release), attributes=(AttributesType[FilesystemEntry], AttributesType[ISO9660Entry]), global_offset=(0x0-0x1a), parent_offset=(0x0-0x0), data_hex=616c70696e652d766972742d332e32332e34203236303431350a]
```

Notice that the files `boot.catalog` and `.alpine-release` are in the root directory in the ISO image, but here it creates a `Folder` without any name to contain them, which is wrong.

This lead to the following error:
```
ofrak.service.job_service_i.ComponentAutoRunFailure: Component ISO9660Unpacker failed when running on d58d0a39b8c54f769c61ab6bcb4d5084. Component was chosen because it matched filters (((ComponentTypeFilter(Unpacker) or ComponentTypeFilter(Identifier))) and ((ComponentTypeFilter(Identifier) and ComponentTargetFilter(FilesystemRoot, ISO9660Image)) or (ComponentTypeFilter(Analyzer) and ComponentTargetFilter(FilesystemRoot, ISO9660Image)) or (not ComponentTypeFilter(Identifier) and not ComponentTypeFilter(Analyzer) and (ComponentTargetFilter(ISO9660Image) then ComponentTargetFilter(FilesystemRoot)))))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/iso_test.py", line 19, in <module>
    ofrak.run(main, args.file)
  File "/ofrak_core/src/ofrak/ofrak_context.py", line 206, in run
    asyncio.get_event_loop().run_until_complete(self.run_async(func, *args))
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/ofrak_core/src/ofrak/ofrak_context.py", line 199, in run_async
    await func(ofrak_context, *args)
  File "/iso_test.py", line 9, in main
    await root_resource.unpack()
  File "/ofrak_core/src/ofrak/resource.py", line 463, in unpack
    return await self.auto_run(all_identifiers=True, all_unpackers=True)
  File "/ofrak_core/src/ofrak/resource.py", line 436, in auto_run
    components_result = await self._job_service.run_components(
  File "/ofrak_core/src/ofrak/service/job_service.py", line 277, in run_components
    individual_component_results = await self._auto_run_components(
  File "/ofrak_core/src/ofrak/service/job_service.py", line 471, in _auto_run_components
    raise component_run_error from ComponentAutoRunFailure(
  File "/ofrak_core/src/ofrak/service/job_service.py", line 133, in _run_component
    result = await component.run(
  File "/ofrak_core/src/ofrak/component/abstract.py", line 94, in run
    await self._run(resource, config)
  File "/ofrak_core/src/ofrak/component/unpacker.py", line 85, in _run
    await self._validate_unpacked_children(resource)
  File "/ofrak_core/src/ofrak/component/unpacker.py", line 147, in _validate_unpacked_children
    raise ValueError(
ValueError: Unpacker ISO9660Unpacker created resource 23d87c85b80c427db443694dccc02fe6 but its tags {FilesystemEntry, Folder} do not match any of the expected patterns this unpacker should create: ISO9660Entry
```

With this PR, the leading `/` in `/boot.catalog` is stripped, so the unpacker create the relevant files in the root directory:
```
┌b3f20e18721842b0aa51d40c26dc0c22: [caption=(File: alpine-virt-3.23.4-aarch64.iso, ISO9660Image), attributes=(AttributesType[FilesystemEntry], Magic, ISO9660ImageAttributes), global_offset=(0x0-0x5987800), parent_offset=(0x0-0x0), data_hash=3ced796c]
...
├────0bbb642e8f184661911e77c4b2c483c2: [caption=(ISO9660Entry, File: boot.catalog), attributes=(AttributesType[FilesystemEntry], AttributesType[ISO9660Entry]), global_offset=(0x0-0x800), parent_offset=(0x0-0x0), data_hash=6dda4cd1]
└────0c71ec1eb9a14e2e8be9aa2010e32a2e: [caption=(ISO9660Entry, File: .alpine-release), attributes=(AttributesType[FilesystemEntry], AttributesType[ISO9660Entry]), global_offset=(0x0-0x1a), parent_offset=(0x0-0x0), data_hex=616c70696e652d766972742d332e32332e34203236303431350a]
```

I added a regression test for this.

**Anyone you think should look at this, specifically?**

@rbs-jacob ?