### PR TITLE
Revert libmagic workaround

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -98,11 +98,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash -euxo pipefail {0}
       run: |
-        brew install cmake
-        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/b8292ac3475e57ca407db18dfeb131cc51116da2/Formula/lib/libmagic.rb
-        brew tap-new redballoonsecurity/ofrak-libmagic
-        cp libmagic.rb $(brew --repository)/Library/Taps/redballoonsecurity/homebrew-ofrak-libmagic/Formula/
-        brew install redballoonsecurity/ofrak-libmagic/libmagic
+        brew install cmake libmagic
 
     - name: Install packages
       shell: bash -euxo pipefail {0}

--- a/docs/install/pypi.md
+++ b/docs/install/pypi.md
@@ -5,7 +5,7 @@ Install OFRAK quickly using pip for the simplest setup.
 ## Prerequisites
 
 - Python 3.9+ and pip
-- cmake and libmagic (macOS only - install via `brew install cmake libmagic`)
+- cmake and libmagic (macOS only - install via `brew install cmake libmagic` - libmagic 5.47 has a known regression affecting ELF identification, ensure libmagic!=5.47 after installing; see [source install docs](source.md#macos-libmagic-install) for more information)
 
 ## Quick Install
 

--- a/docs/install/pypi.md
+++ b/docs/install/pypi.md
@@ -5,7 +5,7 @@ Install OFRAK quickly using pip for the simplest setup.
 ## Prerequisites
 
 - Python 3.9+ and pip
-- cmake and libmagic 5.46 (macOS only - libmagic 5.47 has a known regression affecting ELF identification; see [source install docs](source.md#macos-libmagic-install) for installation steps)
+- cmake and libmagic (macOS only - install via `brew install cmake libmagic`)
 
 ## Quick Install
 

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -7,7 +7,7 @@ Install OFRAK from source code for development or contribution.
 - Python 3.9+ and pip
 - Git with [Git LFS](https://git-lfs.github.com/) installed ([installation instructions](https://github.com/git-lfs/git-lfs#installing))
 - make
-- cmake and libmagic (macOS only - install via `brew install cmake libmagic`)
+- cmake and libmagic (macOS only - install via `brew install cmake libmagic` - libmagic 5.47 has a known regression affecting ELF identification, ensure libmagic!=5.47 after installing; see [macOS libmagic install](#macos-libmagic-install) for more information)
 
 ## Clone
 
@@ -101,6 +101,26 @@ See [OFRAK CLI Configuring Dependencies](../ofrak-cli.md#configuring-dependencie
 ```bash
 make requirements-pip
 make requirements-build-docker
+```
+
+### macOS libmagic Install
+
+libmagic 5.47 contains a regression where ELF files are identified as `ELF` instead of `ELF ` (with trailing space), which breaks OFRAK's ELF identification. If you run into issues with ELF files in OFRAK, first check your libmagic version:
+
+```bash
+brew info libmagic
+==> libmagic: stable 5.48 (bottled)
+Implementation of the file(1) command
+https://www.darwinsys.com/file/
+Installed (on request)
+From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/lib/libmagic.rb
+...
+```
+
+If brew returns 5.47 for the libmagic version, update libmagic with:
+
+```bash
+brew upgrade libmagic
 ```
 
 ### keystone-engine Import Error on macOS (M1/M2)

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -7,7 +7,7 @@ Install OFRAK from source code for development or contribution.
 - Python 3.9+ and pip
 - Git with [Git LFS](https://git-lfs.github.com/) installed ([installation instructions](https://github.com/git-lfs/git-lfs#installing))
 - make
-- cmake and libmagic 5.46 (macOS only - libmagic 5.47 has a known regression affecting ELF identification; see [macOS libmagic install](#macos-libmagic-install) below)
+- cmake and libmagic (macOS only - install via `brew install cmake libmagic`)
 
 ## Clone
 
@@ -101,18 +101,6 @@ See [OFRAK CLI Configuring Dependencies](../ofrak-cli.md#configuring-dependencie
 ```bash
 make requirements-pip
 make requirements-build-docker
-```
-
-### macOS libmagic Install
-
-libmagic 5.47 contains a regression where ELF files are identified as `ELF` instead of `ELF ` (with trailing space), which breaks OFRAK's ELF identification. Install libmagic 5.46 via a custom Homebrew tap:
-
-```bash
-brew install cmake
-curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/b8292ac3475e57ca407db18dfeb131cc51116da2/Formula/lib/libmagic.rb
-brew tap-new local/ofrak-libmagic
-cp libmagic.rb $(brew --repository)/Library/Taps/local/homebrew-ofrak-libmagic/Formula/
-brew install local/ofrak-libmagic/libmagic
 ```
 
 ### keystone-engine Import Error on macOS (M1/M2)

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))
 
 ### Fixed
-- Remove libmagic 5.46 pin as the pinned manifest is not compatible with latest brew and libmagic 5.48 fixes the original regression ([]())
+- Remove libmagic 5.46 pin as the pinned manifest is not compatible with latest brew and libmagic 5.48 fixes the original regression ([#755](https://github.com/redballoonsecurity/ofrak/pull/755))
 - Fix thread-unsafe `os.chdir` in `ZipPacker` by passing `cwd` to subprocess ([#721](https://github.com/redballoonsecurity/ofrak/pull/721))
 - Pin libmagic to 5.46 on macOS CI builds to work around a regression in 5.47 that breaks ELF identification; update documentation to reflect the libmagic 5.46 requirement ([#723](https://github.com/redballoonsecurity/ofrak/pull/723))
 - Bump `aiohttp` to >=3.13.3 to address CVE-2025-69223 ([#693](https://github.com/redballoonsecurity/ofrak/pull/693))

--- a/ofrak_core/CHANGELOG.md
+++ b/ofrak_core/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Remove test dependencies that are already in the global `requirements-dev.txt` ([#695](https://github.com/redballoonsecurity/ofrak/pull/695))
 
 ### Fixed
+- Remove libmagic 5.46 pin as the pinned manifest is not compatible with latest brew and libmagic 5.48 fixes the original regression ([]())
 - Fix thread-unsafe `os.chdir` in `ZipPacker` by passing `cwd` to subprocess ([#721](https://github.com/redballoonsecurity/ofrak/pull/721))
 - Pin libmagic to 5.46 on macOS CI builds to work around a regression in 5.47 that breaks ELF identification; update documentation to reflect the libmagic 5.46 requirement ([#723](https://github.com/redballoonsecurity/ofrak/pull/723))
 - Bump `aiohttp` to >=3.13.3 to address CVE-2025-69223 ([#693](https://github.com/redballoonsecurity/ofrak/pull/693))

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,1 +1,2 @@
-VERSION = "3.4.0rc14"
+VERSION = "3.4.0rc15"
+VERSION = "3.4.0rc7"

--- a/ofrak_core/version.py
+++ b/ofrak_core/version.py
@@ -1,2 +1,1 @@
 VERSION = "3.4.0rc15"
-VERSION = "3.4.0rc7"


### PR DESCRIPTION
- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.
- [x] I have made or updated a changelog entry for the changes in this pull request.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

Remove libmagic 5.46 pin as the pinned manifest is not compatible with latest brew and libmagic 5.48 fixes the original regression

**Link to Related Issue(s)**
N/A

**Please describe the changes in your request.**
Reverts #723 

**Anyone you think should look at this, specifically?**
@whyitfor 
