### PR TITLE
Entropy parallel test: improve reliability

### DIFF
--- a/ofrak_core/tests/components/test_entropy_component.py
+++ b/ofrak_core/tests/components/test_entropy_component.py
@@ -113,7 +113,7 @@ async def test_entropy_does_not_leak_fds(ofrak_context: OFRAKContext):
 
 async def test_entropy_parallel_faster_than_sequential(ofrak_context: OFRAKContext):
     """
-    Time two entropy analyses run sequentially vs. run concurrently with
+    Time four entropy analyses run sequentially vs. run concurrently with
     `asyncio.gather`, and assert that the concurrent version is faster.
     """
     asset_path = os.path.join(components.ASSETS_DIR, "uimage_multi")
@@ -129,11 +129,13 @@ async def test_entropy_parallel_faster_than_sequential(ofrak_context: OFRAKConte
     start = time.perf_counter()
     await analyze_once()
     await analyze_once()
+    await analyze_once()
+    await analyze_once()
     sequential_time = time.perf_counter() - start
 
     # Parallel:
     start = time.perf_counter()
-    await asyncio.gather(analyze_once(), analyze_once())
+    await asyncio.gather(analyze_once(), analyze_once(), analyze_once(), analyze_once())
     parallel_time = time.perf_counter() - start
 
     assert parallel_time < sequential_time * 0.85, (


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [ ] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**

**Please describe the changes in your request.**

On github, the pipeline for entropy sometimes fails on the sequential VS parallel: `AssertionError: Expected parallel analysis to be at least 15% faster, but sequential took 2.697s and parallel took 2.431s (90% of sequential). assert 2.4312723449997975 < (2.697084194999661 * 0.85)`.

This PR improves pipeline reliability by running 4 analysis sequential and comparing with 4 parallel analysis, which should make the gap between sequential and parallel bigger.

**Anyone you think should look at this, specifically?**
